### PR TITLE
feat: cache requirement ids and update on changes

### DIFF
--- a/app/core/validate.py
+++ b/app/core/validate.py
@@ -21,5 +21,6 @@ def validate(data: dict, existing_ids: Iterable[int] = ()) -> None:
         Iterable of identifiers already present in the store.
     """
     validate_schema(data)
-    if data["id"] in set(existing_ids):
+    ids = existing_ids if isinstance(existing_ids, set) else set(existing_ids)
+    if data["id"] in ids:
         raise ValidationError(f"duplicate id: {data['id']}")

--- a/app/ui/main_frame.py
+++ b/app/ui/main_frame.py
@@ -183,14 +183,17 @@ class MainFrame(wx.Frame):
         self._add_recent_dir(path)
         self.SetTitle(f"{self._base_title} - {path}")
         self.current_dir = path
+        self.editor.set_directory(self.current_dir)
         self.labels = store.load_labels(self.current_dir)
         items: list[dict] = []
+        store.clear_index(self.current_dir)
         for fp in self.current_dir.glob("*.json"):
             if fp.name == store.LABELS_FILENAME:
                 continue
             try:
                 data, _ = store.load(fp)
                 items.append(data)
+                store.add_to_index(self.current_dir, data.get("id"))
             except Exception as exc:
                 logging.warning("Failed to load %s: %s", fp, exc)
                 continue
@@ -405,7 +408,7 @@ class MainFrame(wx.Frame):
             return
         self.model.delete(req_id)
         try:
-            (self.current_dir / store.filename_for(req["id"])).unlink()
+            store.delete(self.current_dir, req["id"])
         except Exception:
             pass
         self.panel.refresh()

--- a/tests/test_editor_panel_gui.py
+++ b/tests/test_editor_panel_gui.py
@@ -49,6 +49,38 @@ def test_editor_add_attachment_included():
     assert data["attachments"] == [{"path": "file.txt", "note": "note"}]
 
 
+def test_id_field_highlight_on_duplicate(tmp_path):
+    wx = pytest.importorskip("wx")
+    from app.core import store
+
+    existing = {
+        "id": 1,
+        "title": "T",
+        "statement": "S",
+        "type": "requirement",
+        "status": "draft",
+        "owner": "u",
+        "priority": "medium",
+        "source": "s",
+        "verification": "analysis",
+        "revision": 1,
+    }
+    store.save(tmp_path, existing)
+
+    panel = _make_panel()
+    panel.set_directory(tmp_path)
+    panel.new_requirement()
+    default = panel.fields["id"].GetBackgroundColour()
+
+    panel.fields["id"].SetValue("1")
+    wx.Yield()
+    assert panel.fields["id"].GetBackgroundColour() != default
+
+    panel.fields["id"].SetValue("2")
+    wx.Yield()
+    assert panel.fields["id"].GetBackgroundColour() == default
+
+
 def test_editor_load_populates_fields(tmp_path):
     panel = _make_panel()
     data = {


### PR DESCRIPTION
## Summary
- cache requirement IDs per directory and update cache on save or delete
- update validation to work with cached IDs
- add tests for large stores and cache updates
- highlight ID field in editor when identifier is already used

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c40b2670108320aa0e368ac31b08cf