### PR TITLE
Validate label filter against project labels

### DIFF
--- a/app/ui/main_frame.py
+++ b/app/ui/main_frame.py
@@ -173,7 +173,9 @@ class MainFrame(wx.Frame):
             except Exception as exc:  # pragma: no cover - disk errors
                 logging.warning("Failed to save labels: %s", exc)
             self.panel.refresh()
-            self.editor.update_labels_list([lbl.name for lbl in self.labels])
+            names = [lbl.name for lbl in self.labels]
+            self.editor.update_labels_list(names)
+            self.panel.update_labels_list(names)
         dlg.Destroy()
 
     def _load_directory(self, path: Path) -> None:
@@ -209,7 +211,9 @@ class MainFrame(wx.Frame):
             store.save_labels(self.current_dir, self.labels)
         except Exception as exc:
             logging.warning("Failed to save labels: %s", exc)
-        self.editor.update_labels_list([lbl.name for lbl in self.labels])
+        names = [lbl.name for lbl in self.labels]
+        self.editor.update_labels_list(names)
+        self.panel.update_labels_list(names)
 
     # recent directories -------------------------------------------------
     def _load_recent_dirs(self) -> list[str]:

--- a/tests/test_labels_dialog.py
+++ b/tests/test_labels_dialog.py
@@ -92,6 +92,10 @@ def test_main_frame_manage_labels_saves(monkeypatch, tmp_path):
 
     monkeypatch.setattr(main_frame_mod, "LabelsDialog", DummyLabelsDialog)
 
+    captured: list[tuple[str, list[str]]] = []
+    frame.editor.update_labels_list = lambda labels: captured.append(("editor", labels))
+    frame.panel.update_labels_list = lambda labels: captured.append(("panel", labels))
+
     evt = wx.CommandEvent(wx.EVT_MENU.typeId, frame.manage_labels_id)
     frame.ProcessEvent(evt)
 
@@ -99,6 +103,8 @@ def test_main_frame_manage_labels_saves(monkeypatch, tmp_path):
 
     labels = store.load_labels(tmp_path)
     assert labels[0].color == "#123456"
+    assert ("editor", ["ui"]) in captured
+    assert ("panel", ["ui"]) in captured
 
     frame.Destroy()
     app.Destroy()


### PR DESCRIPTION
## Summary
- Deduplicate and validate labels entered in ListPanel
- Sync label filter options with global project label list
- Cover label validation and sync with tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c3f6d985508320b924e22f7d1b1837