### PR TITLE
Refactor requirements flow to use dataclasses

### DIFF
--- a/app/core/model.py
+++ b/app/core/model.py
@@ -1,9 +1,9 @@
 """Domain models for requirements."""
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, asdict
 from enum import Enum
-from typing import List, Optional
+from typing import List, Optional, Any
 
 
 class RequirementType(str, Enum):
@@ -69,3 +69,50 @@ class Requirement:
     revision: int = 1
     approved_at: Optional[str] = None
     notes: str = ""
+
+
+def requirement_from_dict(data: dict[str, Any]) -> Requirement:
+    """Create :class:`Requirement` instance from a plain ``dict``.
+
+    Nested ``attachments`` and ``units`` structures are converted into their
+    respective dataclasses. Missing optional fields fall back to sensible
+    defaults.
+    """
+    units_data = data.get("units")
+    units = Units(**units_data) if units_data else None
+    attachments = [Attachment(**a) for a in data.get("attachments", [])]
+    return Requirement(
+        id=data["id"],
+        title=data.get("title", ""),
+        statement=data.get("statement", ""),
+        type=RequirementType(data.get("type")),
+        status=Status(data.get("status")),
+        owner=data.get("owner", ""),
+        priority=Priority(data.get("priority")),
+        source=data.get("source", ""),
+        verification=Verification(data.get("verification")),
+        acceptance=data.get("acceptance"),
+        conditions=data.get("conditions", ""),
+        trace_up=data.get("trace_up", ""),
+        trace_down=data.get("trace_down", ""),
+        version=data.get("version", ""),
+        modified_at=data.get("modified_at", ""),
+        units=units,
+        labels=list(data.get("labels", [])),
+        attachments=attachments,
+        revision=data.get("revision", 1),
+        approved_at=data.get("approved_at"),
+        notes=data.get("notes", ""),
+    )
+
+
+def requirement_to_dict(req: Requirement) -> dict[str, Any]:
+    """Convert ``req`` into a plain ``dict`` suitable for JSON storage."""
+    data = asdict(req)
+    for key in ("type", "status", "priority", "verification"):
+        value = data.get(key)
+        if isinstance(value, Enum):
+            data[key] = value.value
+    data = {k: v for k, v in data.items() if v is not None}
+    return data
+

--- a/app/core/store.py
+++ b/app/core/store.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 from .validate import validate
 from .labels import Label
+from .model import requirement_to_dict
 
 LABELS_FILENAME = "labels.json"
 
