### PR TITLE
Show editor when requirement selected

### DIFF
--- a/app/ui/main_frame.py
+++ b/app/ui/main_frame.py
@@ -4,6 +4,7 @@ import wx
 from pathlib import Path
 from app.core import store
 from .list_panel import ListPanel
+from .editor_panel import EditorPanel
 
 
 class MainFrame(wx.Frame):
@@ -14,9 +15,18 @@ class MainFrame(wx.Frame):
         super().__init__(parent=parent, title=self._base_title)
         self._create_menu()
         self._create_toolbar()
-        self.panel = ListPanel(self)
+        self.splitter = wx.SplitterWindow(self)
+        self.panel = ListPanel(self.splitter)
+        self.editor = EditorPanel(self.splitter)
+        self.splitter.SplitVertically(self.panel, self.editor, 300)
+        self.editor.Hide()
+        sizer = wx.BoxSizer(wx.VERTICAL)
+        sizer.Add(self.splitter, 1, wx.EXPAND)
+        self.SetSizer(sizer)
         self.SetSize((800, 600))
         self.Centre()
+        self.requirements: list[dict] = []
+        self.panel.list.Bind(wx.EVT_LIST_ITEM_SELECTED, self.on_requirement_selected)
 
     def _create_menu(self) -> None:
         menu_bar = wx.MenuBar()
@@ -39,12 +49,20 @@ class MainFrame(wx.Frame):
         if dlg.ShowModal() == wx.ID_OK:
             path = dlg.GetPath()
             self.SetTitle(f"{self._base_title} - {path}")
-            requirements = []
+            self.requirements = []
             for fp in Path(path).glob("*.json"):
                 try:
                     data, _ = store.load(fp)
-                    requirements.append(data)
+                    self.requirements.append(data)
                 except Exception:
                     continue
-            self.panel.set_requirements(requirements)
+            self.panel.set_requirements(self.requirements)
+            self.editor.Hide()
         dlg.Destroy()
+
+    def on_requirement_selected(self, event: wx.ListEvent) -> None:
+        idx = event.GetIndex()
+        if 0 <= idx < len(self.requirements):
+            self.editor.load(self.requirements[idx])
+            self.editor.Show()
+            self.splitter.UpdateSize()

--- a/tests/test_main_frame_gui.py
+++ b/tests/test_main_frame_gui.py
@@ -129,3 +129,60 @@ def test_main_frame_loads_requirements(monkeypatch, tmp_path):
 
     frame.Destroy()
     app.Destroy()
+
+
+def test_main_frame_select_opens_editor(monkeypatch, tmp_path):
+    wx = pytest.importorskip("wx")
+    from app.core.store import save
+    import importlib
+
+    data = {
+        "id": "REQ-1",
+        "title": "Title",
+        "statement": "Statement",
+        "type": "requirement",
+        "status": "draft",
+        "owner": "user",
+        "priority": "medium",
+        "source": "spec",
+        "verification": "analysis",
+        "revision": 1,
+    }
+    save(tmp_path, data)
+
+    app = wx.App()
+
+    class DummyDirDialog:
+        def __init__(self, parent, message):
+            pass
+
+        def ShowModal(self):
+            return wx.ID_OK
+
+        def GetPath(self):
+            return str(tmp_path)
+
+        def Destroy(self):
+            pass
+
+    monkeypatch.setattr(wx, "DirDialog", DummyDirDialog)
+
+    import app.ui.list_panel as list_panel
+    import app.ui.main_frame as main_frame
+    importlib.reload(list_panel)
+    importlib.reload(main_frame)
+
+    frame = main_frame.MainFrame(None)
+
+    evt = wx.CommandEvent(wx.EVT_MENU.typeId, wx.ID_OPEN)
+    frame.ProcessEvent(evt)
+
+    list_ctrl = frame.panel.list
+    list_ctrl.Select(0)
+    app.Yield()
+
+    assert frame.editor.IsShown()
+    assert frame.editor.fields["id"].GetValue() == data["id"]
+
+    frame.Destroy()
+    app.Destroy()


### PR DESCRIPTION
## Summary
- Display editor panel alongside list and show it when a requirement is selected
- Track loaded requirements and expose editor via GUI selection
- Add regression test for opening editor on list selection

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c29776b7748320bee4f115c637a967