### PR TITLE
Add headless wx GUI tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,20 @@
 
 Готовые файлы появятся в каталоге `dist/CookaReq`.
 
+## Запуск тестов в контейнере
+
+Чтобы прогонять тесты GUI без сборки wxPython из исходников,
+установите готовые пакеты и зависимости из репозиториев Ubuntu:
+
+```bash
+apt-get update && apt-get install -y \
+    python3-wxgtk4.0 python3-pip xvfb xauth
+python3 -m venv .venv --system-site-packages
+source .venv/bin/activate
+pip install pytest pytest-xvfb jsonschema
+pytest -q
+```
+
+`pytest-xvfb` автоматически поднимает виртуальный дисплей, поэтому
+окна не появятся и тесты выполняются в headless-режиме.
+

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,5 @@
 [pytest]
+xvfb_width = 1280
+xvfb_height = 800
+xvfb_colordepth = 24
 addopts = -q

--- a/tests/test_list_panel_gui.py
+++ b/tests/test_list_panel_gui.py
@@ -1,0 +1,17 @@
+import pytest
+
+
+def test_list_panel_real_widgets():
+    wx = pytest.importorskip("wx")
+    app = wx.App()
+    from app.ui.list_panel import ListPanel
+    frame = wx.Frame(None)
+    panel = ListPanel(frame)
+
+    assert isinstance(panel.search, wx.SearchCtrl)
+    assert isinstance(panel.list, wx.ListCtrl)
+    assert panel.search.GetParent() is panel
+    assert panel.list.GetParent() is panel
+
+    frame.Destroy()
+    app.Destroy()

--- a/tests/test_main_frame_gui.py
+++ b/tests/test_main_frame_gui.py
@@ -1,0 +1,36 @@
+import pytest
+
+
+def test_main_frame_open_folder(monkeypatch, tmp_path):
+    wx = pytest.importorskip("wx")
+    app = wx.App()
+
+    called = {}
+
+    class DummyDirDialog:
+        def __init__(self, parent, message):
+            called["init"] = True
+        def ShowModal(self):
+            called["show"] = True
+            return wx.ID_OK
+        def GetPath(self):
+            return str(tmp_path)
+        def Destroy(self):
+            called["destroy"] = True
+
+    monkeypatch.setattr(wx, "DirDialog", DummyDirDialog)
+
+    from app.ui.main_frame import MainFrame
+    from app.ui.list_panel import ListPanel
+
+    frame = MainFrame(None)
+
+    # emulate menu event
+    evt = wx.CommandEvent(wx.EVT_MENU.typeId, wx.ID_OPEN)
+    frame.ProcessEvent(evt)
+
+    assert called == {"init": True, "show": True, "destroy": True}
+    assert isinstance(frame.panel, ListPanel)
+
+    frame.Destroy()
+    app.Destroy()


### PR DESCRIPTION
## Summary
- configure pytest-xvfb for headless GUI testing
- verify list panel widgets using real wx
- cover MainFrame folder-opening action with dummy dialog
- document container commands for wx and Xvfb setup

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c26a6a8fe4832091b689777b0c5678