### PR TITLE
Handle save conflicts in main frame

### DIFF
--- a/app/ui/main_frame.py
+++ b/app/ui/main_frame.py
@@ -169,7 +169,14 @@ class MainFrame(wx.Frame):
             return
         try:
             self.editor.save(self.current_dir)
-        except ValueError as exc:  # pragma: no cover - GUI event
+        except store.ConflictError:  # pragma: no cover - GUI event
+            wx.MessageBox(
+                "Файл был изменён на диске. Сохранение отменено.",
+                "Ошибка",
+                wx.ICON_ERROR,
+            )
+            return
+        except Exception as exc:  # pragma: no cover - GUI event
             wx.MessageBox(str(exc), "Ошибка", wx.ICON_ERROR)
             return
         data = self.editor.get_data()


### PR DESCRIPTION
## Summary
- handle store.ConflictError during requirement save
- display friendly error and abort updating model

## Testing
- `python3 -m pytest >/tmp/unit.log && tail -n 20 /tmp/unit.log`

------
https://chatgpt.com/codex/tasks/task_e_68c3c325288483208b105b76da2d7805