### PR TITLE
Translate README to English

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,82 +1,73 @@
 # CookaReq
 
-CookaReq — настольное приложение на wxPython для управления требованиями,
-хранящимися в отдельных JSON‑файлах. В комплект входит графический интерфейс и
-командная строка для пакетных операций.
+CookaReq is a desktop application built with wxPython for managing requirements stored in separate JSON files. The package includes a graphical interface and a command-line tool for batch operations.
 
-## Возможности
+## Features
 
-- хранение требований в виде независимых файлов `id.json`;
-- открытие каталога и автоматическая подгрузка списка требований;
-- фильтрация по меткам и полнотекстовый поиск по нескольким полям;
-- создание, клонирование, редактирование и удаление требований;
-- контроль версий: счётчик ревизий и дата последнего изменения;
-- поддержка вложений и пользовательских меток;
-- журнал ошибок, который можно скрывать или отображать;
-- запоминание размера окна, выбранных колонок, сортировки и последних каталогов;
-- локализация интерфейса через `gettext`.
+- Store requirements as independent `id.json` files
+- Open a directory and automatically load the list of requirements
+- Filter by labels and perform full-text search across multiple fields
+- Create, clone, edit, and delete requirements
+- Version control with a revision counter and last modification date
+- Support for attachments and user-defined labels
+- Error log that can be hidden or shown
+- Remembers window size, selected columns, sorting, and recently opened folders
+- Interface localization via `gettext`
 
-## Графический интерфейс
+## Graphical Interface
 
-Главное окно разделено на две части:
+The main window is divided into two parts:
 
-1. **Список требований** — таблица с настраиваемыми колонками. Поддерживает
-   сортировку, фильтры по меткам и текстовый поиск. Из контекстного меню можно
-   создавать новые требования, клонировать существующие и удалять записи.
-2. **Редактор** — форма с полями модели требования. Появляется при создании или
-   редактировании записи и позволяет сохранять изменения в файл.
+1. **Requirement list** — a table with customizable columns. Supports sorting, label filters, and text search. The context menu lets you create new requirements, clone existing ones, and delete entries.
+2. **Editor** — a form with the fields of a requirement model. It appears when creating or editing a record and allows saving changes to a file.
 
-В нижней части окна по желанию отображается консоль логов. Настройки интерфейса
-и последние открытые каталоги сохраняются между запусками.
+An optional log console is shown at the bottom of the window. Interface settings and the last opened directories are preserved between sessions.
 
-## Командная строка
+## Command-Line Interface
 
-CLI реализован в модуле `app.cli`. Пример запуска:
+The CLI lives in the `app.cli` module. Example usage:
 
 ```bash
-python3 -m app.cli <команда> [аргументы]
+python3 -m app.cli <command> [arguments]
 ```
 
-Доступные команды:
+Available commands:
 
-- `list <dir>` — выводит список требований, поддерживает `--labels`,
-  `--query` и `--fields` для фильтрации.
-- `add <dir> <file>` — добавляет требование из JSON‑файла.
-- `edit <dir> <file>` — обновляет существующее требование данными из файла.
-- `show <dir> <id>` — показывает полное содержимое требования в виде JSON.
+- `list <dir>` — print the list of requirements; supports `--labels`, `--query`, and `--fields` for filtering
+- `add <dir> <file>` — add a requirement from a JSON file
+- `edit <dir> <file>` — update an existing requirement with data from a file
+- `show <dir> <id>` — display the full contents of a requirement as JSON
 
-## Формат файла требований
+## Requirement File Format
 
-Каждое требование хранится в отдельном файле `<id>.json` и описывается
-следующими полями:
+Each requirement is stored in its own `<id>.json` file and contains the following fields:
 
-- `id` *(int)* — уникальный идентификатор;
-- `title` *(str)* — краткое название;
-- `statement` *(str)* — формулировка требования;
-- `type` *(str)* — один из: `requirement`, `constraint`, `interface`;
-- `status` *(str)* — `draft`, `in_review`, `approved`, `baselined`, `retired`;
-- `owner` *(str)* — ответственный;
-- `priority` *(str)* — `low`, `medium`, `high`;
-- `source` *(str)* — происхождение требования;
-- `verification` *(str)* — `inspection`, `analysis`, `demonstration`, `test`;
-- `acceptance` *(str, optional)* — критерий приемки;
-- `conditions` *(str)* — условия;
-- `trace_up` *(str)* и `trace_down` *(str)* — связи по трассировке;
-- `version` *(str)* и `modified_at` *(str)* — версия и дата изменения;
-- `units` *(object, optional)* — {`quantity`, `nominal`, `tolerance`};
-- `labels` *(list[str])* — произвольные метки;
-- `attachments` *(list[obj])* — вложения {`path`, `note`};
-- `revision` *(int)* — номер ревизии (начинается с 1);
-- `approved_at` *(str, optional)* — дата утверждения;
-- `notes` *(str)* — дополнительные комментарии.
+- `id` *(int)* — unique identifier
+- `title` *(str)* — short name
+- `statement` *(str)* — requirement statement
+- `type` *(str)* — one of: `requirement`, `constraint`, `interface`
+- `status` *(str)* — `draft`, `in_review`, `approved`, `baselined`, `retired`
+- `owner` *(str)* — responsible person
+- `priority` *(str)* — `low`, `medium`, `high`
+- `source` *(str)* — origin of the requirement
+- `verification` *(str)* — `inspection`, `analysis`, `demonstration`, `test`
+- `acceptance` *(str, optional)* — acceptance criteria
+- `conditions` *(str)* — conditions
+- `trace_up` *(str)* and `trace_down` *(str)* — traceability links
+- `version` *(str)* and `modified_at` *(str)* — version and date of modification
+- `units` *(object, optional)* — {`quantity`, `nominal`, `tolerance`}
+- `labels` *(list[str])* — custom labels
+- `attachments` *(list[obj])* — attachments `{path, note}`
+- `revision` *(int)* — revision number (starting at 1)
+- `approved_at` *(str, optional)* — approval date
+- `notes` *(str)* — additional comments
 
-## Локализация
+## Localization
 
-Интерфейс использует `gettext`. При наличии соответствующих `.mo`‑файлов язык
-определяется автоматически по настройкам системы.
+The interface uses `gettext`. If the corresponding `.mo` files are available, the language is selected automatically based on system settings.
 
-## Лицензия
+## License
 
-Проект распространяется по лицензии [Apache License 2.0](LICENSE).
+This project is distributed under the [Apache License 2.0](LICENSE).
 
 © 2025 Maksim Lashkevich & Codex.


### PR DESCRIPTION
## Summary
- Translate README from Russian to English, documenting features, UI, CLI, requirement format, localization, and license.

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c4338a6d508320bdcb82639007c49d