### PR TITLE
Preserve and validate label usage

### DIFF
--- a/app/ui/labels_dialog.py
+++ b/app/ui/labels_dialog.py
@@ -17,7 +17,6 @@ class LabelsDialog(wx.Dialog):
 
         self.list = wx.ListCtrl(self, style=wx.LC_REPORT | wx.BORDER_SUNKEN)
         self.list.InsertColumn(0, _("Name"))
-        self.list.InsertColumn(1, _("Color"))
 
         # image list to display colored rectangles instead of hex codes
         self._img_list = wx.ImageList(16, 16)
@@ -72,8 +71,7 @@ class LabelsDialog(wx.Dialog):
         for lbl in self._labels:
             idx = self.list.InsertItem(self.list.GetItemCount(), lbl.name)
             img_idx = self._get_icon_index(lbl.color)
-            self.list.SetItem(idx, 1, "")
-            self.list.SetItemColumnImage(idx, 1, img_idx)
+            self.list.SetItemColumnImage(idx, 0, img_idx)
 
     def _on_select(self, event: wx.ListEvent) -> None:  # pragma: no cover - GUI event
         idx = event.GetIndex()
@@ -88,8 +86,7 @@ class LabelsDialog(wx.Dialog):
         colour = event.GetColour().GetAsString(wx.C2S_HTML_SYNTAX)
         self._labels[idx].color = colour
         img_idx = self._get_icon_index(colour)
-        self.list.SetItem(idx, 1, "")
-        self.list.SetItemColumnImage(idx, 1, img_idx)
+        self.list.SetItemColumnImage(idx, 0, img_idx)
 
     def _get_selected_indices(self) -> list[int]:
         indices: list[int] = []

--- a/tests/test_labels_sync.py
+++ b/tests/test_labels_sync.py
@@ -1,0 +1,33 @@
+import pytest
+from app.core import store
+from app.core.labels import PRESET_SETS
+
+
+def _create_requirement(directory):
+    data = {
+        "id": 1,
+        "title": "Title",
+        "statement": "Statement",
+        "type": "requirement",
+        "status": "draft",
+        "owner": "user",
+        "priority": "medium",
+        "source": "spec",
+        "verification": "analysis",
+        "labels": ["ui"],
+        "revision": 1,
+    }
+    store.save(directory, data)
+
+
+def test_sync_labels_preserves_unused(monkeypatch, tmp_path):
+    wx = pytest.importorskip("wx")
+    app = wx.App()
+    store.save_labels(tmp_path, PRESET_SETS["basic"])
+    _create_requirement(tmp_path)
+    from app.ui.main_frame import MainFrame
+    frame = MainFrame(None)
+    frame._load_directory(tmp_path)
+    assert {l.name for l in frame.labels} == {l.name for l in PRESET_SETS["basic"]}
+    frame.Destroy()
+    app.Destroy()


### PR DESCRIPTION
## Summary
- keep all defined labels when syncing with requirements
- warn and remove label usage across requirements on delete
- show label color icons only once by removing redundant column

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c432f3cd3c8320bd8b283f5fdf9cd6