### PR TITLE
Add tests for wx-less ListPanel and main

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,36 @@
+import sys
+import types
+import importlib
+
+
+def test_main_runs(monkeypatch):
+    class DummyApp:
+        def __init__(self):
+            self.loop_ran = False
+        def MainLoop(self):
+            self.loop_ran = True
+
+    dummy_app = DummyApp()
+    wx_stub = types.SimpleNamespace(App=lambda: dummy_app)
+    monkeypatch.setitem(sys.modules, "wx", wx_stub)
+
+    class DummyFrame:
+        instances = []
+        shown = False
+
+        def __init__(self, parent):
+            self.parent = parent
+            DummyFrame.instances.append(self)
+        def Show(self):
+            DummyFrame.shown = True
+
+    monkeypatch.setitem(sys.modules, "app.ui.main_frame", types.SimpleNamespace(MainFrame=DummyFrame))
+
+    import app.main as main_module
+    importlib.reload(main_module)
+
+    main_module.main()
+
+    assert dummy_app.loop_ran
+    assert DummyFrame.shown
+    assert DummyFrame.instances and DummyFrame.instances[0].parent is None


### PR DESCRIPTION
## Summary
- rewrite ListPanel test to use stub `wx` module
- add test for main entry point with stub `wx` and `MainFrame`

## Testing
- `pytest`
- `pytest --cov=app`

------
https://chatgpt.com/codex/tasks/task_e_68c264dcac5883208e5c129b17764d7a