### PR TITLE
Использование ID требований в списке и обработчиках

### DIFF
--- a/app/ui/list_panel.py
+++ b/app/ui/list_panel.py
@@ -127,7 +127,7 @@ class ListPanel(wx.Panel):
         self.set_requirements(self._requirements)
 
     def set_requirements(self, requirements: list) -> None:
-        """Populate list control with requirement data."""
+        """Populate list control with requirement data and store IDs."""
         self._all_requirements = requirements
         self._apply_filters()
 
@@ -159,6 +159,11 @@ class ListPanel(wx.Panel):
         for req in self._requirements:
             title = req.get("title") if isinstance(req, dict) else getattr(req, "title", "")
             index = self.list.InsertItem(self.list.GetItemCount(), title)
+            req_id = req.get("id") if isinstance(req, dict) else getattr(req, "id", 0)
+            try:
+                self.list.SetItemData(index, int(req_id))
+            except Exception:
+                self.list.SetItemData(index, 0)
             for col, field in enumerate(self.columns, start=1):
                 if isinstance(req, dict):
                     value = req.get(field, "")
@@ -219,15 +224,16 @@ class ListPanel(wx.Panel):
         menu = wx.Menu()
         clone_item = menu.Append(wx.ID_ANY, "Клонировать")
         delete_item = menu.Append(wx.ID_ANY, "Удалить")
+        req_id = self.list.GetItemData(index)
         field = self._field_from_column(column)
         edit_item = None
         if field and field != "title":
             edit_item = menu.Append(wx.ID_ANY, f"Изменить {field}")
             self.Bind(wx.EVT_MENU, lambda evt, c=column: self._on_edit_field(c), edit_item)
         if self._on_clone:
-            self.Bind(wx.EVT_MENU, lambda evt: self._on_clone(index), clone_item)
+            self.Bind(wx.EVT_MENU, lambda evt, i=req_id: self._on_clone(i), clone_item)
         if self._on_delete:
-            self.Bind(wx.EVT_MENU, lambda evt: self._on_delete(index), delete_item)
+            self.Bind(wx.EVT_MENU, lambda evt, i=req_id: self._on_delete(i), delete_item)
         return menu, clone_item, delete_item, edit_item
 
     def _get_selected_indices(self) -> List[int]:

--- a/tests/test_list_panel.py
+++ b/tests/test_list_panel.py
@@ -34,19 +34,27 @@ def _build_wx_stub():
         def __init__(self, parent=None, style=0):
             super().__init__(parent)
             self._items = []
+            self._data = []
         def InsertColumn(self, col, heading):
             pass
         def ClearAll(self):
             self._items.clear()
+            self._data.clear()
         def DeleteAllItems(self):
             self._items.clear()
+            self._data.clear()
         def GetItemCount(self):
             return len(self._items)
         def InsertItem(self, index, text):
             self._items.insert(index, text)
+            self._data.insert(index, 0)
             return index
         def SetItem(self, index, col, text):
             pass
+        def SetItemData(self, index, data):
+            self._data[index] = data
+        def GetItemData(self, index):
+            return self._data[index]
 
     class BoxSizer:
         def __init__(self, orient):

--- a/tests/test_list_panel_gui.py
+++ b/tests/test_list_panel_gui.py
@@ -34,11 +34,11 @@ def test_list_panel_context_menu_calls_handlers():
     frame = wx.Frame(None)
     called: dict[str, int] = {}
 
-    def on_clone(idx: int) -> None:
-        called["clone"] = idx
+    def on_clone(req_id: int) -> None:
+        called["clone"] = req_id
 
-    def on_delete(idx: int) -> None:
-        called["delete"] = idx
+    def on_delete(req_id: int) -> None:
+        called["delete"] = req_id
 
     panel = list_panel.ListPanel(frame, on_clone=on_clone, on_delete=on_delete)
     panel.set_requirements([{ "id": 1, "title": "T" }])
@@ -53,7 +53,7 @@ def test_list_panel_context_menu_calls_handlers():
     panel.ProcessEvent(evt)
     menu.Destroy()
 
-    assert called == {"clone": 0, "delete": 0}
+    assert called == {"clone": 1, "delete": 1}
 
     frame.Destroy()
     app.Destroy()

--- a/tests/test_main_frame_gui.py
+++ b/tests/test_main_frame_gui.py
@@ -242,7 +242,7 @@ def test_main_frame_clone_requirement_creates_copy(monkeypatch, tmp_path):
 
     wx, app, frame = _prepare_frame(monkeypatch, tmp_path)
 
-    frame.on_clone_requirement(0)
+    frame.on_clone_requirement(frame.requirements[0]["id"])
 
     assert frame.editor.IsShown()
     new_id = frame.editor.fields["id"].GetValue()
@@ -280,7 +280,7 @@ def test_main_frame_delete_requirement_removes_file(monkeypatch, tmp_path):
     assert path.exists()
     assert frame.panel.list.GetItemCount() == 1
 
-    frame.on_delete_requirement(0)
+    frame.on_delete_requirement(frame.requirements[0]["id"])
 
     assert frame.panel.list.GetItemCount() == 0
     assert not path.exists()


### PR DESCRIPTION
## Summary
- сохранять ID требований в элементах ListCtrl
- получать ID из событий и обрабатывать клонирование/удаление по ID
- обновлены тесты

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c2de489d988320b990ff044d24ba51