### PR TITLE
Use integer requirement IDs

### DIFF
--- a/app/cli.py
+++ b/app/cli.py
@@ -77,7 +77,7 @@ def build_parser() -> argparse.ArgumentParser:
 
     p_show = sub.add_parser("show", help="show requirement details")
     p_show.add_argument("directory", help="requirements directory")
-    p_show.add_argument("id", help="requirement id")
+    p_show.add_argument("id", type=int, help="requirement id")
     p_show.set_defaults(func=cmd_show)
 
     return parser

--- a/app/core/model.py
+++ b/app/core/model.py
@@ -48,7 +48,7 @@ class Attachment:
 
 @dataclass
 class Requirement:
-    id: str
+    id: int
     title: str
     statement: str
     type: RequirementType

--- a/app/core/schema.py
+++ b/app/core/schema.py
@@ -23,7 +23,7 @@ SCHEMA: dict[str, Any] = {
         "revision",
     ],
     "properties": {
-        "id": {"type": "string"},
+        "id": {"type": "integer"},
         "title": {"type": "string"},
         "statement": {"type": "string"},
         "type": {"enum": [e.value for e in RequirementType]},

--- a/app/core/store.py
+++ b/app/core/store.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 from dataclasses import asdict, is_dataclass
 import json
-import re
 from pathlib import Path
 
 from .validate import validate
@@ -13,16 +12,9 @@ class ConflictError(Exception):
     """Raised when a file was modified on disk since loading."""
 
 
-_INVALID_CHARS = r"[\\/:*?\"<>|]"
-
-
-def filename_for(req_id: str) -> str:
-    """Return filename based on *req_id* with ``.json`` extension.
-
-    Any characters illegal for filenames are replaced with ``_``.
-    """
-    safe_id = re.sub(_INVALID_CHARS, "_", req_id)
-    return f"{safe_id}.json"
+def filename_for(req_id: int) -> str:
+    """Return filename for numeric *req_id* with ``.json`` extension."""
+    return f"{req_id}.json"
 
 
 def load(path: str | Path) -> tuple[dict, float]:
@@ -34,8 +26,8 @@ def load(path: str | Path) -> tuple[dict, float]:
     return data, mtime
 
 
-def _existing_ids(directory: Path, exclude: Path) -> set[str]:
-    ids: set[str] = set()
+def _existing_ids(directory: Path, exclude: Path) -> set[int]:
+    ids: set[int] = set()
     for fp in directory.glob("*.json"):
         if fp == exclude:
             continue

--- a/app/core/validate.py
+++ b/app/core/validate.py
@@ -10,7 +10,7 @@ class ValidationError(Exception):
     """Raised when business rules are violated."""
 
 
-def validate(data: dict, existing_ids: Iterable[str] = ()) -> None:
+def validate(data: dict, existing_ids: Iterable[int] = ()) -> None:
     """Validate *data* using schema and business rules.
 
     Parameters

--- a/app/ui/editor_panel.py
+++ b/app/ui/editor_panel.py
@@ -22,7 +22,7 @@ class EditorPanel(wx.Panel):
         self._on_save_callback = on_save
 
         labels = {
-            "id": "Идентификатор требования (например, REQ-001)",
+            "id": "Идентификатор требования (число)",
             "title": "Краткое название требования",
             "statement": "Полный текст требования",
             "acceptance": "Критерии приемки требования",
@@ -41,12 +41,9 @@ class EditorPanel(wx.Panel):
 
         help_texts = {
             "id": (
-                "Поле 'Идентификатор требования' должно содержать уникальный код, "
-                "например REQ-001. Этот код используется для однозначной ссылки на "
-                "требование в документации, обсуждениях и тестах. Желательно "
-                "придерживаться единого формата PREFIX-номер. Заполнение этого поля "
-                "помогает быстро находить требование и избегать путаницы. Примеры: "
-                "REQ-001, INT-5, UI_LOGIN_01."
+                "Поле 'Идентификатор требования' должно содержать уникальное целое "
+                "число без префиксов. Этот номер используется для ссылок на "
+                "требование в документации и тестах."
             ),
             "title": (
                 "Введите краткое название, которое описывает суть требования. Оно "
@@ -239,15 +236,15 @@ class EditorPanel(wx.Panel):
         self.current_path = Path(path) if path else None
         self.mtime = mtime
 
-    def clone(self, new_id: str) -> None:
-        self.fields["id"].SetValue(new_id)
+    def clone(self, new_id: int) -> None:
+        self.fields["id"].SetValue(str(new_id))
         self.current_path = None
         self.mtime = None
 
     # data helpers -----------------------------------------------------
     def get_data(self) -> dict[str, Any]:
         data = {
-            "id": self.fields["id"].GetValue(),
+            "id": int(self.fields["id"].GetValue()),
             "title": self.fields["title"].GetValue(),
             "statement": self.fields["statement"].GetValue(),
             "type": locale.ru_to_code("type", self.enums["type"].GetStringSelection()),

--- a/app/ui/list_panel.py
+++ b/app/ui/list_panel.py
@@ -138,7 +138,13 @@ class ListPanel(wx.Panel):
             self._sort_ascending = True
         field = "title" if col == 0 else self.columns[col - 1]
         def get_value(req):
-            return req.get(field, "") if isinstance(req, dict) else getattr(req, field, "")
+            value = req.get(field, "") if isinstance(req, dict) else getattr(req, field, "")
+            if field == "id":
+                try:
+                    return int(value)
+                except Exception:
+                    return 0
+            return value
         sorted_reqs = sorted(
             self._requirements,
             key=get_value,

--- a/app/ui/main_frame.py
+++ b/app/ui/main_frame.py
@@ -1,6 +1,5 @@
 """Main application window."""
 
-import re
 import wx
 from pathlib import Path
 from dataclasses import fields
@@ -162,38 +161,14 @@ class MainFrame(wx.Frame):
         event.Skip()
 
     # context menu actions -------------------------------------------
-    def _generate_new_id(self, base: str | None = None) -> str:
+    def _generate_new_id(self) -> int:
         existing = {req["id"] for req in self.requirements}
-        if base:
-            match = re.match(r"^(.*?)(\d+)$", base)
-            if match:
-                prefix, num = match.groups()
-                width = len(num)
-                n = int(num)
-                while True:
-                    n += 1
-                    candidate = f"{prefix}{n:0{width}d}"
-                    if candidate not in existing:
-                        return candidate
-            base_candidate = f"{base}_copy"
-            candidate = base_candidate
-            counter = 1
-            while candidate in existing:
-                candidate = f"{base_candidate}{counter}"
-                counter += 1
-            return candidate
-        prefix = "REQ-"
-        n = 1
-        candidate = f"{prefix}{n:03d}"
-        while candidate in existing:
-            n += 1
-            candidate = f"{prefix}{n:03d}"
-        return candidate
+        return max(existing, default=0) + 1
 
     def on_new_requirement(self, event: wx.Event) -> None:
         new_id = self._generate_new_id()
         self.editor.new_requirement()
-        self.editor.fields["id"].SetValue(new_id)
+        self.editor.fields["id"].SetValue(str(new_id))
         data = self.editor.get_data()
         self.requirements.append(data)
         self.panel.set_requirements(self.requirements)
@@ -204,7 +179,7 @@ class MainFrame(wx.Frame):
         if not (0 <= index < len(self.requirements)):
             return
         source = self.requirements[index]
-        new_id = self._generate_new_id(source.get("id", ""))
+        new_id = self._generate_new_id()
         data = dict(source)
         data["id"] = new_id
         data["title"] = f"(Копия) {source.get('title', '')}".strip()

--- a/app/util/hashing.py
+++ b/app/util/hashing.py
@@ -4,17 +4,17 @@ from __future__ import annotations
 from hashlib import sha256
 
 
-def id_to_hash(identifier: str, length: int = 12) -> str:
+def id_to_hash(identifier: int | str, length: int = 12) -> str:
     """Return the first ``length`` hex digits of SHA-256 for *identifier*.
 
     Parameters
     ----------
     identifier:
-        Source identifier string.
+        Source identifier value.
     length:
         Number of hex characters to return (default 12).
     """
     if length <= 0:
         raise ValueError("length must be positive")
-    digest = sha256(identifier.encode("utf-8")).hexdigest()
+    digest = sha256(str(identifier).encode("utf-8")).hexdigest()
     return digest[:length]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9,7 +9,7 @@ from app.core.store import save
 
 def sample() -> dict:
     return {
-        "id": "REQ-1",
+        "id": 1,
         "title": "Title",
         "statement": "Statement",
         "type": "requirement",
@@ -27,16 +27,16 @@ def test_cli_list(tmp_path, capsys):
     save(tmp_path, data)
     main(["list", str(tmp_path)])
     captured = capsys.readouterr().out
-    assert "REQ-1" in captured
+    assert "1" in captured
 
 
 def test_cli_show(tmp_path, capsys):
     data = sample()
     save(tmp_path, data)
-    main(["show", str(tmp_path), "REQ-1"])
+    main(["show", str(tmp_path), "1"])
     captured = capsys.readouterr().out
     loaded = json.loads(captured)
-    assert loaded["id"] == "REQ-1"
+    assert loaded["id"] == 1
 
 
 def test_cli_edit(tmp_path, capsys):
@@ -49,7 +49,7 @@ def test_cli_edit(tmp_path, capsys):
     file.write_text(json.dumps(updated))
     main(["edit", str(tmp_path), str(file)])
     capsys.readouterr()
-    main(["show", str(tmp_path), "REQ-1"])
+    main(["show", str(tmp_path), "1"])
     captured = capsys.readouterr().out
     loaded = json.loads(captured)
     assert loaded["title"] == "New title"

--- a/tests/test_editor_panel.py
+++ b/tests/test_editor_panel.py
@@ -11,7 +11,7 @@ def _make_panel():
 
 def _base_data():
     return {
-        "id": "REQ-1",
+        "id": 1,
         "title": "Title",
         "statement": "Statement",
         "type": "requirement",
@@ -27,7 +27,7 @@ def _base_data():
 def test_editor_save_and_delete(tmp_path):
     panel = _make_panel()
     panel.new_requirement()
-    panel.fields["id"].SetValue("REQ-1")
+    panel.fields["id"].SetValue("1")
     panel.fields["title"].SetValue("Title")
     panel.fields["statement"].SetValue("Statement")
     panel.fields["owner"].SetValue("owner")
@@ -44,7 +44,7 @@ def test_editor_save_and_delete(tmp_path):
     from app.core import store
 
     data, _ = store.load(path)
-    assert data["id"] == "REQ-1"
+    assert data["id"] == 1
     assert data["attachments"][0]["path"] == f"attachments/{att.name}"
 
     panel.delete()
@@ -59,12 +59,12 @@ def test_editor_clone(tmp_path):
 
     panel = _make_panel()
     panel.load(orig_data, path=orig_path, mtime=mtime)
-    panel.clone("REQ-2")
+    panel.clone(2)
     new_path = panel.save(tmp_path)
 
     assert new_path != orig_path
     data, _ = store.load(new_path)
-    assert data["id"] == "REQ-2"
+    assert data["id"] == 2
     assert data["title"] == orig_data["title"]
 
 
@@ -82,7 +82,7 @@ def test_enum_localization_roundtrip():
 
     panel.load(
         {
-            "id": "REQ-1",
+            "id": 1,
             "title": "T",
             "statement": "S",
             "type": "constraint",

--- a/tests/test_editor_panel_gui.py
+++ b/tests/test_editor_panel_gui.py
@@ -12,7 +12,7 @@ def _make_panel():
 def test_editor_new_requirement_resets(tmp_path):
     panel = _make_panel()
     data = {
-        "id": "REQ-1",
+        "id": 1,
         "title": "T",
         "statement": "S",
         "attachments": [{"path": "a.txt", "note": "n"}],
@@ -50,7 +50,7 @@ def test_editor_add_attachment_included():
 def test_editor_load_populates_fields(tmp_path):
     panel = _make_panel()
     data = {
-        "id": "REQ-1",
+        "id": 1,
         "title": "Title",
         "statement": "Statement",
         "acceptance": "Accept",
@@ -94,9 +94,9 @@ def test_editor_load_populates_fields(tmp_path):
 
 def test_editor_clone_resets_path_and_mtime(tmp_path):
     panel = _make_panel()
-    panel.load({"id": "OLD"}, path=tmp_path / "old.json", mtime=1.0)
-    panel.clone("NEW")
-    assert panel.fields["id"].GetValue() == "NEW"
+    panel.load({"id": 1}, path=tmp_path / "old.json", mtime=1.0)
+    panel.clone(2)
+    assert panel.fields["id"].GetValue() == "2"
     assert panel.current_path is None
     assert panel.mtime is None
 
@@ -106,7 +106,7 @@ def test_editor_save_and_delete_roundtrip(tmp_path):
 
     panel = _make_panel()
     panel.new_requirement()
-    panel.fields["id"].SetValue("REQ-2")
+    panel.fields["id"].SetValue("2")
     panel.fields["title"].SetValue("Title")
     saved_path = panel.save(tmp_path)
 
@@ -115,7 +115,7 @@ def test_editor_save_and_delete_roundtrip(tmp_path):
     assert panel.mtime == saved_path.stat().st_mtime
     with saved_path.open() as fh:
         saved = json.load(fh)
-    assert saved["id"] == "REQ-2"
+    assert saved["id"] == 2
     assert saved["title"] == "Title"
 
     panel.delete()

--- a/tests/test_hashing.py
+++ b/tests/test_hashing.py
@@ -2,19 +2,19 @@ from app.util.hashing import id_to_hash
 
 
 def test_id_to_hash_deterministic():
-    assert id_to_hash("REQ-1") == id_to_hash("REQ-1")
+    assert id_to_hash(1) == id_to_hash(1)
 
 
 def test_id_to_hash_length_and_value():
-    h = id_to_hash("REQ-1", length=16)
+    h = id_to_hash(1, length=16)
     assert len(h) == 16
-    assert h == id_to_hash("REQ-1", length=16)
-    assert h != id_to_hash("REQ-2", length=16)
+    assert h == id_to_hash(1, length=16)
+    assert h != id_to_hash(2, length=16)
 
 
 def test_id_to_hash_invalid_length():
     try:
-        id_to_hash("REQ-1", length=0)
+        id_to_hash(1, length=0)
     except ValueError:
         pass
     else:

--- a/tests/test_list_panel.py
+++ b/tests/test_list_panel.py
@@ -112,18 +112,18 @@ def test_column_click_sorts(monkeypatch):
     panel = ListPanel(frame)
     panel.set_columns(["id"])
     panel.set_requirements([
-        {"id": "2", "title": "B"},
-        {"id": "1", "title": "A"},
+        {"id": 2, "title": "B"},
+        {"id": 1, "title": "A"},
     ])
 
     panel._on_col_click(types.SimpleNamespace(GetColumn=lambda: 0))
-    assert [r["id"] for r in panel._requirements] == ["1", "2"]
+    assert [r["id"] for r in panel._requirements] == [1, 2]
 
     panel._on_col_click(types.SimpleNamespace(GetColumn=lambda: 1))
-    assert [r["id"] for r in panel._requirements] == ["1", "2"]
+    assert [r["id"] for r in panel._requirements] == [1, 2]
 
     panel._on_col_click(types.SimpleNamespace(GetColumn=lambda: 1))
-    assert [r["id"] for r in panel._requirements] == ["2", "1"]
+    assert [r["id"] for r in panel._requirements] == [2, 1]
 
 
 def test_search_and_label_filters(monkeypatch):
@@ -137,16 +137,16 @@ def test_search_and_label_filters(monkeypatch):
     frame = wx_stub.Panel(None)
     panel = ListPanel(frame)
     panel.set_requirements([
-        {"id": "1", "title": "Login", "labels": ["ui"]},
-        {"id": "2", "title": "Export", "labels": ["report"]},
+        {"id": 1, "title": "Login", "labels": ["ui"]},
+        {"id": 2, "title": "Export", "labels": ["report"]},
     ])
 
     panel.set_label_filter(["ui"])
-    assert [r["id"] for r in panel._requirements] == ["1"]
+    assert [r["id"] for r in panel._requirements] == [1]
 
     panel.set_label_filter([])
     panel.set_search_query("Export", fields=["title"])
-    assert [r["id"] for r in panel._requirements] == ["2"]
+    assert [r["id"] for r in panel._requirements] == [2]
 
     panel.set_label_filter(["ui"])
     panel.set_search_query("Export", fields=["title"])
@@ -165,8 +165,8 @@ def test_bulk_edit_updates_requirements(monkeypatch):
     panel = ListPanel(frame)
     panel.set_columns(["version"])
     reqs = [
-        {"id": "1", "title": "A", "version": "1"},
-        {"id": "2", "title": "B", "version": "1"},
+        {"id": 1, "title": "A", "version": "1"},
+        {"id": 2, "title": "B", "version": "1"},
     ]
     panel.set_requirements(reqs)
     monkeypatch.setattr(panel, "_get_selected_indices", lambda: [0, 1])

--- a/tests/test_list_panel_gui.py
+++ b/tests/test_list_panel_gui.py
@@ -41,7 +41,7 @@ def test_list_panel_context_menu_calls_handlers():
         called["delete"] = idx
 
     panel = list_panel.ListPanel(frame, on_clone=on_clone, on_delete=on_delete)
-    panel.set_requirements([{"id": "1", "title": "T"}])
+    panel.set_requirements([{ "id": 1, "title": "T" }])
 
     menu, clone_item, delete_item, _ = panel._create_context_menu(0, 0)
     evt = wx.CommandEvent(wx.EVT_MENU.typeId, clone_item.GetId())
@@ -68,8 +68,8 @@ def test_bulk_edit_updates_selected_items(monkeypatch):
     panel = list_panel.ListPanel(frame)
     panel.set_columns(["version", "type"])
     reqs = [
-        {"id": "1", "title": "A", "version": "1", "type": "requirement"},
-        {"id": "2", "title": "B", "version": "1", "type": "requirement"},
+        {"id": 1, "title": "A", "version": "1", "type": "requirement"},
+        {"id": 2, "title": "B", "version": "1", "type": "requirement"},
     ]
     panel.set_requirements(reqs)
     panel.list.SetItemState(0, wx.LIST_STATE_SELECTED, wx.LIST_STATE_SELECTED)

--- a/tests/test_main_frame_gui.py
+++ b/tests/test_main_frame_gui.py
@@ -84,7 +84,7 @@ def test_main_frame_loads_requirements(monkeypatch, tmp_path):
     from app.core.store import save
 
     data = {
-        "id": "REQ-1",
+        "id": 1,
         "title": "Title",
         "statement": "Statement",
         "type": "requirement",
@@ -137,7 +137,7 @@ def test_main_frame_select_opens_editor(monkeypatch, tmp_path):
     import importlib
 
     data = {
-        "id": "REQ-1",
+        "id": 1,
         "title": "Title",
         "statement": "Statement",
         "type": "requirement",
@@ -182,7 +182,7 @@ def test_main_frame_select_opens_editor(monkeypatch, tmp_path):
     app.Yield()
 
     assert frame.editor.IsShown()
-    assert frame.editor.fields["id"].GetValue() == data["id"]
+    assert frame.editor.fields["id"].GetValue() == str(data["id"])
 
     frame.Destroy()
     app.Destroy()
@@ -190,7 +190,7 @@ def test_main_frame_select_opens_editor(monkeypatch, tmp_path):
 
 def _sample_requirement():
     return {
-        "id": "REQ-1",
+        "id": 1,
         "title": "Title",
         "statement": "Statement",
         "type": "requirement",
@@ -246,7 +246,7 @@ def test_main_frame_clone_requirement_creates_copy(monkeypatch, tmp_path):
 
     assert frame.editor.IsShown()
     new_id = frame.editor.fields["id"].GetValue()
-    assert new_id and new_id != data["id"]
+    assert new_id and new_id != str(data["id"])
     assert frame.editor.fields["title"].GetValue().startswith("(Копия)")
     assert len(frame.requirements) == 2
 
@@ -263,7 +263,7 @@ def test_main_frame_new_requirement_button(monkeypatch, tmp_path):
 
     assert frame.editor.IsShown()
     assert frame.requirements
-    assert frame.editor.fields["id"].GetValue() == frame.requirements[0]["id"]
+    assert frame.editor.fields["id"].GetValue() == str(frame.requirements[0]["id"])
 
     frame.Destroy()
     app.Destroy()

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -9,7 +9,7 @@ from app.core.model import (
 
 def test_requirement_defaults():
     req = Requirement(
-        id="REQ-1",
+        id=1,
         title="Title",
         statement="Statement",
         type=RequirementType.REQUIREMENT,

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -5,7 +5,7 @@ from app.core.schema import validate
 
 def make_valid() -> dict:
     return {
-        "id": "REQ-1",
+        "id": 1,
         "title": "Title",
         "statement": "Statement",
         "type": "requirement",

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -11,7 +11,7 @@ from app.core.search import filter_by_labels, search, search_text
 def sample_requirements():
     return [
         Requirement(
-            id="REQ-1",
+            id=1,
             title="Login form",
             statement="System shows login form",
             type=RequirementType.REQUIREMENT,
@@ -24,7 +24,7 @@ def sample_requirements():
             notes="Requires username",
         ),
         Requirement(
-            id="REQ-2",
+            id=2,
             title="Store data",
             statement="System stores data in DB",
             type=RequirementType.REQUIREMENT,
@@ -36,7 +36,7 @@ def sample_requirements():
             labels=["backend"],
         ),
         Requirement(
-            id="REQ-3",
+            id=3,
             title="Export report",
             statement="User can export report",
             type=RequirementType.REQUIREMENT,
@@ -52,8 +52,8 @@ def sample_requirements():
 
 def test_filter_by_labels():
     reqs = sample_requirements()
-    assert {r.id for r in filter_by_labels(reqs, ["ui"])} == {"REQ-1", "REQ-3"}
-    assert [r.id for r in filter_by_labels(reqs, ["ui", "auth"])] == ["REQ-1"]
+    assert {r.id for r in filter_by_labels(reqs, ["ui"])} == {1, 3}
+    assert [r.id for r in filter_by_labels(reqs, ["ui", "auth"])] == [1]
 
 
 def test_filter_by_labels_empty_returns_all():
@@ -64,9 +64,9 @@ def test_filter_by_labels_empty_returns_all():
 def test_search_text():
     reqs = sample_requirements()
     found = search_text(reqs, "login", ["title", "notes"])
-    assert [r.id for r in found] == ["REQ-1"]
+    assert [r.id for r in found] == [1]
     found = search_text(reqs, "EXPORT", ["title"])
-    assert [r.id for r in found] == ["REQ-3"]
+    assert [r.id for r in found] == [3]
 
 
 def test_search_text_empty_query_returns_all():
@@ -82,13 +82,13 @@ def test_search_text_no_valid_fields_returns_all():
 def test_combined_search():
     reqs = sample_requirements()
     found = search(reqs, labels=["ui"], query="export", fields=["title"])
-    assert [r.id for r in found] == ["REQ-3"]
+    assert [r.id for r in found] == [3]
 
 
 def test_accepts_plain_dicts():
     reqs = [
-        {"id": "1", "title": "Login", "labels": ["ui"]},
-        {"id": "2", "title": "Export", "labels": ["report"]},
+        {"id": 1, "title": "Login", "labels": ["ui"]},
+        {"id": 2, "title": "Export", "labels": ["report"]},
     ]
     found = search(reqs, labels=["ui"], query="login", fields=["title"])
-    assert [r["id"] for r in found] == ["1"]
+    assert [r["id"] for r in found] == [1]

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -25,7 +25,7 @@ from app.core.store import (
 
 def sample() -> dict:
     return {
-        "id": "REQ-1",
+        "id": 1,
         "title": "Title",
         "statement": "Statement",
         "type": "requirement",
@@ -61,19 +61,19 @@ def test_conflict_detection(tmp_path: Path):
 
 def test_existing_ids_skips_invalid_and_excluded(tmp_path: Path):
     valid = tmp_path / "valid.json"
-    valid.write_text(json.dumps({"id": "REQ-1"}))
+    valid.write_text(json.dumps({"id": 1}))
     exclude = tmp_path / "exclude.json"
-    exclude.write_text(json.dumps({"id": "REQ-2"}))
+    exclude.write_text(json.dumps({"id": 2}))
     bad = tmp_path / "bad.json"
     bad.write_text("{invalid json")
 
     ids = _existing_ids(tmp_path, exclude)
-    assert ids == {"REQ-1"}
+    assert ids == {1}
 
 
 def test_save_accepts_dataclass(tmp_path: Path):
     req = Requirement(
-        id="REQ-10",
+        id=10,
         title="Dataclass", 
         statement="Save dataclass",
         type=RequirementType.REQUIREMENT,
@@ -92,4 +92,4 @@ def test_save_accepts_dataclass(tmp_path: Path):
 
 
 def test_filename_for_sanitizes():
-    assert filename_for("REQ/1:*?") == "REQ_1___.json"
+    assert filename_for(1) == "1.json"

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -4,7 +4,7 @@ from app.core.validate import ValidationError, validate
 
 def make_valid() -> dict:
     return {
-        "id": "REQ-1",
+        "id": 1,
         "title": "Title",
         "statement": "Statement",
         "type": "requirement",
@@ -20,7 +20,7 @@ def make_valid() -> dict:
 def test_duplicate_id():
     data = make_valid()
     with pytest.raises(ValidationError):
-        validate(data, existing_ids={"REQ-1"})
+        validate(data, existing_ids={1})
 
 
 def test_acceptance_optional_for_verification_methods():


### PR DESCRIPTION
## Summary
- store requirement IDs as integers and adjust schema and storage
- sort by numeric ID in list panel and generate sequential IDs
- update tests and CLI to handle integer IDs

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c2cc5287b88320abd6d115fc1cd167