### PR TITLE
Generate localization maps from enums

### DIFF
--- a/app/ui/locale.py
+++ b/app/ui/locale.py
@@ -1,34 +1,24 @@
 """Localization helpers for enumerated fields using gettext."""
 
 from gettext import gettext as _
+from enum import Enum
 
-# English labels for enum values
-TYPE = {
-    "requirement": "Requirement",
-    "constraint": "Constraint",
-    "interface": "Interface",
-}
+from app.core.model import RequirementType, Status, Priority, Verification
 
-STATUS = {
-    "draft": "Draft",
-    "in_review": "In review",
-    "approved": "Approved",
-    "baselined": "Baselined",
-    "retired": "Retired",
-}
 
-PRIORITY = {
-    "low": "Low",
-    "medium": "Medium",
-    "high": "High",
-}
+def _enum_label(e: Enum) -> str:
+    """Convert enum member name to human-readable English label."""
+    return e.name.replace("_", " ").lower().capitalize()
 
-VERIFICATION = {
-    "inspection": "Inspection",
-    "analysis": "Analysis",
-    "demonstration": "Demonstration",
-    "test": "Test",
-}
+
+# English labels generated from enum values
+TYPE = {e.value: _(_enum_label(e)) for e in RequirementType}
+
+STATUS = {e.value: _(_enum_label(e)) for e in Status}
+
+PRIORITY = {e.value: _(_enum_label(e)) for e in Priority}
+
+VERIFICATION = {e.value: _(_enum_label(e)) for e in Verification}
 
 EN_LABELS = {
     "type": TYPE,

--- a/tests/test_locale.py
+++ b/tests/test_locale.py
@@ -1,4 +1,8 @@
+import pytest
+from gettext import gettext as _
+
 from app.ui import locale
+from app.core import model
 
 
 def test_round_trip():
@@ -11,3 +15,21 @@ def test_round_trip():
 def test_unknown_values_return_input():
     assert locale.code_to_label('type', 'unknown') == 'unknown'
     assert locale.label_to_code('type', 'Unknown') == 'Unknown'
+
+
+def _enum_label(e):
+    return e.name.replace('_', ' ').lower().capitalize()
+
+
+@pytest.mark.parametrize(
+    'enum_cls,mapping',
+    [
+        (model.RequirementType, locale.TYPE),
+        (model.Status, locale.STATUS),
+        (model.Priority, locale.PRIORITY),
+        (model.Verification, locale.VERIFICATION),
+    ],
+)
+def test_localizations_match_enums(enum_cls, mapping):
+    expected = {e.value: _(_enum_label(e)) for e in enum_cls}
+    assert mapping == expected


### PR DESCRIPTION
## Summary
- derive localization dictionaries from RequirementType, Status, Priority and Verification enums
- add tests ensuring localization maps mirror the enum definitions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c408a4a7bc8320b6ec69fc6bda2c40