### PR TITLE
Add tests for search and store edge cases

### DIFF
--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -56,12 +56,27 @@ def test_filter_by_labels():
     assert [r.id for r in filter_by_labels(reqs, ["ui", "auth"])] == ["REQ-1"]
 
 
+def test_filter_by_labels_empty_returns_all():
+    reqs = sample_requirements()
+    assert filter_by_labels(reqs, []) == reqs
+
+
 def test_search_text():
     reqs = sample_requirements()
     found = search_text(reqs, "login", ["title", "notes"])
     assert [r.id for r in found] == ["REQ-1"]
     found = search_text(reqs, "EXPORT", ["title"])
     assert [r.id for r in found] == ["REQ-3"]
+
+
+def test_search_text_empty_query_returns_all():
+    reqs = sample_requirements()
+    assert search_text(reqs, "", ["title"]) == reqs
+
+
+def test_search_text_no_valid_fields_returns_all():
+    reqs = sample_requirements()
+    assert search_text(reqs, "login", ["unknown"]) == reqs
 
 
 def test_combined_search():

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -6,7 +6,21 @@ from pathlib import Path
 
 import pytest
 
-from app.core.store import ConflictError, load, save, filename_for
+from app.core.model import (
+    Priority,
+    Requirement,
+    RequirementType,
+    Status,
+    Units,
+    Verification,
+)
+from app.core.store import (
+    ConflictError,
+    filename_for,
+    load,
+    save,
+    _existing_ids,
+)
 
 
 def sample() -> dict:
@@ -42,3 +56,35 @@ def test_conflict_detection(tmp_path: Path):
     path.write_text(json.dumps(loaded))
     with pytest.raises(ConflictError):
         save(tmp_path, data, mtime=mtime)
+
+
+def test_existing_ids_skips_invalid_and_excluded(tmp_path: Path):
+    valid = tmp_path / "valid.json"
+    valid.write_text(json.dumps({"id": "REQ-1"}))
+    exclude = tmp_path / "exclude.json"
+    exclude.write_text(json.dumps({"id": "REQ-2"}))
+    bad = tmp_path / "bad.json"
+    bad.write_text("{invalid json")
+
+    ids = _existing_ids(tmp_path, exclude)
+    assert ids == {"REQ-1"}
+
+
+def test_save_accepts_dataclass(tmp_path: Path):
+    req = Requirement(
+        id="REQ-10",
+        title="Dataclass", 
+        statement="Save dataclass",
+        type=RequirementType.REQUIREMENT,
+        status=Status.DRAFT,
+        owner="user",
+        priority=Priority.MEDIUM,
+        source="spec",
+        verification=Verification.ANALYSIS,
+        acceptance="",
+        units=Units(quantity="kg", nominal=1.0),
+    )
+    path = save(tmp_path, req)
+    loaded, _ = load(path)
+    assert loaded["id"] == req.id
+    assert loaded["title"] == req.title


### PR DESCRIPTION
## Summary
- Add tests for search helpers covering empty labels, empty queries and invalid fields
- Extend store tests for invalid JSON handling and dataclass saving

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c26241a2088320b0cb59961ad6f80f