### PR TITLE
Add derivation metadata and cross-reference validation

### DIFF
--- a/app/core/schema.py
+++ b/app/core/schema.py
@@ -59,6 +59,28 @@ SCHEMA: dict[str, Any] = {
                 },
             },
         },
+        "derived_from": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "required": ["source_id", "source_revision"],
+                "properties": {
+                    "source_id": {"type": "integer"},
+                    "source_revision": {"type": "integer"},
+                    "suspect": {"type": "boolean"},
+                },
+            },
+        },
+        "derivation": {
+            "type": "object",
+            "required": ["rationale", "assumptions", "method", "margin"],
+            "properties": {
+                "rationale": {"type": "string"},
+                "assumptions": {"type": "array", "items": {"type": "string"}},
+                "method": {"type": "string"},
+                "margin": {"type": "string"},
+            },
+        },
         "revision": {"type": "integer", "minimum": 1},
         "approved_at": {"type": ["string", "null"]},
         "notes": {"type": "string"},

--- a/app/core/store.py
+++ b/app/core/store.py
@@ -107,7 +107,7 @@ def save(
     ids = load_index(directory)
     existing_ids = set(ids)
     existing_ids.discard(data["id"])
-    validate(data, existing_ids=existing_ids)
+    validate(data, directory, existing_ids=existing_ids)
 
     if path.exists() and mtime is not None:
         current = path.stat().st_mtime

--- a/app/core/validate.py
+++ b/app/core/validate.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 """Additional business rules for requirements."""
 
-from typing import Iterable
+from pathlib import Path
 
 from .schema import validate as validate_schema
 
@@ -10,17 +10,46 @@ class ValidationError(Exception):
     """Raised when business rules are violated."""
 
 
-def validate(data: dict, existing_ids: Iterable[int] = ()) -> None:
+def validate(
+    data: dict,
+    directory: str | Path,
+    existing_ids: Iterable[int] | None = None,
+) -> None:
     """Validate *data* using schema and business rules.
 
     Parameters
     ----------
     data:
         Requirement data as dictionary.
+    directory:
+        Path to requirement storage used to resolve cross-references.
     existing_ids:
-        Iterable of identifiers already present in the store.
+        Optional set of identifiers already present (excluding ``data['id']``).
     """
+    from . import store  # local import to avoid circular dependency
+
     validate_schema(data)
-    ids = existing_ids if isinstance(existing_ids, set) else set(existing_ids)
+    directory = Path(directory)
+
+    all_ids = store.load_index(directory)
+    if existing_ids is None:
+        ids = set(all_ids)
+        ids.discard(data["id"])
+    else:
+        ids = existing_ids if isinstance(existing_ids, set) else set(existing_ids)
+
     if data["id"] in ids:
         raise ValidationError(f"duplicate id: {data['id']}")
+
+    for link in data.get("derived_from", []):
+        src_id = link.get("source_id")
+        if src_id == data["id"]:
+            raise ValidationError("derived_from references self")
+        if src_id not in all_ids:
+            raise ValidationError(f"missing source id: {src_id}")
+
+        src_path = directory / store.filename_for(src_id)
+        src_data, _ = store.load(src_path)
+        for back in src_data.get("derived_from", []):
+            if back.get("source_id") == data["id"]:
+                raise ValidationError(f"cyclic derivation via {src_id}")

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -34,3 +34,35 @@ def test_validate_rejects_bad_enum():
     data["type"] = "bad"
     with pytest.raises(ValueError):
         validate(data)
+
+
+def test_derived_from_and_derivation_valid():
+    data = make_valid()
+    data["derived_from"] = [
+        {"source_id": 2, "source_revision": 1, "suspect": True}
+    ]
+    data["derivation"] = {
+        "rationale": "r",
+        "assumptions": ["a"],
+        "method": "m",
+        "margin": "10%",
+    }
+    validate(data)
+
+
+def test_derived_from_missing_field():
+    data = make_valid()
+    data["derived_from"] = [{"source_id": 2}]
+    with pytest.raises(ValueError):
+        validate(data)
+
+
+def test_derivation_missing_field():
+    data = make_valid()
+    data["derivation"] = {
+        "rationale": "r",
+        "assumptions": ["a"],
+        "method": "m",
+    }
+    with pytest.raises(ValueError):
+        validate(data)

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -1,4 +1,7 @@
+import json
 import pytest
+
+from app.core.store import load_index
 from app.core.validate import ValidationError, validate
 
 
@@ -17,21 +20,62 @@ def make_valid() -> dict:
     }
 
 
-def test_duplicate_id():
+def write_req(directory, req_id, **extra):
+    req = make_valid()
+    req["id"] = req_id
+    req.update(extra)
+    (directory / f"{req_id}.json").write_text(json.dumps(req))
+
+
+def test_duplicate_id(tmp_path):
+    write_req(tmp_path, 1)
     data = make_valid()
+    existing_ids = set(load_index(tmp_path))
     with pytest.raises(ValidationError):
-        validate(data, existing_ids={1})
+        validate(data, tmp_path, existing_ids=existing_ids)
 
 
-def test_acceptance_optional_for_verification_methods():
+def test_acceptance_optional_for_verification_methods(tmp_path):
     data = make_valid()
     data["verification"] = "test"
     data.pop("acceptance", None)
-    validate(data)
+    validate(data, tmp_path)
 
 
-def test_acceptance_present_passes():
+def test_acceptance_present_passes(tmp_path):
     data = make_valid()
     data["verification"] = "test"
     data["acceptance"] = "TST-1"
-    validate(data)
+    validate(data, tmp_path)
+
+
+def test_self_reference(tmp_path):
+    data = make_valid()
+    data["derived_from"] = [{"source_id": 1, "source_revision": 1, "suspect": False}]
+    with pytest.raises(ValidationError):
+        validate(data, tmp_path)
+
+
+def test_missing_source_id(tmp_path):
+    data = make_valid()
+    data["id"] = 2
+    data["derived_from"] = [{"source_id": 1, "source_revision": 1, "suspect": False}]
+    with pytest.raises(ValidationError):
+        validate(data, tmp_path)
+
+
+def test_cycle_detection(tmp_path):
+    write_req(tmp_path, 1, derived_from=[{"source_id": 2, "source_revision": 1, "suspect": False}])
+    data = make_valid()
+    data["id"] = 2
+    data["derived_from"] = [{"source_id": 1, "source_revision": 1, "suspect": False}]
+    with pytest.raises(ValidationError):
+        validate(data, tmp_path)
+
+
+def test_valid_reference_passes(tmp_path):
+    write_req(tmp_path, 1)
+    data = make_valid()
+    data["id"] = 2
+    data["derived_from"] = [{"source_id": 1, "source_revision": 1, "suspect": False}]
+    validate(data, tmp_path)


### PR DESCRIPTION
## Summary
- expand requirement schema with `derived_from` and `derivation` structures
- validate derivation links, checking self-references, existence and simple cycles
- adjust store to supply existing IDs during validation

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c41a01e6c883209c72714f0a5cea0d