### PR TITLE
feat: support labels column in requirement list

### DIFF
--- a/app/ui/list_panel.py
+++ b/app/ui/list_panel.py
@@ -154,7 +154,10 @@ class ListPanel(wx.Panel, ColumnSorterMixin):
         config.Write("col_order", ",".join(names))
 
     def set_columns(self, fields: List[str]) -> None:
-        """Set additional columns (beyond Title) to display."""
+        """Set additional columns (beyond Title) to display.
+
+        ``labels`` is treated specially and rendered as a comma-separated list.
+        """
         self.columns = fields
         self._setup_columns()
         # repopulate with existing requirements after changing columns
@@ -194,6 +197,8 @@ class ListPanel(wx.Panel, ColumnSorterMixin):
                 self.list.SetItemData(index, 0)
             for col, field in enumerate(self.columns, start=1):
                 value = req.get(field, "")
+                if field == "labels" and isinstance(value, list):
+                    value = ", ".join(value)
                 self.list.SetItem(index, col, str(value))
 
     def refresh(self) -> None:

--- a/app/ui/main_frame.py
+++ b/app/ui/main_frame.py
@@ -40,7 +40,13 @@ class MainFrame(wx.Frame):
     def __init__(self, parent: wx.Window | None):
         self._base_title = "CookaReq"
         self.config = wx.Config(appName="CookaReq")
-        self.available_fields = [f.name for f in fields(Requirement) if f.name != "title"]
+        # ``Requirement`` содержит множество полей, но в списке колонок
+        # нам нужны только скалярные значения. Метки отображаются особым
+        # образом, поэтому добавим их вручную в конец списка.
+        self.available_fields = [
+            f.name for f in fields(Requirement) if f.name not in {"title", "labels"}
+        ]
+        self.available_fields.append("labels")
         self.selected_fields = self._load_columns()
         self.recent_dirs = self._load_recent_dirs()
         self._recent_items: Dict[int, Path] = {}

--- a/app/ui/requirement_model.py
+++ b/app/ui/requirement_model.py
@@ -85,6 +85,9 @@ class RequirementModel:
                     return int(value)
                 except Exception:
                     return 0
+            if self._sort_field == "labels" and isinstance(value, list):
+                # сортируем по первой метке, остальные не учитываем
+                return value[0] if value else ""
             return value
 
         self._visible.sort(key=get_value, reverse=not self._sort_ascending)


### PR DESCRIPTION
## Summary
- add `labels` to available fields and handle rendering in list panel
- render label lists as comma-separated strings
- enable sorting requirements by first label
- test label column rendering and sorting

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c3f31bc2d48320b2551567a6bcf98a