### PR TITLE
Fix autosize interference between editor fields

### DIFF
--- a/app/ui/editor_panel.py
+++ b/app/ui/editor_panel.py
@@ -136,8 +136,9 @@ class EditorPanel(ScrolledPanel):
             if multiline:
                 self._bind_autosize(ctrl)
             self.fields[name] = ctrl
-            proportion = 1 if name == "statement" else 0
-            sizer.Add(ctrl, proportion, wx.EXPAND | wx.ALL, 5)
+            # Высоту многострочных полей мы управляем вручную,
+            # поэтому не передаём sizer'у коэффициент роста.
+            sizer.Add(ctrl, 0, wx.EXPAND | wx.ALL, 5)
             if name == "id":
                 ctrl.SetHint(_("Unique integer identifier"))
                 ctrl.Bind(wx.EVT_TEXT, self._on_id_change)
@@ -230,8 +231,9 @@ class EditorPanel(ScrolledPanel):
             if multiline:
                 self._bind_autosize(ctrl)
             self.derivation_fields[name] = ctrl
-            proportion = 1 if multiline else 0
-            sizer.Add(ctrl, proportion, wx.EXPAND | wx.ALL, 5)
+            # Здесь также используем пропорцию 0, чтобы изменение
+            # одного поля не растягивало другие.
+            sizer.Add(ctrl, 0, wx.EXPAND | wx.ALL, 5)
 
         self.save_btn = wx.Button(self, label=_("Save"))
         self.save_btn.Bind(wx.EVT_BUTTON, self._on_save_button)

--- a/tests/test_editor_panel_gui.py
+++ b/tests/test_editor_panel_gui.py
@@ -190,3 +190,23 @@ def test_multiline_fields_resize_dynamically():
     shrunk = ctrl.GetSize().height
     assert shrunk < grown
     assert shrunk >= line_h * 2
+
+def test_rationale_autosizes_without_affecting_statement():
+    panel = _make_panel()
+    wx = pytest.importorskip("wx")
+    panel.new_requirement()
+    stmt = panel.fields["statement"]
+    rat = panel.derivation_fields["rationale"]
+    wx.Yield()
+    line_h = rat.GetCharHeight()
+    s_start = stmt.GetSize().height
+    r_start = rat.GetSize().height
+    assert s_start >= line_h * 2
+    assert r_start >= line_h * 2
+    rat.SetValue("one\ntwo\nthree")
+    wx.Yield()
+    s_after = stmt.GetSize().height
+    r_after = rat.GetSize().height
+    assert r_after >= line_h * 4
+    assert r_after > r_start
+    assert s_after == s_start


### PR DESCRIPTION
## Summary
- prevent multiline controls from stretching sibling fields
- add regression test ensuring Rationale resize doesn't affect statement

## Testing
- `pytest -q`
- `pytest tests/test_editor_panel_gui.py::test_rationale_autosizes_without_affecting_statement -q`


------
https://chatgpt.com/codex/tasks/task_e_68c43441acf883208349025e64a8e041