### PR TITLE
Load requirements into list panel

### DIFF
--- a/app/ui/list_panel.py
+++ b/app/ui/list_panel.py
@@ -4,13 +4,21 @@ import wx
 
 
 class ListPanel(wx.Panel):
-    """Stub panel with search box and list control."""
+    """Panel with a search box and list of requirement titles."""
 
     def __init__(self, parent: wx.Window):
         super().__init__(parent)
         sizer = wx.BoxSizer(wx.VERTICAL)
         self.search = wx.SearchCtrl(self)
         self.list = wx.ListCtrl(self, style=wx.LC_REPORT)
+        self.list.InsertColumn(0, "Title")
         sizer.Add(self.search, 0, wx.EXPAND | wx.ALL, 5)
         sizer.Add(self.list, 1, wx.EXPAND | wx.ALL, 5)
         self.SetSizer(sizer)
+
+    def set_requirements(self, requirements: list) -> None:
+        """Populate list control with requirement titles."""
+        self.list.DeleteAllItems()
+        for req in requirements:
+            title = req.get("title") if isinstance(req, dict) else getattr(req, "title", "")
+            self.list.InsertItem(self.list.GetItemCount(), title)

--- a/app/ui/main_frame.py
+++ b/app/ui/main_frame.py
@@ -1,6 +1,8 @@
 """Main application window."""
 
 import wx
+from pathlib import Path
+from app.core import store
 from .list_panel import ListPanel
 
 
@@ -37,6 +39,12 @@ class MainFrame(wx.Frame):
         if dlg.ShowModal() == wx.ID_OK:
             path = dlg.GetPath()
             self.SetTitle(f"{self._base_title} - {path}")
-            # TODO: connect to storage later
-            _ = path
+            requirements = []
+            for fp in Path(path).glob("*.json"):
+                try:
+                    data, _ = store.load(fp)
+                    requirements.append(data)
+                except Exception:
+                    continue
+            self.panel.set_requirements(requirements)
         dlg.Destroy()

--- a/tests/test_list_panel.py
+++ b/tests/test_list_panel.py
@@ -25,6 +25,12 @@ def _build_wx_stub():
     class ListCtrl(Window):
         def __init__(self, parent=None, style=0):
             super().__init__(parent)
+        def InsertColumn(self, col, heading):
+            pass
+        def DeleteAllItems(self):
+            pass
+        def InsertItem(self, index, text):
+            pass
 
     class BoxSizer:
         def __init__(self, orient):

--- a/tests/test_main_frame_gui.py
+++ b/tests/test_main_frame_gui.py
@@ -77,3 +77,55 @@ def test_main_frame_open_folder_toolbar(monkeypatch, tmp_path):
 
     frame.Destroy()
     app.Destroy()
+
+
+def test_main_frame_loads_requirements(monkeypatch, tmp_path):
+    wx = pytest.importorskip("wx")
+    from app.core.store import save
+
+    data = {
+        "id": "REQ-1",
+        "title": "Title",
+        "statement": "Statement",
+        "type": "requirement",
+        "status": "draft",
+        "owner": "user",
+        "priority": "medium",
+        "source": "spec",
+        "verification": "analysis",
+        "revision": 1,
+    }
+    save(tmp_path, data)
+
+    app = wx.App()
+
+    class DummyDirDialog:
+        def __init__(self, parent, message):
+            pass
+
+        def ShowModal(self):
+            return wx.ID_OK
+
+        def GetPath(self):
+            return str(tmp_path)
+
+        def Destroy(self):
+            pass
+
+    monkeypatch.setattr(wx, "DirDialog", DummyDirDialog)
+
+    import app.ui.list_panel as list_panel
+    import app.ui.main_frame as main_frame
+    importlib.reload(list_panel)
+    importlib.reload(main_frame)
+
+    frame = main_frame.MainFrame(None)
+
+    evt = wx.CommandEvent(wx.EVT_MENU.typeId, wx.ID_OPEN)
+    frame.ProcessEvent(evt)
+
+    assert frame.panel.list.GetItemCount() == 1
+    assert frame.panel.list.GetItemText(0) == data["title"]
+
+    frame.Destroy()
+    app.Destroy()


### PR DESCRIPTION
## Summary
- Add GUI test ensuring requirements appear after opening a folder
- Show requirement titles in ListPanel and add `set_requirements`
- Load JSON requirements on folder open and populate list

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c294f66494832086ec48e8688310c4