### PR TITLE
Implement labels management dialog

### DIFF
--- a/app/ui/labels_dialog.py
+++ b/app/ui/labels_dialog.py
@@ -1,0 +1,60 @@
+"""Dialog for managing label colors."""
+
+from gettext import gettext as _
+
+import wx
+
+from app.core.labels import Label
+
+
+class LabelsDialog(wx.Dialog):
+    """Dialog allowing to view labels and adjust their colors."""
+
+    def __init__(self, parent: wx.Window, labels: list[Label]):
+        super().__init__(parent, title=_("Labels"))
+        # copy labels to avoid modifying caller until OK
+        self._labels: list[Label] = [Label(l.name, l.color) for l in labels]
+
+        self.list = wx.ListCtrl(self, style=wx.LC_REPORT | wx.BORDER_SUNKEN)
+        self.list.InsertColumn(0, _("Name"))
+        self.list.InsertColumn(1, _("Color"))
+
+        self._populate()
+
+        self.color_picker = wx.ColourPickerCtrl(self)
+        self.color_picker.Disable()
+
+        self.list.Bind(wx.EVT_LIST_ITEM_SELECTED, self._on_select)
+        self.color_picker.Bind(wx.EVT_COLOURPICKER_CHANGED, self._on_color_changed)
+
+        sizer = wx.BoxSizer(wx.VERTICAL)
+        sizer.Add(self.list, 1, wx.EXPAND | wx.ALL, 5)
+        sizer.Add(self.color_picker, 0, wx.ALL | wx.ALIGN_RIGHT, 5)
+        btn_sizer = self.CreateStdDialogButtonSizer(wx.OK | wx.CANCEL)
+        if btn_sizer:
+            sizer.Add(btn_sizer, 0, wx.ALIGN_CENTER | wx.ALL, 5)
+        self.SetSizerAndFit(sizer)
+
+    def _populate(self) -> None:
+        self.list.DeleteAllItems()
+        for lbl in self._labels:
+            idx = self.list.InsertItem(self.list.GetItemCount(), lbl.name)
+            self.list.SetItem(idx, 1, lbl.color)
+
+    def _on_select(self, event: wx.ListEvent) -> None:  # pragma: no cover - GUI event
+        idx = event.GetIndex()
+        colour = wx.Colour(self._labels[idx].color)
+        self.color_picker.SetColour(colour)
+        self.color_picker.Enable()
+
+    def _on_color_changed(self, event: wx.ColourPickerEvent) -> None:  # pragma: no cover - GUI event
+        idx = self.list.GetFirstSelected()
+        if idx == -1:
+            return
+        colour = event.GetColour().GetAsString(wx.C2S_HTML_SYNTAX)
+        self._labels[idx].color = colour
+        self.list.SetItem(idx, 1, colour)
+
+    def get_labels(self) -> list[Label]:
+        """Return updated labels."""
+        return list(self._labels)

--- a/tests/test_labels_dialog.py
+++ b/tests/test_labels_dialog.py
@@ -1,0 +1,104 @@
+import importlib
+from types import SimpleNamespace
+
+import pytest
+
+from app.core.labels import Label
+
+
+def test_labels_dialog_changes_color():
+    wx = pytest.importorskip("wx")
+    app = wx.App()
+    from app.ui.labels_dialog import LabelsDialog
+
+    dlg = LabelsDialog(None, [Label("ui", "#ff0000")])
+    dlg.list.Select(0)
+    dlg._on_select(SimpleNamespace(GetIndex=lambda: 0))
+
+    class DummyEvent:
+        def GetColour(self):
+            return wx.Colour("#00ff00")
+
+    dlg._on_color_changed(DummyEvent())
+    labels = dlg.get_labels()
+    assert labels[0].color.lower() == "#00ff00"
+    dlg.Destroy()
+    app.Destroy()
+
+
+def _prepare_frame(monkeypatch, tmp_path):
+    from app.core.store import save
+
+    data = {
+        "id": 1,
+        "title": "Title",
+        "statement": "Statement",
+        "type": "requirement",
+        "status": "draft",
+        "owner": "user",
+        "priority": "medium",
+        "source": "spec",
+        "verification": "analysis",
+        "labels": ["ui"],
+        "revision": 1,
+    }
+    save(tmp_path, data)
+
+    wx = pytest.importorskip("wx")
+    app = wx.App()
+
+    class DummyDirDialog:
+        def __init__(self, parent, message):
+            pass
+
+        def ShowModal(self):
+            return wx.ID_OK
+
+        def GetPath(self):
+            return str(tmp_path)
+
+        def Destroy(self):
+            pass
+
+    monkeypatch.setattr(wx, "DirDialog", DummyDirDialog)
+
+    import app.ui.list_panel as list_panel
+    import app.ui.main_frame as main_frame
+    importlib.reload(list_panel)
+    importlib.reload(main_frame)
+
+    frame = main_frame.MainFrame(None)
+    evt = wx.CommandEvent(wx.EVT_MENU.typeId, wx.ID_OPEN)
+    frame.ProcessEvent(evt)
+
+    return wx, app, frame, main_frame
+
+
+def test_main_frame_manage_labels_saves(monkeypatch, tmp_path):
+    wx, app, frame, main_frame_mod = _prepare_frame(monkeypatch, tmp_path)
+
+    class DummyLabelsDialog:
+        def __init__(self, parent, labels):
+            self._labels = [Label(l.name, "#123456") for l in labels]
+
+        def ShowModal(self):
+            return wx.ID_OK
+
+        def get_labels(self):
+            return self._labels
+
+        def Destroy(self):
+            pass
+
+    monkeypatch.setattr(main_frame_mod, "LabelsDialog", DummyLabelsDialog)
+
+    evt = wx.CommandEvent(wx.EVT_MENU.typeId, frame.manage_labels_id)
+    frame.ProcessEvent(evt)
+
+    from app.core import store
+
+    labels = store.load_labels(tmp_path)
+    assert labels[0].color == "#123456"
+
+    frame.Destroy()
+    app.Destroy()


### PR DESCRIPTION
## Summary
- Add `LabelsDialog` for viewing and editing label colors
- Hook dialog into `MainFrame` via new `Manage Labels` menu option
- Cover label management with GUI tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c3ee4b9c488320a8a01fb3335c4405