### PR TITLE
Validate requirement ID before saving

### DIFF
--- a/app/ui/editor_panel.py
+++ b/app/ui/editor_panel.py
@@ -134,6 +134,8 @@ class EditorPanel(wx.Panel):
             self.fields[name] = ctrl
             proportion = 1 if multiline and name != "source" else 0
             sizer.Add(ctrl, proportion, wx.EXPAND | wx.ALL, 5)
+            if name == "id":
+                ctrl.SetHint("Уникальный целочисленный идентификатор")
 
         def add_text_field(name: str) -> None:
             container = wx.BoxSizer(wx.VERTICAL)
@@ -244,8 +246,17 @@ class EditorPanel(wx.Panel):
     # data helpers -----------------------------------------------------
     def get_data(self) -> dict[str, Any]:
         id_value = self.fields["id"].GetValue().strip()
+        if not id_value:
+            raise ValueError("требуется указать идентификатор")
+        try:
+            req_id = int(id_value)
+        except ValueError as exc:  # pragma: no cover - error path
+            raise ValueError("идентификатор должен быть целым числом") from exc
+        if req_id <= 0:
+            raise ValueError("идентификатор должен быть положительным")
+
         data = {
-            "id": int(id_value) if id_value else 0,
+            "id": req_id,
             "title": self.fields["title"].GetValue(),
             "statement": self.fields["statement"].GetValue(),
             "type": locale.ru_to_code("type", self.enums["type"].GetStringSelection()),

--- a/app/ui/main_frame.py
+++ b/app/ui/main_frame.py
@@ -167,7 +167,11 @@ class MainFrame(wx.Frame):
     def _on_editor_save(self) -> None:
         if not self.current_dir:
             return
-        path = self.editor.save(self.current_dir)
+        try:
+            self.editor.save(self.current_dir)
+        except ValueError as exc:  # pragma: no cover - GUI event
+            wx.MessageBox(str(exc), "Ошибка", wx.ICON_ERROR)
+            return
         data = self.editor.get_data()
         self.model.update(data)
         self.panel.refresh()

--- a/tests/test_editor_panel.py
+++ b/tests/test_editor_panel.py
@@ -68,12 +68,29 @@ def test_editor_clone(tmp_path):
     assert data["title"] == orig_data["title"]
 
 
+def test_get_data_requires_valid_id():
+    panel = _make_panel()
+    panel.new_requirement()
+    with pytest.raises(ValueError):
+        panel.get_data()
+    panel.fields["id"].SetValue("abc")
+    with pytest.raises(ValueError):
+        panel.get_data()
+    panel.fields["id"].SetValue("-5")
+    with pytest.raises(ValueError):
+        panel.get_data()
+    panel.fields["id"].SetValue("10")
+    data = panel.get_data()
+    assert data["id"] == 10
+
+
 def test_enum_localization_roundtrip():
     wx = pytest.importorskip("wx")
     from app.ui import locale
 
     panel = _make_panel()
     panel.new_requirement()
+    panel.fields["id"].SetValue("1")
     data = panel.get_data()
     assert data["type"] == "requirement"
     assert data["status"] == "draft"

--- a/tests/test_editor_panel_gui.py
+++ b/tests/test_editor_panel_gui.py
@@ -25,6 +25,7 @@ def test_editor_new_requirement_resets(tmp_path):
     panel.new_requirement()
 
     assert all(ctrl.GetValue() == "" for ctrl in panel.fields.values())
+    panel.fields["id"].SetValue("1")
     defaults = panel.get_data()
     assert defaults["type"] == "requirement"
     assert defaults["status"] == "draft"
@@ -43,6 +44,7 @@ def test_editor_add_attachment_included():
     panel = _make_panel()
     panel.new_requirement()
     panel.add_attachment("file.txt", "note")
+    panel.fields["id"].SetValue("1")
     data = panel.get_data()
     assert data["attachments"] == [{"path": "file.txt", "note": "note"}]
 


### PR DESCRIPTION
## Summary
- enforce explicit positive integer ID in editor panel
- show validation error dialog and add ID hint
- test coverage for ID validation

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c3be444ffc8320a9359765128e2d46