@@ -97,7 +98,7 @@ def save(
     directory.mkdir(parents=True, exist_ok=True)
 
     if is_dataclass(data):
-        data = asdict(data)
+        data = requirement_to_dict(data)
 
     filename = filename_for(data["id"])
     path = directory / filename

--- a/tests/test_editor_panel.py
+++ b/tests/test_editor_panel.py
@@ -1,6 +1,8 @@
 import os
 import pytest
 
+from app.core.model import RequirementType, Status, Priority, Verification
+
 
 def _make_panel():
     wx = pytest.importorskip("wx")
@@ -82,7 +84,7 @@ def test_get_data_requires_valid_id():
         panel.get_data()
     panel.fields["id"].SetValue("10")
     data = panel.get_data()
-    assert data["id"] == 10
+    assert data.id == 10
 
 
 def test_enum_localization_roundtrip():
@@ -93,10 +95,10 @@ def test_enum_localization_roundtrip():
     panel.new_requirement()
     panel.fields["id"].SetValue("1")
     data = panel.get_data()
-    assert data["type"] == "requirement"
-    assert data["status"] == "draft"
-    assert data["priority"] == "medium"
-    assert data["verification"] == "analysis"
+    assert data.type == RequirementType.REQUIREMENT
+    assert data.status == Status.DRAFT
+    assert data.priority == Priority.MEDIUM
+    assert data.verification == Verification.ANALYSIS
 
     panel.load(
         {
@@ -119,10 +121,10 @@ def test_enum_localization_roundtrip():
     panel.enums["priority"].SetStringSelection(locale.PRIORITY["low"])
     panel.enums["verification"].SetStringSelection(locale.VERIFICATION["demonstration"])
     data = panel.get_data()
-    assert data["type"] == "interface"
-    assert data["status"] == "baselined"
-    assert data["priority"] == "low"
-    assert data["verification"] == "demonstration"
+    assert data.type == RequirementType.INTERFACE
+    assert data.status == Status.BASELINED
+    assert data.priority == Priority.LOW
+    assert data.verification == Verification.DEMONSTRATION
 
 
 def test_labels_selection_and_update():
@@ -133,7 +135,7 @@ def test_labels_selection_and_update():
     # select one label
     panel.labels_list.Check(1, True)
     data = panel.get_data()
-    assert data["labels"] == ["backend"]
+    assert data.labels == ["backend"]
     # load with different label
     panel.load({"id": 1, "labels": ["ui"]})
     assert panel.labels_list.IsChecked(0)

--- a/tests/test_editor_panel_gui.py
+++ b/tests/test_editor_panel_gui.py
@@ -1,4 +1,7 @@
 import pytest
+from dataclasses import asdict
+
+from app.core.model import RequirementType, Status, Priority, Verification
 
 
 def _make_panel():
@@ -27,17 +30,17 @@ def test_editor_new_requirement_resets(tmp_path):
     assert all(ctrl.GetValue() == "" for ctrl in panel.fields.values())
     panel.fields["id"].SetValue("1")
     defaults = panel.get_data()
-    assert defaults["type"] == "requirement"
-    assert defaults["status"] == "draft"
-    assert defaults["priority"] == "medium"
-    assert defaults["verification"] == "analysis"
+    assert defaults.type == RequirementType.REQUIREMENT
+    assert defaults.status == Status.DRAFT
+    assert defaults.priority == Priority.MEDIUM
+    assert defaults.verification == Verification.ANALYSIS
     assert panel.attachments == []
     assert panel.current_path is None
     assert panel.mtime is None
-    assert defaults["labels"] == []
-    assert defaults["revision"] == 1
-    assert defaults["approved_at"] is None
-    assert defaults["notes"] == ""
+    assert defaults.labels == []
+    assert defaults.revision == 1
+    assert defaults.approved_at is None
+    assert defaults.notes == ""
 
 
 def test_editor_add_attachment_included():
@@ -46,7 +49,7 @@ def test_editor_add_attachment_included():
     panel.add_attachment("file.txt", "note")
     panel.fields["id"].SetValue("1")
     data = panel.get_data()
-    assert data["attachments"] == [{"path": "file.txt", "note": "note"}]
+    assert [asdict(a) for a in data.attachments] == [{"path": "file.txt", "note": "note"}]
 
 
 def test_id_field_highlight_on_duplicate(tmp_path):
@@ -105,24 +108,21 @@ def test_editor_load_populates_fields(tmp_path):
     panel.load(data, path=path, mtime=42.0)
 
     result = panel.get_data()
-    for key in (
-        "id",
-        "title",
-        "statement",
-        "acceptance",
-        "owner",
-        "source",
-        "type",
-        "status",
-        "priority",
-        "verification",
-        "labels",
-        "attachments",
-        "revision",
-        "approved_at",
-        "notes",
-    ):
-        assert result[key] == data[key]
+    assert result.id == data["id"]
+    assert result.title == data["title"]
+    assert result.statement == data["statement"]
+    assert result.acceptance == data["acceptance"]
+    assert result.owner == data["owner"]
+    assert result.source == data["source"]
+    assert result.type.value == data["type"]
+    assert result.status.value == data["status"]
+    assert result.priority.value == data["priority"]
+    assert result.verification.value == data["verification"]
+    assert result.labels == data["labels"]
+    assert [asdict(a) for a in result.attachments] == data["attachments"]
+    assert result.revision == data["revision"]
+    assert result.approved_at == data["approved_at"]
+    assert result.notes == data["notes"]
     assert panel.current_path == path
     assert panel.mtime == 42.0
 

--- a/tests/test_main_frame_gui.py
+++ b/tests/test_main_frame_gui.py
@@ -242,7 +242,7 @@ def test_main_frame_clone_requirement_creates_copy(monkeypatch, tmp_path):
 
     wx, app, frame = _prepare_frame(monkeypatch, tmp_path)
 
-    frame.on_clone_requirement(frame.model.get_all()[0]["id"])
+    frame.on_clone_requirement(frame.model.get_all()[0].id)
 
     assert frame.editor.IsShown()
     new_id = frame.editor.fields["id"].GetValue()
@@ -263,7 +263,7 @@ def test_main_frame_new_requirement_button(monkeypatch, tmp_path):
 
     assert frame.editor.IsShown()
     assert frame.model.get_all()
-    assert frame.editor.fields["id"].GetValue() == str(frame.model.get_all()[0]["id"])
+    assert frame.editor.fields["id"].GetValue() == str(frame.model.get_all()[0].id)
 
     frame.Destroy()
     app.Destroy()
@@ -280,7 +280,7 @@ def test_main_frame_delete_requirement_removes_file(monkeypatch, tmp_path):
     assert path.exists()
     assert frame.panel.list.GetItemCount() == 1
 
-    frame.on_delete_requirement(frame.model.get_all()[0]["id"])
+    frame.on_delete_requirement(frame.model.get_all()[0].id)
 
     assert frame.panel.list.GetItemCount() == 0
     assert not path.exists()

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -97,10 +97,3 @@ def test_search_match_any():
     assert {r.id for r in found} == {1, 2}
 
 
-def test_accepts_plain_dicts():
-    reqs = [
-        {"id": 1, "title": "Login", "labels": ["ui"]},
-        {"id": 2, "title": "Export", "labels": ["report"]},
-    ]
-    found = search(reqs, labels=["ui"], query="login", fields=["title"])
-    assert [r["id"] for r in found] == [1]


### PR DESCRIPTION
## Summary
- Use typed `Requirement` dataclasses throughout the UI and model layers
- Convert to/from dicts at I/O boundaries and update sorting, search and panels
- Adjust tests for the new typed data

## Testing
- `python3 -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c411b5ccac83208ab9069b094ba369