### PR TITLE
Use named logger and prevent duplicate Wx handlers

### DIFF
--- a/app/cli.py
+++ b/app/cli.py
@@ -5,10 +5,10 @@ from gettext import gettext as _
 
 import argparse
 import json
-import logging
 from pathlib import Path
 
 from .core import store, search, model
+from .log import configure_logging
 
 
 def _load_all(directory: str | Path) -> list[model.Requirement]:
@@ -89,7 +89,7 @@ def build_parser() -> argparse.ArgumentParser:
 
 
 def main(argv: list[str] | None = None) -> int:
-    logging.basicConfig(level=logging.INFO)
+    configure_logging()
     parser = build_parser()
     args = parser.parse_args(argv)
     args.func(args)

--- a/app/core/store.py
+++ b/app/core/store.py
@@ -3,8 +3,9 @@ from __future__ import annotations
 
 from dataclasses import asdict, is_dataclass
 import json
-import logging
 from pathlib import Path
+
+from app.log import logger
 
 from .validate import validate
 from .labels import Label
@@ -43,7 +44,7 @@ def _scan_ids(directory: Path) -> set[int]:
             with fp.open("r", encoding="utf-8") as fh:
                 ids.add(json.load(fh)["id"])
         except Exception as exc:
-            logging.warning("Failed to read %s: %s", fp, exc)
+            logger.warning("Failed to read %s: %s", fp, exc)
             continue
     return ids
 

--- a/app/log.py
+++ b/app/log.py
@@ -1,0 +1,13 @@
+import logging
+
+logger = logging.getLogger("cookareq")
+
+def configure_logging(level: int = logging.INFO) -> None:
+    """Configure application logger once."""
+    if logger.handlers:
+        return
+    handler = logging.StreamHandler()
+    handler.setFormatter(logging.Formatter("%(levelname)s: %(message)s"))
+    logger.addHandler(handler)
+    logger.setLevel(level)
+

--- a/app/main.py
+++ b/app/main.py
@@ -1,11 +1,11 @@
 """Application entry point for CookaReq."""
 
-import logging
 import os
 import gettext
 import wx
 
 from .ui.main_frame import MainFrame
+from .log import configure_logging
 
 
 APP_NAME = "CookaReq"
@@ -25,7 +25,7 @@ def init_locale() -> wx.Locale:
 
 def main() -> None:
     """Run wx application with the main frame."""
-    logging.basicConfig(level=logging.INFO)
+    configure_logging()
     app = wx.App()
     app.locale = init_locale()
     frame = MainFrame(parent=None)

--- a/tests/test_main_frame_gui.py
+++ b/tests/test_main_frame_gui.py
@@ -1,5 +1,6 @@
 import importlib
 import pytest
+import logging
 
 
 def test_main_frame_open_folder(monkeypatch, tmp_path):
@@ -76,6 +77,40 @@ def test_main_frame_open_folder_toolbar(monkeypatch, tmp_path):
     assert isinstance(frame.panel, list_panel.ListPanel)
 
     frame.Destroy()
+    app.Destroy()
+
+
+def test_log_handler_not_duplicated(tmp_path):
+    wx = pytest.importorskip("wx")
+    app = wx.App()
+
+    import app.ui.main_frame as main_frame
+
+    logger = logging.getLogger("cookareq")
+    for h in list(logger.handlers):
+        if isinstance(h, main_frame.WxLogHandler):
+            logger.removeHandler(h)
+
+    frame1 = main_frame.MainFrame(None)
+    assert (
+        sum(isinstance(h, main_frame.WxLogHandler) for h in logger.handlers) == 1
+    )
+    frame1.Close()
+    app.Yield()
+    assert (
+        sum(isinstance(h, main_frame.WxLogHandler) for h in logger.handlers) == 0
+    )
+
+    frame2 = main_frame.MainFrame(None)
+    assert (
+        sum(isinstance(h, main_frame.WxLogHandler) for h in logger.handlers) == 1
+    )
+    frame2.Close()
+    app.Yield()
+    assert (
+        sum(isinstance(h, main_frame.WxLogHandler) for h in logger.handlers) == 0
+    )
+
     app.Destroy()
 
 


### PR DESCRIPTION
## Summary
- introduce shared `cookareq` logger with configuration helper
- attach GUI log console to named logger without duplicates
- ensure CLI and GUI configure logging consistently
- add regression test for duplicate GUI log handlers

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c411aafb3c8320ad51cbcb67a26b74