### PR TITLE
Fix crash on empty label filter

### DIFF
--- a/app/ui/list_panel.py
+++ b/app/ui/list_panel.py
@@ -35,7 +35,7 @@ class ListPanel(wx.Panel, ColumnSorterMixin):
         self.model = model if model is not None else RequirementModel()
         sizer = wx.BoxSizer(wx.VERTICAL)
         self.search = wx.SearchCtrl(self)
-        self.labels = wx.ComboCtrl(self)
+        self.labels = wx.TextCtrl(self)
         self._label_choices: list[str] = []
         self._ignore_label_event = False
         self.match_any = wx.CheckBox(self, label=_("Match any labels"))

--- a/tests/test_list_panel.py
+++ b/tests/test_list_panel.py
@@ -37,6 +37,9 @@ def _build_wx_stub():
         def GetValue(self):
             return self._value
 
+    class TextCtrl(SearchCtrl):
+        pass
+
     class ComboCtrl(SearchCtrl):
         pass
 
@@ -102,6 +105,7 @@ def _build_wx_stub():
     wx_mod = types.SimpleNamespace(
         Panel=Panel,
         SearchCtrl=SearchCtrl,
+        TextCtrl=TextCtrl,
         ComboCtrl=ComboCtrl,
         CheckBox=CheckBox,
         ListCtrl=ListCtrl,
@@ -164,7 +168,7 @@ def test_list_panel_has_search_and_list(monkeypatch):
     panel = ListPanel(frame, model=RequirementModel())
 
     assert isinstance(panel.search, wx_stub.SearchCtrl)
-    assert isinstance(panel.labels, wx_stub.ComboCtrl)
+    assert isinstance(panel.labels, wx_stub.TextCtrl)
     assert isinstance(panel.match_any, wx_stub.CheckBox)
     assert isinstance(panel.list, wx_stub.ListCtrl)
     assert panel.search.GetParent() is panel


### PR DESCRIPTION
## Summary
- replace ComboCtrl with TextCtrl for label filter
- update list panel tests for new widget

## Testing
- `python3 -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c4163a84348320ba5d868fa99382b1