### PR TITLE
Add gettext translation compilation script and integrate into build

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,12 +59,23 @@ pytest -q
 
 ## Локализация
 
-Проект использует `gettext` и `wx.Locale`. В репозитории хранятся только исходные `.po`‑файлы переводов. Скомпилированные каталоги `.mo`
-не добавляются в git и генерируются локально. Для их создания установите утилиты GNU gettext и выполните:
+Проект использует `gettext` и `wx.Locale`. В репозитории хранятся только исходные
+`.po`‑файлы переводов. Скомпилированные каталоги `.mo` не добавляются в git и
+генерируются локально.
 
-```bash
-msgfmt app/locale/ru/LC_MESSAGES/CookaReq.po -o app/locale/ru/LC_MESSAGES/CookaReq.mo
-msgfmt app/locale/en/LC_MESSAGES/CookaReq.po -o app/locale/en/LC_MESSAGES/CookaReq.mo
-```
+1. Установите утилиты GNU gettext (необходима команда `msgfmt`). Например, в
+   Ubuntu:
 
-После этого приложение и тесты будут использовать переводы из соответствующих `.mo`.
+   ```bash
+   sudo apt-get update && sudo apt-get install -y gettext
+   ```
+
+2. Скомпилируйте все переводы:
+
+   ```bash
+   python3 compile_translations.py
+   ```
+
+Скрипт сгенерирует `.mo`‑файлы рядом с соответствующими `.po`. При запуске
+`build.py` компиляция выполняется автоматически, поэтому готовая сборка всегда
+содержит актуальные переводы.

--- a/build.py
+++ b/build.py
@@ -9,9 +9,13 @@ import sys
 
 import PyInstaller.__main__  # type: ignore
 
+from compile_translations import compile_all
+
 
 def main() -> None:
     root = Path(__file__).resolve().parent
+    # Ensure localisation files are compiled before packaging
+    compile_all(root / "app" / "locale")
     script = root / "app" / "main.py"
     args: list[str] = [
         str(script),

--- a/compile_translations.py
+++ b/compile_translations.py
@@ -1,0 +1,27 @@
+"""Compile gettext .po files into .mo files."""
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+def compile_all(locales_dir: Path) -> None:
+    """Compile all ``.po`` files under ``locales_dir`` into ``.mo`` files."""
+    if shutil.which("msgfmt") is None:
+        print("msgfmt not found. Please install GNU gettext.", file=sys.stderr)
+        raise SystemExit(1)
+
+    for po_file in locales_dir.rglob("*.po"):
+        mo_file = po_file.with_suffix(".mo")
+        subprocess.run(["msgfmt", str(po_file), "-o", str(mo_file)], check=True)
+
+
+def main() -> None:
+    root = Path(__file__).resolve().parent
+    compile_all(root / "app" / "locale")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add script to compile gettext `.po` files into `.mo`
- invoke translation compilation automatically in `build.py`
- document translation compilation in README and note gettext dependency

## Testing
- `python3 compile_translations.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c3d39ddf508320a7d5da9b44dfcd7a