### PR TITLE
Добавлены текстовые поля требований и кнопка сохранения

### DIFF
--- a/app/core/model.py
+++ b/app/core/model.py
@@ -58,6 +58,11 @@ class Requirement:
     source: str
     verification: Verification
     acceptance: Optional[str] = None
+    conditions: str = ""
+    trace_up: str = ""
+    trace_down: str = ""
+    version: str = ""
+    modified_at: str = ""
     units: Optional[Units] = None
     labels: List[str] = field(default_factory=list)
     attachments: List[Attachment] = field(default_factory=list)

--- a/app/core/schema.py
+++ b/app/core/schema.py
@@ -33,6 +33,11 @@ SCHEMA: dict[str, Any] = {
         "source": {"type": "string"},
         "verification": {"enum": [e.value for e in Verification]},
         "acceptance": {"type": "string"},
+        "conditions": {"type": "string"},
+        "trace_up": {"type": "string"},
+        "trace_down": {"type": "string"},
+        "version": {"type": "string"},
+        "modified_at": {"type": "string"},
         "units": {
             "type": "object",
             "properties": {

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -22,3 +22,8 @@ def test_requirement_defaults():
     assert req.revision == 1
     assert req.labels == []
     assert req.attachments == []
+    assert req.conditions == ""
+    assert req.trace_up == ""
+    assert req.trace_down == ""
+    assert req.version == ""
+    assert req.modified_at == ""


### PR DESCRIPTION
## Summary
- расширена модель требования дополнительными текстовыми полями и датой изменения
- добавлена кнопка "Сохранить" с автоматическим заполнением даты
- главный фрейм сохраняет изменения и обновляет список требований

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c29d9caa4c8320810156a037c38656