### PR TITLE
feat: allow configurable fields in requirement list

### DIFF
--- a/app/ui/list_panel.py
+++ b/app/ui/list_panel.py
@@ -2,23 +2,48 @@
 
 import wx
 
+from typing import List
+
 
 class ListPanel(wx.Panel):
-    """Panel with a search box and list of requirement titles."""
+    """Panel with a search box and list of requirement fields."""
 
     def __init__(self, parent: wx.Window):
         super().__init__(parent)
         sizer = wx.BoxSizer(wx.VERTICAL)
         self.search = wx.SearchCtrl(self)
         self.list = wx.ListCtrl(self, style=wx.LC_REPORT)
-        self.list.InsertColumn(0, "Title")
+        self.columns: List[str] = []
+        self._requirements: List = []
+        self._setup_columns()
         sizer.Add(self.search, 0, wx.EXPAND | wx.ALL, 5)
         sizer.Add(self.list, 1, wx.EXPAND | wx.ALL, 5)
         self.SetSizer(sizer)
 
+    def _setup_columns(self) -> None:
+        """Configure list control columns based on selected fields."""
+        self.list.ClearAll()
+        self.list.InsertColumn(0, "Title")
+        for idx, field in enumerate(self.columns, start=1):
+            self.list.InsertColumn(idx, field)
+
+    def set_columns(self, fields: List[str]) -> None:
+        """Set additional columns (beyond Title) to display."""
+        self.columns = fields
+        self._setup_columns()
+        # repopulate with existing requirements after changing columns
+        self.set_requirements(self._requirements)
+
     def set_requirements(self, requirements: list) -> None:
-        """Populate list control with requirement titles."""
+        """Populate list control with requirement data."""
+        self._requirements = requirements
         self.list.DeleteAllItems()
         for req in requirements:
             title = req.get("title") if isinstance(req, dict) else getattr(req, "title", "")
-            self.list.InsertItem(self.list.GetItemCount(), title)
+            index = self.list.InsertItem(self.list.GetItemCount(), title)
+            for col, field in enumerate(self.columns, start=1):
+                if isinstance(req, dict):
+                    value = req.get(field, "")
+                else:
+                    value = getattr(req, field, "")
+                self.list.SetItem(index, col, str(value))

--- a/tests/test_list_panel.py
+++ b/tests/test_list_panel.py
@@ -27,9 +27,13 @@ def _build_wx_stub():
             super().__init__(parent)
         def InsertColumn(self, col, heading):
             pass
+        def ClearAll(self):
+            pass
         def DeleteAllItems(self):
             pass
         def InsertItem(self, index, text):
+            pass
+        def SetItem(self, index, col, text):
             pass
 
     class BoxSizer:


### PR DESCRIPTION
## Summary
- allow ListPanel to show configurable columns alongside Title
- add View menu with checkboxes to control visible requirement fields
- persist selected columns between runs
- remove container setup script and restore manual test instructions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c29c1efd548320890de002a4771e1e