### PR TITLE
Add language selection to settings

### DIFF
--- a/app/locale/ru/LC_MESSAGES/CookaReq.po
+++ b/app/locale/ru/LC_MESSAGES/CookaReq.po
@@ -228,6 +228,9 @@ msgstr "Открывать последнюю папку при запуске"
 msgid "Remember sort order"
 msgstr "Запоминать порядок сортировки"
 
+msgid "Language"
+msgstr "Язык"
+
 # CLI strings
 msgid "CookaReq CLI"
 msgstr "CookaReq CLI"

--- a/app/main.py
+++ b/app/main.py
@@ -12,14 +12,22 @@ APP_NAME = "CookaReq"
 LOCALE_DIR = os.path.join(os.path.dirname(__file__), "locale")
 
 
-def init_locale() -> wx.Locale:
+def init_locale(language: str | None = None) -> wx.Locale:
     """Initialize wx and gettext locales."""
     wx.Locale.AddCatalogLookupPathPrefix(LOCALE_DIR)
-    locale = wx.Locale(wx.LANGUAGE_DEFAULT)
+    if language:
+        info = wx.Locale.FindLanguageInfo(language)
+        if info:
+            locale = wx.Locale(info.Language)
+        else:  # fallback to system default if code is unknown
+            locale = wx.Locale(wx.LANGUAGE_DEFAULT)
+    else:
+        locale = wx.Locale(wx.LANGUAGE_DEFAULT)
     locale.AddCatalog(APP_NAME)
     gettext.bindtextdomain(APP_NAME, LOCALE_DIR)
     gettext.textdomain(APP_NAME)
-    gettext.install(APP_NAME, LOCALE_DIR)
+    codes = [language] if language else None
+    gettext.translation(APP_NAME, LOCALE_DIR, languages=codes, fallback=True).install()
     return locale
 
 
@@ -27,7 +35,9 @@ def main() -> None:
     """Run wx application with the main frame."""
     configure_logging()
     app = wx.App()
-    app.locale = init_locale()
+    config = wx.Config(appName=APP_NAME)
+    language = config.Read("language") or None
+    app.locale = init_locale(language)
     frame = MainFrame(parent=None)
     frame.Show()
     app.MainLoop()

--- a/app/ui/main_frame.py
+++ b/app/ui/main_frame.py
@@ -54,6 +54,7 @@ class MainFrame(wx.Frame):
         self._recent_items: Dict[int, Path] = {}
         self.auto_open_last = self.config.ReadBool("auto_open_last", False)
         self.remember_sort = self.config.ReadBool("remember_sort", False)
+        self.language = self.config.Read("language")
         self.sort_column = self.config.ReadInt("sort_column", -1)
         self.sort_ascending = self.config.ReadBool("sort_ascending", True)
         self.labels: list[Label] = []
@@ -157,11 +158,13 @@ class MainFrame(wx.Frame):
             self,
             open_last=self.auto_open_last,
             remember_sort=self.remember_sort,
+            language=self.language,
         )
         if dlg.ShowModal() == wx.ID_OK:
-            self.auto_open_last, self.remember_sort = dlg.get_values()
+            self.auto_open_last, self.remember_sort, self.language = dlg.get_values()
             self.config.WriteBool("auto_open_last", self.auto_open_last)
             self.config.WriteBool("remember_sort", self.remember_sort)
+            self.config.Write("language", self.language)
             self.config.Flush()
         dlg.Destroy()
 

--- a/app/ui/settings_dialog.py
+++ b/app/ui/settings_dialog.py
@@ -1,28 +1,63 @@
 """Dialog for application settings."""
 
 from gettext import gettext as _
+from importlib import resources
 
 import wx
+
+
+def available_translations() -> list[tuple[str, str]]:
+    """Return list of (language_code, display_name) for available translations."""
+    langs: list[tuple[str, str]] = []
+    locale_root = resources.files("app") / "locale"
+    for entry in locale_root.iterdir():
+        if entry.is_dir():
+            code = entry.name
+            info = wx.Locale.FindLanguageInfo(code)
+            name = info.Description if info else code
+            langs.append((code, name))
+    return langs
 
 
 class SettingsDialog(wx.Dialog):
     """Simple dialog with application preferences."""
 
