### PR TITLE
Fix editor field layout and add failing test

### DIFF
--- a/app/ui/editor_panel.py
+++ b/app/ui/editor_panel.py
@@ -9,6 +9,7 @@ from gettext import gettext as _
 
 import wx
 from wx.lib.dialogs import ScrolledMessageDialog
+from wx.lib.scrolledpanel import ScrolledPanel
 
 from app.core import store
 from app.core.model import (
@@ -24,7 +25,7 @@ from app.core.model import (
 from . import locale
 
 
-class EditorPanel(wx.Panel):
+class EditorPanel(ScrolledPanel):
     """Panel for creating and editing requirements."""
 
     def __init__(
@@ -131,10 +132,11 @@ class EditorPanel(wx.Panel):
 
             style = wx.TE_MULTILINE if multiline else 0
             ctrl = wx.TextCtrl(self, style=style)
-            if name == "source":
-                ctrl.SetMinSize((-1, 60))
+            if multiline:
+                height = 60 if name == "source" else 80
+                ctrl.SetMinSize((-1, height))
             self.fields[name] = ctrl
-            proportion = 1 if multiline and name != "source" else 0
+            proportion = 1 if name == "statement" else 0
             sizer.Add(ctrl, proportion, wx.EXPAND | wx.ALL, 5)
             if name == "id":
                 ctrl.SetHint(_("Unique integer identifier"))
@@ -239,6 +241,7 @@ class EditorPanel(wx.Panel):
         sizer.Add(btn_row, 0, wx.ALIGN_RIGHT)
 
         self.SetSizer(sizer)
+        self.SetupScrolling()
 
         self.attachments: list[dict[str, str]] = []
         self.derived_from: list[dict[str, Any]] = []

--- a/app/ui/main_frame.py
+++ b/app/ui/main_frame.py
@@ -353,6 +353,7 @@ class MainFrame(wx.Frame):
         if req:
             self.editor.load(req)
             self.editor.Show()
+            self.editor.Layout()
             self.splitter.UpdateSize()
 
     def _on_editor_save(self) -> None:

--- a/tests/test_main_frame_gui_size.py
+++ b/tests/test_main_frame_gui_size.py
@@ -1,0 +1,54 @@
+import pytest
+
+from app.core.store import save
+from app.ui import main_frame
+
+
+def test_main_frame_editor_multiline_fields_have_size(tmp_path, monkeypatch):
+    wx = pytest.importorskip("wx")
+    data = {
+        "id": 1,
+        "title": "Title",
+        "statement": "Stmt",
+        "acceptance": "A",
+        "conditions": "C",
+        "trace_up": "TU",
+        "trace_down": "TD",
+        "source": "Src",
+        "type": "requirement",
+        "status": "draft",
+        "owner": "Own",
+        "priority": "medium",
+        "verification": "analysis",
+        "revision": 1,
+    }
+    save(tmp_path, data)
+
+    class DummyDirDialog:
+        def __init__(self, parent, message):
+            pass
+
+        def ShowModal(self):
+            return wx.ID_OK
+
+        def GetPath(self):
+            return str(tmp_path)
+
+        def Destroy(self):
+            pass
+
+    monkeypatch.setattr(wx, "DirDialog", DummyDirDialog)
+
+    app = wx.App()
+    frame = main_frame.MainFrame(None)
+    evt = wx.CommandEvent(wx.EVT_MENU.typeId, wx.ID_OPEN)
+    frame.ProcessEvent(evt)
+    frame.Show()
+    frame.panel.list.Select(0)
+    app.Yield()
+
+    for name in ["statement", "acceptance", "conditions", "trace_up", "trace_down", "source"]:
+        assert frame.editor.fields[name].GetSize().GetHeight() > 0
+
+    frame.Destroy()
+    app.Destroy()


### PR DESCRIPTION
## Summary
- ensure multiline fields in editor have visible size by using a scrolled panel and fixed minimum heights
- trigger layout after selecting a requirement so fields are displayed
- test editor panel shows all multiline fields when opening a requirement

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c42cb64cd88320a941db23200436dc