### PR TITLE
Add derived requirement search filters and UI controls

### DIFF
--- a/app/ui/list_panel.py
+++ b/app/ui/list_panel.py
@@ -39,6 +39,9 @@ class ListPanel(wx.Panel, ColumnSorterMixin):
         self._label_choices: list[str] = []
         self._ignore_label_event = False
         self.match_any = wx.CheckBox(self, label=_("Match any labels"))
+        self.is_derived = wx.CheckBox(self, label=_("Derived only"))
+        self.has_derived = wx.CheckBox(self, label=_("Has derived"))
+        self.suspect_only = wx.CheckBox(self, label=_("Suspect only"))
         # На Windows ``SearchCtrl`` рисует пустые белые квадраты вместо
         # иконок поиска/сброса, если битмапы не заданы. Загрузим стандартные
         # изображения через ``wx.ArtProvider`` и включим обе кнопки. Для
@@ -70,6 +73,9 @@ class ListPanel(wx.Panel, ColumnSorterMixin):
         sizer.Add(self.search, 0, wx.EXPAND | wx.ALL, 5)
         sizer.Add(self.labels, 0, wx.EXPAND | wx.ALL, 5)
         sizer.Add(self.match_any, 0, wx.ALL, 5)
+        sizer.Add(self.is_derived, 0, wx.ALL, 5)
+        sizer.Add(self.has_derived, 0, wx.ALL, 5)
+        sizer.Add(self.suspect_only, 0, wx.ALL, 5)
         sizer.Add(self.list, 1, wx.EXPAND | wx.ALL, 5)
         self.SetSizer(sizer)
         self.list.Bind(wx.EVT_LIST_ITEM_RIGHT_CLICK, self._on_right_click)
@@ -77,6 +83,9 @@ class ListPanel(wx.Panel, ColumnSorterMixin):
         self.search.Bind(wx.EVT_TEXT, self._on_search)
         self.labels.Bind(wx.EVT_TEXT, self._on_labels_changed)
         self.match_any.Bind(wx.EVT_CHECKBOX, self._on_match_any)
+        self.is_derived.Bind(wx.EVT_CHECKBOX, self._on_is_derived)
+        self.has_derived.Bind(wx.EVT_CHECKBOX, self._on_has_derived)
+        self.suspect_only.Bind(wx.EVT_CHECKBOX, self._on_suspect_only)
 
     # ColumnSorterMixin requirement
     def GetListCtrl(self):  # pragma: no cover - simple forwarding
@@ -221,6 +230,21 @@ class ListPanel(wx.Panel, ColumnSorterMixin):
 
     def _on_match_any(self, event):  # pragma: no cover - simple event binding
         self.model.set_label_match_all(not self.match_any.GetValue())
+        if hasattr(event, "Skip"):
+            event.Skip()
+
+    def _on_is_derived(self, event):  # pragma: no cover - simple event binding
+        self.model.set_is_derived(self.is_derived.GetValue())
+        if hasattr(event, "Skip"):
+            event.Skip()
+
+    def _on_has_derived(self, event):  # pragma: no cover - simple event binding
+        self.model.set_has_derived(self.has_derived.GetValue())
+        if hasattr(event, "Skip"):
+            event.Skip()
+
+    def _on_suspect_only(self, event):  # pragma: no cover - simple event binding
+        self.model.set_suspect_only(self.suspect_only.GetValue())
         if hasattr(event, "Skip"):
             event.Skip()
 

--- a/app/ui/requirement_model.py
+++ b/app/ui/requirement_model.py
@@ -18,6 +18,9 @@ class RequirementModel:
         self._labels_match_all: bool = True
         self._query: str = ""
         self._fields: Sequence[str] | None = None
+        self._is_derived: bool = False
+        self._has_derived: bool = False
+        self._suspect_only: bool = False
         self._sort_field: str | None = None
         self._sort_ascending: bool = True
 
@@ -65,6 +68,18 @@ class RequirementModel:
         self._fields = fields
         self._refresh()
 
+    def set_is_derived(self, value: bool) -> None:
+        self._is_derived = value
+        self._refresh()
+
+    def set_has_derived(self, value: bool) -> None:
+        self._has_derived = value
+        self._refresh()
+
+    def set_suspect_only(self, value: bool) -> None:
+        self._suspect_only = value
+        self._refresh()
+
     # sorting ---------------------------------------------------------
     def sort(self, field: str, ascending: bool = True) -> None:
         self._sort_field = field
@@ -79,6 +94,9 @@ class RequirementModel:
             query=self._query,
             fields=self._fields,
             match_all=self._labels_match_all,
+            is_derived=self._is_derived,
+            has_derived=self._has_derived,
+            suspect_only=self._suspect_only,
         )
         self._apply_sort()
 

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -4,8 +4,15 @@ from app.core.model import (
     RequirementType,
     Status,
     Verification,
+    DerivationLink,
 )
-from app.core.search import filter_by_labels, search, search_text
+from app.core.search import (
+    filter_by_labels,
+    filter_has_derived,
+    filter_is_derived,
+    search,
+    search_text,
+)
 
 
 def sample_requirements():
@@ -46,6 +53,7 @@ def sample_requirements():
             source="spec",
             verification=Verification.ANALYSIS,
             labels=["ui"],
+            derived_from=[DerivationLink(source_id=2, source_revision=1, suspect=True)],
         ),
     ]
 
@@ -95,5 +103,21 @@ def test_search_match_any():
     reqs = sample_requirements()
     found = search(reqs, labels=["auth", "backend"], match_all=False)
     assert {r.id for r in found} == {1, 2}
+
+
+def test_filter_is_and_has_derived():
+    reqs = sample_requirements()
+    assert [r.id for r in filter_is_derived(reqs)] == [3]
+    assert [r.id for r in filter_is_derived(reqs, suspect_only=True)] == [3]
+    assert [r.id for r in filter_has_derived(reqs, reqs)] == [2]
+    assert [r.id for r in filter_has_derived(reqs, reqs, suspect_only=True)] == [2]
+
+
+def test_search_with_derived_filters():
+    reqs = sample_requirements()
+    assert [r.id for r in search(reqs, is_derived=True)] == [3]
+    assert [r.id for r in search(reqs, has_derived=True)] == [2]
+    assert [r.id for r in search(reqs, is_derived=True, suspect_only=True)] == [3]
+    assert [r.id for r in search(reqs, has_derived=True, suspect_only=True)] == [2]
 
 


### PR DESCRIPTION
## Summary
- implement filters for derived and suspect links in core search
- wire derived filters into RequirementModel and ListPanel UI
- extend tests for search and list panel to cover new filters

## Testing
- `python3 -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c41f42b60883208888a5dc6bf813f6