### PR TITLE
feat: enhance labels dialog

### DIFF
--- a/app/ui/labels_dialog.py
+++ b/app/ui/labels_dialog.py
@@ -10,10 +10,14 @@ from app.core.labels import Label, PRESET_SETS, PRESET_SET_TITLES
 class LabelsDialog(wx.Dialog):
     """Dialog allowing to view labels and adjust their colors."""
 
-    def __init__(self, parent: wx.Window, labels: list[Label]):
-        super().__init__(parent, title=_("Labels"))
+    def __init__(self, parent: wx.Window | None, labels: list[Label]):
+        style = wx.DEFAULT_DIALOG_STYLE | wx.RESIZE_BORDER
+        super().__init__(parent, title=_("Labels"), style=style)
         # copy labels to avoid modifying caller until OK
         self._labels: list[Label] = [Label(l.name, l.color) for l in labels]
+        self._config = (
+            parent.config if hasattr(parent, "config") else wx.Config(appName="CookaReq")
+        )
 
         self.list = wx.ListCtrl(self, style=wx.LC_REPORT | wx.BORDER_SUNKEN)
         self.list.InsertColumn(0, _("Name"))
@@ -31,6 +35,9 @@ class LabelsDialog(wx.Dialog):
         self.add_presets = wx.Button(self, label=_("Add presets"))
         self.add_presets.Bind(wx.EVT_BUTTON, self._on_show_presets_menu)
 
+        self.rename_btn = wx.Button(self, label=_("Rename"))
+        self.rename_btn.Bind(wx.EVT_BUTTON, self._on_rename_selected)
+
         self.delete_btn = wx.Button(self, label=_("Delete"))
         self.delete_btn.Bind(wx.EVT_BUTTON, self._on_delete_selected)
 
@@ -38,6 +45,7 @@ class LabelsDialog(wx.Dialog):
         self.clear_btn.Bind(wx.EVT_BUTTON, self._on_clear_all)
 
         self.list.Bind(wx.EVT_LIST_ITEM_SELECTED, self._on_select)
+        self.list.Bind(wx.EVT_SIZE, self._on_list_size)
         self.color_picker.Bind(wx.EVT_COLOURPICKER_CHANGED, self._on_color_changed)
 
         sizer = wx.BoxSizer(wx.VERTICAL)
@@ -45,13 +53,18 @@ class LabelsDialog(wx.Dialog):
         sizer.Add(self.color_picker, 0, wx.ALL | wx.ALIGN_RIGHT, 5)
         btn_row = wx.BoxSizer(wx.HORIZONTAL)
         btn_row.Add(self.add_presets, 0, wx.ALL, 5)
+        btn_row.Add(self.rename_btn, 0, wx.ALL, 5)
         btn_row.Add(self.delete_btn, 0, wx.ALL, 5)
         btn_row.Add(self.clear_btn, 0, wx.ALL, 5)
         sizer.Add(btn_row, 0, wx.ALIGN_RIGHT)
         btn_sizer = self.CreateStdDialogButtonSizer(wx.OK | wx.CANCEL)
         if btn_sizer:
             sizer.Add(btn_sizer, 0, wx.ALIGN_CENTER | wx.ALL, 5)
-        self.SetSizerAndFit(sizer)
+        self.SetSizer(sizer)
+        sizer.Fit(self)
+        self.SetMinSize(self.GetSize())
+        self._load_layout()
+        wx.CallAfter(self._resize_column)
 
     def _get_icon_index(self, colour: str) -> int:
         """Return image index for ``colour``, creating bitmap if needed."""
@@ -72,6 +85,7 @@ class LabelsDialog(wx.Dialog):
             idx = self.list.InsertItem(self.list.GetItemCount(), lbl.name)
             img_idx = self._get_icon_index(lbl.color)
             self.list.SetItemColumnImage(idx, 0, img_idx)
+        self._resize_column()
 
     def _on_select(self, event: wx.ListEvent) -> None:  # pragma: no cover - GUI event
         idx = event.GetIndex()
