### PR TITLE
feat: improve label editing UX

### DIFF
--- a/app/ui/main_frame.py
+++ b/app/ui/main_frame.py
@@ -283,7 +283,7 @@ class MainFrame(wx.Frame):
             except Exception as exc:  # pragma: no cover - disk errors
                 logger.warning("Failed to save labels: %s", exc)
             names = [lbl.name for lbl in self.labels]
-            self.editor.update_labels_list(names)
+            self.editor.update_labels_list(self.labels)
             self.panel.update_labels_list(names)
         dlg.Destroy()
 
@@ -347,7 +347,7 @@ class MainFrame(wx.Frame):
         except Exception as exc:
             logger.warning("Failed to save labels: %s", exc)
         names = [lbl.name for lbl in self.labels]
-        self.editor.update_labels_list(names)
+        self.editor.update_labels_list(self.labels)
         self.panel.update_labels_list(names)
 
     # recent directories -------------------------------------------------

--- a/tests/test_editor_panel.py
+++ b/tests/test_editor_panel.py
@@ -2,6 +2,7 @@ import os
 import pytest
 
 from app.core.model import RequirementType, Status, Priority, Verification
+from app.core.labels import Label
 
 
 def _make_panel():
@@ -129,19 +130,15 @@ def test_enum_localization_roundtrip():
 
 def test_labels_selection_and_update():
     panel = _make_panel()
-    panel.update_labels_list(["ui", "backend"])
+    panel.update_labels_list([Label("ui", "#ff0000"), Label("backend", "#00ff00")])
     panel.new_requirement()
     panel.fields["id"].SetValue("1")
-    # select one label
-    panel.labels_list.Check(1, True)
+    panel.apply_label_selection(["backend"])
     data = panel.get_data()
     assert data.labels == ["backend"]
-    # load with different label
     panel.load({"id": 1, "labels": ["ui"]})
-    assert panel.labels_list.IsChecked(0)
-    assert not panel.labels_list.IsChecked(1)
-    # update list removing old selection
-    panel.update_labels_list(["docs"])
-    assert panel.labels_list.GetCount() == 1
+    assert panel.extra["labels"] == ["ui"]
+    panel.update_labels_list([Label("docs", "#123456")])
+    assert len(panel._label_defs) == 1
     assert panel.extra["labels"] == []
 

--- a/tests/test_editor_panel_gui.py
+++ b/tests/test_editor_panel_gui.py
@@ -2,6 +2,7 @@ import pytest
 from dataclasses import asdict
 
 from app.core.model import RequirementType, Status, Priority, Verification
+from app.core.labels import Label
 
 
 def _make_panel():
@@ -104,7 +105,7 @@ def test_editor_load_populates_fields(tmp_path):
         "notes": "Note",
     }
     path = tmp_path / "req.json"
-    panel.update_labels_list(["L"])
+    panel.update_labels_list([Label("L", "#000000")])
     panel.load(data, path=path, mtime=42.0)
 
     result = panel.get_data()

--- a/tests/test_labels_dialog.py
+++ b/tests/test_labels_dialog.py
@@ -156,7 +156,9 @@ def test_main_frame_manage_labels_saves(monkeypatch, tmp_path):
     monkeypatch.setattr(main_frame_mod, "LabelsDialog", DummyLabelsDialog)
 
     captured: list[tuple[str, list[str]]] = []
-    frame.editor.update_labels_list = lambda labels: captured.append(("editor", labels))
+    frame.editor.update_labels_list = lambda labels: captured.append(
+        ("editor", [l.name for l in labels])
+    )
     frame.panel.update_labels_list = lambda labels: captured.append(("panel", labels))
 
     evt = wx.CommandEvent(wx.EVT_MENU.typeId, frame.manage_labels_id)


### PR DESCRIPTION
## Summary
- show requirement labels inline with colors and open popup for selection
- supply label definitions with colors to editor
- update tests for new label workflow

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c43a0f9a948320ab2a3cf7c14d8321