### PR TITLE
Use app.ico as application icon

### DIFF
--- a/app/resources/__init__.py
+++ b/app/resources/__init__.py
@@ -1,0 +1,1 @@
+"""Package for bundled application resources."""

--- a/app/ui/main_frame.py
+++ b/app/ui/main_frame.py
@@ -3,6 +3,7 @@
 from gettext import gettext as _
 
 import logging
+from importlib import resources
 import wx
 from pathlib import Path
 from dataclasses import fields
@@ -46,6 +47,8 @@ class MainFrame(wx.Frame):
         self.sort_column = self.config.ReadInt("sort_column", -1)
         self.sort_ascending = self.config.ReadBool("sort_ascending", True)
         super().__init__(parent=parent, title=self._base_title)
+        with resources.as_file(resources.files("app.resources") / "app.ico") as icon_path:
+            self.SetIcon(wx.Icon(str(icon_path)))
         self.model = RequirementModel()
         self._create_menu()
         self._create_toolbar()

--- a/build.py
+++ b/build.py
@@ -5,6 +5,7 @@ folder. It requires PyInstaller to be installed in the active
 environment.
 """
 from pathlib import Path
+import os
 import sys
 
 import PyInstaller.__main__  # type: ignore
@@ -17,6 +18,7 @@ def main() -> None:
     # Ensure localisation files are compiled before packaging
     compile_all(root / "app" / "locale")
     script = root / "app" / "main.py"
+    icon = root / "app" / "resources" / "app.ico"
     args: list[str] = [
         str(script),
         "--name=CookaReq",
@@ -30,6 +32,8 @@ def main() -> None:
         # Collect package data/binaries that wx/jsonschema may need
         "--collect-all=wx",
         "--collect-all=jsonschema",
+        f"--add-data={icon}{os.pathsep}app/resources",
+        f"--icon={icon}",
     ]
 
     # Allow switching to a single EXE if user passes "--onefile"


### PR DESCRIPTION
## Summary
- load `app.ico` as main window icon via `importlib.resources`
- include icon in PyInstaller build and set executable icon
- mark resources directory as a package for bundling

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c3d654cff483209ff4377918f1dc8a