### PR TITLE
Add context menu for requirement clone/delete

### DIFF
--- a/tests/test_list_panel.py
+++ b/tests/test_list_panel.py
@@ -9,6 +9,8 @@ def _build_wx_stub():
             self._parent = parent
         def GetParent(self):
             return self._parent
+        def Bind(self, event, handler):
+            pass
 
     class Panel(Window):
         def __init__(self, parent=None):
@@ -54,6 +56,7 @@ def _build_wx_stub():
         EXPAND=0,
         ALL=0,
         LC_REPORT=0,
+        EVT_LIST_ITEM_RIGHT_CLICK=types.SimpleNamespace(),
     )
 
 

--- a/tests/test_list_panel_gui.py
+++ b/tests/test_list_panel_gui.py
@@ -25,3 +25,36 @@ def test_list_panel_real_widgets():
     frame.Destroy()
     app.Destroy()
 
+
+def test_list_panel_context_menu_calls_handlers():
+    wx = pytest.importorskip("wx")
+    app = wx.App()
+    import app.ui.list_panel as list_panel
+    importlib.reload(list_panel)
+    frame = wx.Frame(None)
+    called: dict[str, int] = {}
+
+    def on_clone(idx: int) -> None:
+        called["clone"] = idx
+
+    def on_delete(idx: int) -> None:
+        called["delete"] = idx
+
+    panel = list_panel.ListPanel(frame, on_clone=on_clone, on_delete=on_delete)
+    panel.set_requirements([{"id": "1", "title": "T"}])
+
+    menu, clone_item, delete_item = panel._create_context_menu(0)
+    evt = wx.CommandEvent(wx.EVT_MENU.typeId, clone_item.GetId())
+    panel.ProcessEvent(evt)
+    menu.Destroy()
+
+    menu, clone_item, delete_item = panel._create_context_menu(0)
+    evt = wx.CommandEvent(wx.EVT_MENU.typeId, delete_item.GetId())
+    panel.ProcessEvent(evt)
+    menu.Destroy()
+
+    assert called == {"clone": 0, "delete": 0}
+
+    frame.Destroy()
+    app.Destroy()
+


### PR DESCRIPTION
## Summary
- add context menu to requirement list for cloning and deleting
- handle clone/delete actions in main window
- cover context menu operations with tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c2a20fd29083208230f4c75e35d29f