### PR TITLE
Implement label management and persistence

### DIFF
--- a/app/core/labels.py
+++ b/app/core/labels.py
@@ -1,0 +1,58 @@
+"""Label definitions and in-memory CRUD helpers."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List
+
+
+@dataclass(slots=True)
+class Label:
+    """Simple label with a ``name`` and associated ``color``."""
+
+    name: str
+    color: str
+
+
+def add_label(labels: List[Label], label: Label) -> None:
+    """Add ``label`` to ``labels`` ensuring unique names."""
+    if any(l.name == label.name for l in labels):
+        raise ValueError(f"label exists: {label.name}")
+    labels.append(label)
+
+
+def get_label(labels: List[Label], name: str) -> Label | None:
+    """Return label with ``name`` or ``None`` if absent."""
+    for lbl in labels:
+        if lbl.name == name:
+            return lbl
+    return None
+
+
+def update_label(labels: List[Label], label: Label) -> None:
+    """Replace existing label with same name as ``label``.
+
+    Raises
+    ------
+    KeyError
+        If label with given name is not found.
+    """
+    for i, existing in enumerate(labels):
+        if existing.name == label.name:
+            labels[i] = label
+            return
+    raise KeyError(f"label not found: {label.name}")
+
+
+def delete_label(labels: List[Label], name: str) -> None:
+    """Remove label with ``name`` from ``labels``.
+
+    Raises
+    ------
+    KeyError
+        If no label with ``name`` exists.
+    """
+    for i, lbl in enumerate(labels):
+        if lbl.name == name:
+            del labels[i]
+            return
+    raise KeyError(f"label not found: {name}")

--- a/tests/test_labels.py
+++ b/tests/test_labels.py
@@ -1,0 +1,21 @@
+from app.core.labels import Label, add_label, get_label, update_label, delete_label
+from app.core import store
+from pathlib import Path
+
+
+def test_label_crud_operations(tmp_path: Path) -> None:
+    labels: list[Label] = []
+    lbl = Label("ui", "#ff0000")
+    add_label(labels, lbl)
+    assert get_label(labels, "ui") == lbl
+    update_label(labels, Label("ui", "#00ff00"))
+    assert get_label(labels, "ui").color == "#00ff00"
+    delete_label(labels, "ui")
+    assert get_label(labels, "ui") is None
+
+
+def test_store_load_save_labels(tmp_path: Path) -> None:
+    labels = [Label("ui", "#ff0000"), Label("backend", "#00ff00")]
+    store.save_labels(tmp_path, labels)
+    loaded = store.load_labels(tmp_path)
+    assert loaded == labels


### PR DESCRIPTION
## Summary
- add dataclass `Label` with CRUD helpers
- support loading and saving `labels.json` via `store`
- synchronize labels in `MainFrame` when folders change

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c3e857f34c83209a2de95a1430809a