### PR TITLE
Add CLI interface for CookaReq

### DIFF
--- a/app/cli.py
+++ b/app/cli.py
@@ -1,0 +1,76 @@
+"""Command-line interface for CookaReq."""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from .core import store, search, model
+
+
+def _load_all(directory: str | Path) -> list[model.Requirement]:
+    """Load all requirements from *directory*."""
+    reqs: list[model.Requirement] = []
+    for path in Path(directory).glob("*.json"):
+        data, _ = store.load(path)
+        reqs.append(model.Requirement(**data))
+    return reqs
+
+
+def cmd_list(args: argparse.Namespace) -> None:
+    """List requirements in directory, optionally filtered."""
+    reqs = _load_all(args.directory)
+    reqs = search.search(reqs, labels=args.labels, query=args.query, fields=args.fields)
+    for r in reqs:
+        print(f"{r.id}: {r.title}")
+
+
+def cmd_add(args: argparse.Namespace) -> None:
+    """Add requirement from JSON file to directory."""
+    with open(args.file, "r", encoding="utf-8") as fh:
+        data = json.load(fh)
+    path = store.save(args.directory, data)
+    print(path)
+
+
+def cmd_show(args: argparse.Namespace) -> None:
+    """Show detailed JSON for requirement with *id*."""
+    fname = store.filename_for(args.id)
+    path = Path(args.directory) / fname
+    data, _ = store.load(path)
+    print(json.dumps(data, ensure_ascii=False, indent=2, sort_keys=True))
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="CookaReq CLI")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_list = sub.add_parser("list", help="list requirements")
+    p_list.add_argument("directory", help="requirements directory")
+    p_list.add_argument("--labels", nargs="*", default=[], help="filter by labels")
+    p_list.add_argument("--query", help="text search query")
+    p_list.add_argument("--fields", nargs="*", help="fields for text search")
+    p_list.set_defaults(func=cmd_list)
+
+    p_add = sub.add_parser("add", help="add requirement from JSON file")
+    p_add.add_argument("directory", help="requirements directory")
+    p_add.add_argument("file", help="JSON file with requirement")
+    p_add.set_defaults(func=cmd_add)
+
+    p_show = sub.add_parser("show", help="show requirement details")
+    p_show.add_argument("directory", help="requirements directory")
+    p_show.add_argument("id", help="requirement id")
+    p_show.set_defaults(func=cmd_show)
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    args.func(args)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from app.cli import main
+from app.core.store import save
+
+
+def sample() -> dict:
+    return {
+        "id": "REQ-1",
+        "title": "Title",
+        "statement": "Statement",
+        "type": "requirement",
+        "status": "draft",
+        "owner": "user",
+        "priority": "medium",
+        "source": "spec",
+        "verification": "analysis",
+        "revision": 1,
+    }
+
+
+def test_cli_list(tmp_path, capsys):
+    data = sample()
+    save(tmp_path, data)
+    main(["list", str(tmp_path)])
+    captured = capsys.readouterr().out
+    assert "REQ-1" in captured
+
+
+def test_cli_show(tmp_path, capsys):
+    data = sample()
+    save(tmp_path, data)
+    main(["show", str(tmp_path), "REQ-1"])
+    captured = capsys.readouterr().out
+    loaded = json.loads(captured)
+    assert loaded["id"] == "REQ-1"


### PR DESCRIPTION
## Summary
- add `app.cli` with list, add, show subcommands to manage requirements from the command line
- cover CLI with tests for listing and showing requirements

## Testing
- `pytest` *(fails: ValueError: None is not of type 'object'; AssertionError: assert False; AssertionError: assert 'low' == 'medium'; TypeError: Window.SetSizer(): argument 1 has unexpected type 'BoxSizer')*
- `pytest tests/test_cli.py`

------
https://chatgpt.com/codex/tasks/task_e_68c2847359c8832082f14471938fde30