### PR TITLE
Skip labels.json when listing requirements

### DIFF
--- a/app/cli.py
+++ b/app/cli.py
@@ -15,6 +15,8 @@ def _load_all(directory: str | Path) -> list[model.Requirement]:
     """Load all requirements from *directory*."""
     reqs: list[model.Requirement] = []
     for path in Path(directory).glob("*.json"):
+        if path.name == store.LABELS_FILENAME:
+            continue
         data, _ = store.load(path)
         reqs.append(model.Requirement(**data))
     return reqs


### PR DESCRIPTION
## Summary
- ignore labels.json in CLI `_load_all` to avoid parsing label metadata as requirements

## Testing
- `python3 -m pytest`
- `python3 -m app.cli list /tmp/reqdir`


------
https://chatgpt.com/codex/tasks/task_e_68c4060d4fe88320831975a2627e99dc