### PR TITLE
Expand label management

### DIFF
--- a/app/core/labels.py
+++ b/app/core/labels.py
@@ -1,8 +1,9 @@
-"""Label definitions and in-memory CRUD helpers."""
+"""Label definitions, preset sets and in-memory CRUD helpers."""
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import List
+from hashlib import sha1
+from typing import Dict, List
 
 
 @dataclass(slots=True)
@@ -11,6 +12,70 @@ class Label:
 
     name: str
     color: str
+
+
+def _color_from_name(name: str) -> str:
+    """Generate a stable pastel color from ``name``."""
+    digest = sha1(name.encode("utf-8")).hexdigest()
+    r = (int(digest[0:2], 16) + 0xAA) // 2
+    g = (int(digest[2:4], 16) + 0xAA) // 2
+    b = (int(digest[4:6], 16) + 0xAA) // 2
+    return f"#{r:02x}{g:02x}{b:02x}"
+
+
+def _preset(names: List[str]) -> List[Label]:
+    return [Label(n, _color_from_name(n)) for n in names]
+
+
+PRESET_SETS: Dict[str, List[Label]] = {
+    "basic": _preset([
+        "functional",
+        "non-functional",
+        "ui",
+        "performance",
+        "reliability",
+        "safety",
+        "security",
+        "usability",
+        "constraint",
+        "regulatory",
+    ]),
+    "role": _preset([
+        "system",
+        "software",
+        "hardware",
+        "integration",
+        "test",
+    ]),
+    "status": _preset([
+        "draft",
+        "approved",
+        "in-progress",
+        "implemented",
+        "verified",
+        "obsolete",
+    ]),
+    "priority": _preset([
+        "high",
+        "medium",
+        "low",
+    ]),
+    "additional": _preset([
+        "critical",
+        "derived",
+        "untested",
+        "suspect-link",
+        "attachments",
+    ]),
+}
+
+PRESET_SET_TITLES: Dict[str, str] = {
+    "basic": "Basic",
+    "role": "By role",
+    "status": "By status",
+    "priority": "By priority",
+    "additional": "Additional",
+}
 
 
 def add_label(labels: List[Label], label: Label) -> None:

--- a/tests/test_labels_dialog.py
+++ b/tests/test_labels_dialog.py
@@ -26,6 +26,51 @@ def test_labels_dialog_changes_color():
     app.Destroy()
 
 
+def test_labels_dialog_adds_presets():
+    wx = pytest.importorskip("wx")
+    app = wx.App()
+    from app.ui.labels_dialog import LabelsDialog
+    from app.core.labels import PRESET_SETS
+
+    dlg = LabelsDialog(None, [])
+    dlg._on_add_preset_set("basic")
+    labels = dlg.get_labels()
+    assert {l.name for l in labels} == {l.name for l in PRESET_SETS["basic"]}
+    # calling again should not duplicate
+    dlg._on_add_preset_set("basic")
+    assert len(dlg.get_labels()) == len(PRESET_SETS["basic"])
+    dlg.Destroy()
+    app.Destroy()
+
+
+def test_labels_dialog_deletes_selected():
+    wx = pytest.importorskip("wx")
+    app = wx.App()
+    from app.ui.labels_dialog import LabelsDialog
+
+    dlg = LabelsDialog(None, [Label("a", "#111111"), Label("b", "#222222"), Label("c", "#333333")])
+    dlg.list.SetItemState(0, wx.LIST_STATE_SELECTED, wx.LIST_STATE_SELECTED)
+    dlg.list.SetItemState(2, wx.LIST_STATE_SELECTED, wx.LIST_STATE_SELECTED)
+    dlg._on_delete_selected(None)
+    names = [l.name for l in dlg.get_labels()]
+    assert names == ["b"]
+    dlg.Destroy()
+    app.Destroy()
+
+
+def test_labels_dialog_clear_all(monkeypatch):
+    wx = pytest.importorskip("wx")
+    app = wx.App()
+    from app.ui.labels_dialog import LabelsDialog
+
+    dlg = LabelsDialog(None, [Label("a", "#111111")])
+    monkeypatch.setattr(wx, "MessageBox", lambda *a, **k: wx.YES)
+    dlg._on_clear_all(None)
+    assert dlg.get_labels() == []
+    dlg.Destroy()
+    app.Destroy()
+
+
 def _prepare_frame(monkeypatch, tmp_path):
     from app.core.store import save
 


### PR DESCRIPTION
## Summary
- translate requirement labels into multiple preset sets with auto-generated colors
- allow bulk deletion and clearing all labels with confirmation
- test preset sets and new label management actions

## Testing
- `python3 -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c41571a13c83209f68605adce8e521