### PR TITLE
feat(ui): remember column order

### DIFF
--- a/app/ui/list_panel.py
+++ b/app/ui/list_panel.py
@@ -82,6 +82,41 @@ class ListPanel(wx.Panel):
             width = max(self.MIN_COL_WIDTH, min(width, self.MAX_COL_WIDTH))
             config.WriteInt(f"col_width_{i}", width)
 
+    def load_column_order(self, config: wx.Config) -> None:
+        """Restore column ordering from config."""
+        value = config.Read("col_order", "")
+        if not value:
+            return
+        names = [n for n in value.split(",") if n]
+        order: List[int] = []
+        for name in names:
+            if name == "title":
+                order.append(0)
+            elif name in self.columns:
+                order.append(self.columns.index(name) + 1)
+        count = self.list.GetColumnCount()
+        for idx in range(count):
+            if idx not in order:
+                order.append(idx)
+        try:  # pragma: no cover - depends on GUI backend
+            self.list.SetColumnsOrder(order)
+        except Exception:
+            pass
+
+    def save_column_order(self, config: wx.Config) -> None:
+        """Persist current column ordering to config."""
+        try:  # pragma: no cover - depends on GUI backend
+            order = self.list.GetColumnsOrder()
+        except Exception:
+            return
+        names: List[str] = []
+        for idx in order:
+            if idx == 0:
+                names.append("title")
+            elif 1 <= idx <= len(self.columns):
+                names.append(self.columns[idx - 1])
+        config.Write("col_order", ",".join(names))
+
     def set_columns(self, fields: List[str]) -> None:
         """Set additional columns (beyond Title) to display."""
         self.columns = fields

--- a/app/ui/main_frame.py
+++ b/app/ui/main_frame.py
@@ -116,6 +116,7 @@ class MainFrame(wx.Frame):
             self.selected_fields.append(field)
         self.panel.set_columns(self.selected_fields)
         self.panel.load_column_widths(self.config)
+        self.panel.load_column_order(self.config)
         self._save_columns()
 
     def _load_columns(self) -> list[str]:
@@ -144,6 +145,7 @@ class MainFrame(wx.Frame):
         sash = max(100, min(sash, max(client_w - 100, 100)))
         self.splitter.SetSashPosition(sash)
         self.panel.load_column_widths(self.config)
+        self.panel.load_column_order(self.config)
 
     def _save_layout(self) -> None:
         """Persist window geometry, splitter, and column widths."""
@@ -155,6 +157,7 @@ class MainFrame(wx.Frame):
         self.config.WriteInt("win_y", y)
         self.config.WriteInt("sash_pos", self.splitter.GetSashPosition())
         self.panel.save_column_widths(self.config)
+        self.panel.save_column_order(self.config)
         self.config.Flush()
 
     def _on_close(self, event: wx.Event) -> None:  # pragma: no cover - GUI event


### PR DESCRIPTION
## Summary
- persist list column order in config and restore it on startup
- include column order when toggling visible fields and saving layout

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c2cd4f6bfc83209587bbd6e57808d8