### PR TITLE
feat: add requirement derivation model

### DIFF
--- a/app/core/model.py
+++ b/app/core/model.py
@@ -47,6 +47,25 @@ class Attachment:
 
 
 @dataclass
+class DerivationLink:
+    """Reference to a source requirement used for derivation."""
+
+    source_id: int
+    source_revision: int
+    suspect: bool = False
+
+
+@dataclass
+class DerivationInfo:
+    """Details describing how the requirement was derived."""
+
+    rationale: str
+    assumptions: List[str]
+    method: str
+    margin: str
+
+
+@dataclass
 class Requirement:
     id: int
     title: str
@@ -69,18 +88,23 @@ class Requirement:
     revision: int = 1
     approved_at: Optional[str] = None
     notes: str = ""
+    derived_from: List[DerivationLink] = field(default_factory=list)
+    derivation: Optional[DerivationInfo] = None
 
 
 def requirement_from_dict(data: dict[str, Any]) -> Requirement:
     """Create :class:`Requirement` instance from a plain ``dict``.
 
-    Nested ``attachments`` and ``units`` structures are converted into their
-    respective dataclasses. Missing optional fields fall back to sensible
-    defaults.
+    Nested ``attachments``, ``units`` and derivation structures are converted
+    into their respective dataclasses. Missing optional fields fall back to
+    sensible defaults.
     """
     units_data = data.get("units")
     units = Units(**units_data) if units_data else None
     attachments = [Attachment(**a) for a in data.get("attachments", [])]
+    derived_from = [DerivationLink(**d) for d in data.get("derived_from", [])]
+    derivation_data = data.get("derivation")
+    derivation = DerivationInfo(**derivation_data) if derivation_data else None
     return Requirement(
         id=data["id"],
         title=data.get("title", ""),
@@ -103,6 +127,8 @@ def requirement_from_dict(data: dict[str, Any]) -> Requirement:
         revision=data.get("revision", 1),
         approved_at=data.get("approved_at"),
         notes=data.get("notes", ""),
+        derived_from=derived_from,
+        derivation=derivation,
     )
 
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -4,6 +4,8 @@ from app.core.model import (
     RequirementType,
     Status,
     Verification,
+    requirement_from_dict,
+    requirement_to_dict,
 )
 
 
@@ -27,3 +29,35 @@ def test_requirement_defaults():
     assert req.trace_down == ""
     assert req.version == ""
     assert req.modified_at == ""
+    assert req.derived_from == []
+    assert req.derivation is None
+
+
+def test_requirement_derivation_conversion():
+    data = {
+        "id": 1,
+        "title": "Title",
+        "statement": "Statement",
+        "type": "requirement",
+        "status": "draft",
+        "owner": "user",
+        "priority": "medium",
+        "source": "spec",
+        "verification": "analysis",
+        "derived_from": [
+            {"source_id": 2, "source_revision": 3, "suspect": True}
+        ],
+        "derivation": {
+            "rationale": "r",
+            "assumptions": ["a1", "a2"],
+            "method": "m",
+            "margin": "10%",
+        },
+    }
+    req = requirement_from_dict(data)
+    assert req.derived_from[0].source_id == 2
+    assert req.derived_from[0].suspect is True
+    assert req.derivation.margin == "10%"
+    roundtrip = requirement_to_dict(req)
+    assert roundtrip["derived_from"][0]["source_revision"] == 3
+    assert roundtrip["derivation"]["assumptions"] == ["a1", "a2"]


### PR DESCRIPTION
## Summary
- add derivation dataclasses and fields to Requirement
- support nested derivation structures in requirement_from_dict and requirement_to_dict
- test round-trip conversion for new fields

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c418f606a88320a5b40d2913bee74f