### PR TITLE
fix menu rebuild to support older wx versions

### DIFF
--- a/app/ui/main_frame.py
+++ b/app/ui/main_frame.py
@@ -118,7 +118,8 @@ class MainFrame(wx.Frame):
         self._rebuild_recent_menu()
 
     def _rebuild_recent_menu(self) -> None:
-        self._recent_menu.Clear()
+        for item in list(self._recent_menu.GetMenuItems()):
+            self._recent_menu.Delete(item)
         self._recent_items.clear()
         for p in self.recent_dirs:
             item = self._recent_menu.Append(wx.ID_ANY, p)


### PR DESCRIPTION
## Summary
- fix recent menu rebuild to delete items individually

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c2d19c028883209e8b430d5af5b8eb