@@ -137,3 +151,72 @@ class LabelsDialog(wx.Dialog):
     def get_labels(self) -> list[Label]:
         """Return updated labels."""
         return list(self._labels)
+
+    # --- new methods -------------------------------------------------
+
+    def _resize_column(self) -> None:
+        width = self.list.GetClientSize().width
+        if width > 0:
+            self.list.SetColumnWidth(0, width - 4)
+
+    def _on_list_size(self, _event: wx.Event) -> None:  # pragma: no cover - GUI event
+        self._resize_column()
+
+    def _on_rename_selected(self, _event: wx.Event) -> None:  # pragma: no cover - GUI event
+        idx = self.list.GetFirstSelected()
+        if idx == -1:
+            return
+        old_name = self._labels[idx].name
+        dlg = wx.TextEntryDialog(self, _("New name"), _("Rename"), value=old_name)
+        if dlg.ShowModal() == wx.ID_OK:
+            new_name = dlg.GetValue().strip()
+            if not new_name:
+                dlg.Destroy()
+                return
+            existing = {l.name for i, l in enumerate(self._labels) if i != idx}
+            if new_name in existing:
+                wx.MessageBox(_("Label already exists"), _("Error"), style=wx.ICON_ERROR)
+            else:
+                self._labels[idx].name = new_name
+                self.list.SetItem(idx, 0, new_name)
+        dlg.Destroy()
+
+    def _load_layout(self) -> None:
+        w = self._config.ReadInt("labels_w", 300)
+        h = self._config.ReadInt("labels_h", 200)
+        w = max(200, min(w, 1000))
+        h = max(150, min(h, 800))
+        self.SetSize((w, h))
+        x = self._config.ReadInt("labels_x", -1)
+        y = self._config.ReadInt("labels_y", -1)
+        if x != -1 and y != -1:
+            self.SetPosition((x, y))
+            rect = self.GetRect()
+            visible = False
+            for i in range(wx.Display.GetCount()):
+                if wx.Display(i).GetGeometry().Intersects(rect):
+                    visible = True
+                    break
+            if not visible:
+                if parent := self.GetParent():
+                    self.CentreOnParent()
+                else:
+                    self.Centre()
+        else:
+            if parent := self.GetParent():
+                self.CentreOnParent()
+            else:
+                self.Centre()
+
+    def _save_layout(self) -> None:
+        w, h = self.GetSize()
+        x, y = self.GetPosition()
+        self._config.WriteInt("labels_w", w)
+        self._config.WriteInt("labels_h", h)
+        self._config.WriteInt("labels_x", x)
+        self._config.WriteInt("labels_y", y)
+        self._config.Flush()
+
+    def Destroy(self) -> bool:  # pragma: no cover - GUI side effect
+        self._save_layout()
+        return super().Destroy()

--- a/tests/test_labels_dialog.py
+++ b/tests/test_labels_dialog.py
@@ -89,6 +89,34 @@ def test_labels_dialog_clear_all(monkeypatch):
     app.Destroy()
 
 
+def test_labels_dialog_renames_selected(monkeypatch):
+    wx = pytest.importorskip("wx")
+    app = wx.App()
+    from app.ui.labels_dialog import LabelsDialog
+
+    dlg = LabelsDialog(None, [Label("old", "#111111")])
+    dlg.list.SetItemState(0, wx.LIST_STATE_SELECTED, wx.LIST_STATE_SELECTED)
+
+    class DummyTextEntryDialog:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def ShowModal(self):
+            return wx.ID_OK
+
+        def GetValue(self):
+            return "new"
+
+        def Destroy(self):
+            pass
+
+    monkeypatch.setattr(wx, "TextEntryDialog", DummyTextEntryDialog)
+    dlg._on_rename_selected(None)
+    assert dlg.get_labels()[0].name == "new"
+    dlg.Destroy()
+    app.Destroy()
+
+
 def _prepare_frame(monkeypatch, tmp_path):
     from app.core.store import save
 


### PR DESCRIPTION
## Summary
- Make labels dialog resizable and remember geometry
- Resize Name column to fit dialog width
- Add label renaming and tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c43995ab388320aa39d5abd47d1180