### PR TITLE
Добавлены групповые операции над требованиями

### DIFF
--- a/tests/test_list_panel.py
+++ b/tests/test_list_panel.py
@@ -151,3 +151,25 @@ def test_search_and_label_filters(monkeypatch):
     panel.set_label_filter(["ui"])
     panel.set_search_query("Export", fields=["title"])
     assert panel._requirements == []
+
+
+def test_bulk_edit_updates_requirements(monkeypatch):
+    wx_stub = _build_wx_stub()
+    monkeypatch.setitem(sys.modules, "wx", wx_stub)
+
+    list_panel_module = importlib.import_module("app.ui.list_panel")
+    importlib.reload(list_panel_module)
+    ListPanel = list_panel_module.ListPanel
+
+    frame = wx_stub.Panel(None)
+    panel = ListPanel(frame)
+    panel.set_columns(["version"])
+    reqs = [
+        {"id": "1", "title": "A", "version": "1"},
+        {"id": "2", "title": "B", "version": "1"},
+    ]
+    panel.set_requirements(reqs)
+    monkeypatch.setattr(panel, "_get_selected_indices", lambda: [0, 1])
+    monkeypatch.setattr(panel, "_prompt_value", lambda field: "2")
+    panel._on_edit_field(1)
+    assert [r["version"] for r in reqs] == ["2", "2"]

--- a/tests/test_list_panel_gui.py
+++ b/tests/test_list_panel_gui.py
@@ -43,18 +43,42 @@ def test_list_panel_context_menu_calls_handlers():
     panel = list_panel.ListPanel(frame, on_clone=on_clone, on_delete=on_delete)
     panel.set_requirements([{"id": "1", "title": "T"}])
 
-    menu, clone_item, delete_item = panel._create_context_menu(0)
+    menu, clone_item, delete_item, _ = panel._create_context_menu(0, 0)
     evt = wx.CommandEvent(wx.EVT_MENU.typeId, clone_item.GetId())
     panel.ProcessEvent(evt)
     menu.Destroy()
 
-    menu, clone_item, delete_item = panel._create_context_menu(0)
+    menu, clone_item, delete_item, _ = panel._create_context_menu(0, 0)
     evt = wx.CommandEvent(wx.EVT_MENU.typeId, delete_item.GetId())
     panel.ProcessEvent(evt)
     menu.Destroy()
 
     assert called == {"clone": 0, "delete": 0}
 
+    frame.Destroy()
+    app.Destroy()
+
+
+def test_bulk_edit_updates_selected_items(monkeypatch):
+    wx = pytest.importorskip("wx")
+    app = wx.App()
+    import app.ui.list_panel as list_panel
+    importlib.reload(list_panel)
+    frame = wx.Frame(None)
+    panel = list_panel.ListPanel(frame)
+    panel.set_columns(["version", "type"])
+    reqs = [
+        {"id": "1", "title": "A", "version": "1", "type": "requirement"},
+        {"id": "2", "title": "B", "version": "1", "type": "requirement"},
+    ]
+    panel.set_requirements(reqs)
+    panel.list.SetItemState(0, wx.LIST_STATE_SELECTED, wx.LIST_STATE_SELECTED)
+    panel.list.SetItemState(1, wx.LIST_STATE_SELECTED, wx.LIST_STATE_SELECTED)
+    monkeypatch.setattr(panel, "_prompt_value", lambda field: "2" if field == "version" else "constraint")
+    panel._on_edit_field(1)
+    panel._on_edit_field(2)
+    assert [r["version"] for r in reqs] == ["2", "2"]
+    assert [r["type"] for r in reqs] == ["constraint", "constraint"]
     frame.Destroy()
     app.Destroy()
 


### PR DESCRIPTION
## Summary
- Добавлена возможность массового редактирования полей требований через контекстное меню
- Тесты для группового редактирования, включая GUI, и обновление существующих проверок

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c2c63dd3188320a0aaac65239ae719