-    def __init__(self, parent: wx.Window, *, open_last: bool, remember_sort: bool):
+    def __init__(
+        self,
+        parent: wx.Window,
+        *,
+        open_last: bool,
+        remember_sort: bool,
+        language: str,
+    ) -> None:
         super().__init__(parent, title=_("Settings"))
         self._open_last = wx.CheckBox(self, label=_("Open last folder on startup"))
         self._open_last.SetValue(open_last)
         self._remember_sort = wx.CheckBox(self, label=_("Remember sort order"))
         self._remember_sort.SetValue(remember_sort)
 
+        self._languages = available_translations()
+        choices = [name for _, name in self._languages]
+        self._language_choice = wx.Choice(self, choices=choices)
+        try:
+            idx = [code for code, _ in self._languages].index(language)
+        except ValueError:
+            idx = 0
+        self._language_choice.SetSelection(idx)
+
         sizer = wx.BoxSizer(wx.VERTICAL)
         sizer.Add(self._open_last, 0, wx.ALL, 5)
         sizer.Add(self._remember_sort, 0, wx.ALL, 5)
+        lang_sizer = wx.BoxSizer(wx.HORIZONTAL)
+        lang_sizer.Add(wx.StaticText(self, label=_("Language")), 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, 5)
+        lang_sizer.Add(self._language_choice, 1, wx.ALIGN_CENTER_VERTICAL)
+        sizer.Add(lang_sizer, 0, wx.ALL | wx.EXPAND, 5)
         btn_sizer = self.CreateStdDialogButtonSizer(wx.OK | wx.CANCEL)
         if btn_sizer:
             sizer.Add(btn_sizer, 0, wx.ALIGN_CENTER | wx.ALL, 5)
         self.SetSizerAndFit(sizer)
 
-    def get_values(self) -> tuple[bool, bool]:
-        """Return (open_last_folder, remember_sort)."""
-        return self._open_last.GetValue(), self._remember_sort.GetValue()
+    def get_values(self) -> tuple[bool, bool, str]:
+        """Return (open_last_folder, remember_sort, language_code)."""
+        lang_code = self._languages[self._language_choice.GetSelection()][0]
+        return self._open_last.GetValue(), self._remember_sort.GetValue(), lang_code

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -17,12 +17,19 @@ def test_main_runs(monkeypatch):
         def AddCatalog(self, name):
             pass
 
+    class DummyConfig:
+        def __init__(self, appName):
+            self.appName = appName
+        def Read(self, key):
+            return ""
+
     def add_prefix(path):
         return None
 
     wx_stub = types.SimpleNamespace(
         App=lambda: dummy_app,
         Locale=DummyLocale,
+        Config=DummyConfig,
         LANGUAGE_DEFAULT=0,
     )
     wx_stub.Locale.AddCatalogLookupPathPrefix = add_prefix

--- a/tests/test_settings_dialog.py
+++ b/tests/test_settings_dialog.py
@@ -1,0 +1,22 @@
+import pytest
+
+
+def test_available_translations_contains_locales():
+    wx = pytest.importorskip("wx")
+    from app.ui.settings_dialog import available_translations
+
+    langs = available_translations()
+    codes = {code for code, _ in langs}
+    # english is default, russian is provided in repo
+    assert {"en", "ru"}.issubset(codes)
+
+
+def test_settings_dialog_returns_language():
+    wx = pytest.importorskip("wx")
+    _app = wx.App()
+    from app.ui.settings_dialog import SettingsDialog
+
+    dlg = SettingsDialog(None, open_last=True, remember_sort=False, language="ru")
+    values = dlg.get_values()
+    assert values == (True, False, "ru")
+    dlg.Destroy()


### PR DESCRIPTION
## Summary
- add language dropdown in settings populated from translation directories
- store selected language in config and use on startup
- cover language selection with tests

## Testing
- `python3 compile_translations.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c415c7b7f8832097abca45966d150a