### PR TITLE
feat: add label filtering and any-label search option

### DIFF
--- a/app/ui/requirement_model.py
+++ b/app/ui/requirement_model.py
@@ -13,6 +13,7 @@ class RequirementModel:
         self._all: List[dict] = []
         self._visible: List[dict] = []
         self._labels: List[str] = []
+        self._labels_match_all: bool = True
         self._query: str = ""
         self._fields: Sequence[str] | None = None
         self._sort_field: str | None = None
@@ -53,6 +54,10 @@ class RequirementModel:
         self._labels = labels
         self._refresh()
 
+    def set_label_match_all(self, match_all: bool) -> None:
+        self._labels_match_all = match_all
+        self._refresh()
+
     def set_search_query(self, query: str, fields: Sequence[str] | None = None) -> None:
         self._query = query
         self._fields = fields
@@ -71,6 +76,7 @@ class RequirementModel:
             labels=self._labels,
             query=self._query,
             fields=self._fields,
+            match_all=self._labels_match_all,
         )
         self._apply_sort()
 

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -56,6 +56,12 @@ def test_filter_by_labels():
     assert [r.id for r in filter_by_labels(reqs, ["ui", "auth"])] == [1]
 
 
+def test_filter_by_labels_any_mode():
+    reqs = sample_requirements()
+    ids = {r.id for r in filter_by_labels(reqs, ["auth", "backend"], match_all=False)}
+    assert ids == {1, 2}
+
+
 def test_filter_by_labels_empty_returns_all():
     reqs = sample_requirements()
     assert filter_by_labels(reqs, []) == reqs
@@ -83,6 +89,12 @@ def test_combined_search():
     reqs = sample_requirements()
     found = search(reqs, labels=["ui"], query="export", fields=["title"])
     assert [r.id for r in found] == [3]
+
+
+def test_search_match_any():
+    reqs = sample_requirements()
+    found = search(reqs, labels=["auth", "backend"], match_all=False)
+    assert {r.id for r in found} == {1, 2}
 
 
 def test_accepts_plain_dicts():


### PR DESCRIPTION
## Summary
- allow selecting labels and "match any" mode in list panel
- track label match mode in requirement model
- support any/all label filtering in core search
- test label filter UI and search helpers

## Testing
- `python3 -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c3f50c9a3c83208c956c60c6c53f6a