### PR TITLE
Enable search and label filtering

### DIFF
--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -83,3 +83,12 @@ def test_combined_search():
     reqs = sample_requirements()
     found = search(reqs, labels=["ui"], query="export", fields=["title"])
     assert [r.id for r in found] == ["REQ-3"]
+
+
+def test_accepts_plain_dicts():
+    reqs = [
+        {"id": "1", "title": "Login", "labels": ["ui"]},
+        {"id": "2", "title": "Export", "labels": ["report"]},
+    ]
+    found = search(reqs, labels=["ui"], query="login", fields=["title"])
+    assert [r["id"] for r in found] == ["1"]


### PR DESCRIPTION
## Summary
- support dict-based requirements in core search helpers
- add label and text search filtering to ListPanel and expose setters
- cover search and filters with unit tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c2c41c19b48320b80cd537746f5ab2