### PR TITLE
Добавлена форма настроек и сохранение сортировки

### DIFF
--- a/app/ui/settings_dialog.py
+++ b/app/ui/settings_dialog.py
@@ -1,0 +1,26 @@
+"""Dialog for application settings."""
+
+import wx
+
+
+class SettingsDialog(wx.Dialog):
+    """Simple dialog with application preferences."""
+
+    def __init__(self, parent: wx.Window, *, open_last: bool, remember_sort: bool):
+        super().__init__(parent, title="Settings")
+        self._open_last = wx.CheckBox(self, label="Open last folder on startup")
+        self._open_last.SetValue(open_last)
+        self._remember_sort = wx.CheckBox(self, label="Remember sort order")
+        self._remember_sort.SetValue(remember_sort)
+
+        sizer = wx.BoxSizer(wx.VERTICAL)
+        sizer.Add(self._open_last, 0, wx.ALL, 5)
+        sizer.Add(self._remember_sort, 0, wx.ALL, 5)
+        btn_sizer = self.CreateStdDialogButtonSizer(wx.OK | wx.CANCEL)
+        if btn_sizer:
+            sizer.Add(btn_sizer, 0, wx.ALIGN_CENTER | wx.ALL, 5)
+        self.SetSizerAndFit(sizer)
+
+    def get_values(self) -> tuple[bool, bool]:
+        """Return (open_last_folder, remember_sort)."""
+        return self._open_last.GetValue(), self._remember_sort.GetValue()

--- a/tests/test_list_panel.py
+++ b/tests/test_list_panel.py
@@ -173,3 +173,29 @@ def test_bulk_edit_updates_requirements(monkeypatch):
     monkeypatch.setattr(panel, "_prompt_value", lambda field: "2")
     panel._on_edit_field(1)
     assert [r["version"] for r in reqs] == ["2", "2"]
+
+
+def test_sort_method_and_callback(monkeypatch):
+    wx_stub = _build_wx_stub()
+    monkeypatch.setitem(sys.modules, "wx", wx_stub)
+
+    list_panel_module = importlib.import_module("app.ui.list_panel")
+    importlib.reload(list_panel_module)
+    ListPanel = list_panel_module.ListPanel
+
+    frame = wx_stub.Panel(None)
+    calls = []
+    panel = ListPanel(frame, on_sort_changed=lambda c, a: calls.append((c, a)))
+    panel.set_columns(["id"])
+    panel.set_requirements([
+        {"id": 2, "title": "B"},
+        {"id": 1, "title": "A"},
+    ])
+
+    panel.sort(1, True)
+    assert [r["id"] for r in panel._requirements] == [1, 2]
+    assert calls[-1] == (1, True)
+
+    panel.sort(1, False)
+    assert [r["id"] for r in panel._requirements] == [2, 1]
+    assert calls[-1] == (1, False)


### PR DESCRIPTION
## Summary
- добавить диалог настроек с опциями автозагрузки последней папки и запоминания сортировки
- сохранять выбранный столбец и порядок сортировки между запусками
- автозагружать последнюю папку требований при старте приложения при включённой опции

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c2d7465d9c8320a28a1bea00a626fc