### PR TITLE
Handle empty ID in editor panel and allow default list model

### DIFF
--- a/app/ui/editor_panel.py
+++ b/app/ui/editor_panel.py
@@ -243,8 +243,9 @@ class EditorPanel(wx.Panel):
 
     # data helpers -----------------------------------------------------
     def get_data(self) -> dict[str, Any]:
+        id_value = self.fields["id"].GetValue().strip()
         data = {
-            "id": int(self.fields["id"].GetValue()),
+            "id": int(id_value) if id_value else 0,
             "title": self.fields["title"].GetValue(),
             "statement": self.fields["statement"].GetValue(),
             "type": locale.ru_to_code("type", self.enums["type"].GetStringSelection()),

--- a/app/ui/list_panel.py
+++ b/app/ui/list_panel.py
@@ -22,13 +22,13 @@ class ListPanel(wx.Panel, ColumnSorterMixin):
         self,
         parent: wx.Window,
         *,
-        model: RequirementModel,
+        model: RequirementModel | None = None,
         on_clone: Callable[[int], None] | None = None,
         on_delete: Callable[[int], None] | None = None,
         on_sort_changed: Callable[[int, bool], None] | None = None,
     ):
         wx.Panel.__init__(self, parent)
-        self.model = model
+        self.model = model if model is not None else RequirementModel()
         sizer = wx.BoxSizer(wx.VERTICAL)
         self.search = wx.SearchCtrl(self)
         self.list = wx.ListCtrl(self, style=wx.LC_REPORT)


### PR DESCRIPTION
## Summary
- Avoid ValueError in EditorPanel when ID field is empty by defaulting to 0
- Allow ListPanel to be constructed without explicitly passing a model

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c3bd54dbfc8320bfea04828482bce4