### PR TITLE
feat: show label colors in selection dialog

### DIFF
--- a/app/ui/editor_panel.py
+++ b/app/ui/editor_panel.py
@@ -24,6 +24,7 @@ from app.core.model import (
     requirement_to_dict,
 )
 from . import locale
+from .label_selection_dialog import LabelSelectionDialog
 
 
 class EditorPanel(ScrolledPanel):
@@ -474,17 +475,12 @@ class EditorPanel(ScrolledPanel):
         self.labels_panel.Layout()
 
     def _on_labels_click(self, _event: wx.Event) -> None:
-        choices = [lbl.name for lbl in self._label_defs]
-        if not choices:
+        if not self._label_defs:
             return
-        preselect = [
-            i for i, lbl in enumerate(self._label_defs) if lbl.name in self.extra.get("labels", [])
-        ]
-        dlg = wx.MultiChoiceDialog(self, _("Select labels"), _("Labels"), choices)
-        dlg.SetSelections(preselect)
+        selected = self.extra.get("labels", [])
+        dlg = LabelSelectionDialog(self, self._label_defs, selected)
         if dlg.ShowModal() == wx.ID_OK:
-            selected = [choices[i] for i in dlg.GetSelections()]
-            self.apply_label_selection(selected)
+            self.apply_label_selection(dlg.get_selected())
         dlg.Destroy()
 
     def _on_add_link(self, _event: wx.CommandEvent) -> None:

--- a/app/ui/label_selection_dialog.py
+++ b/app/ui/label_selection_dialog.py
@@ -1,0 +1,75 @@
+"""Dialog for selecting labels with color icons."""
+from gettext import gettext as _
+
+import wx
+from wx.lib.mixins.listctrl import CheckListCtrlMixin
+
+from app.core.labels import Label
+
+
+class _CheckListCtrl(wx.ListCtrl, CheckListCtrlMixin):
+    """ListCtrl with checkboxes."""
+
+    def __init__(self, parent: wx.Window):
+        wx.ListCtrl.__init__(self, parent, style=wx.LC_REPORT | wx.BORDER_SUNKEN)
+        CheckListCtrlMixin.__init__(self)
+
+
+class LabelSelectionDialog(wx.Dialog):
+    """Dialog allowing to choose labels while displaying their colors."""
+
+    def __init__(self, parent: wx.Window | None, labels: list[Label], selected: list[str]):
+        style = wx.DEFAULT_DIALOG_STYLE | wx.RESIZE_BORDER
+        super().__init__(parent, title=_("Labels"), style=style)
+        self._labels = list(labels)
+
+        self.list = _CheckListCtrl(self)
+        self.list.InsertColumn(0, _("Name"))
+
+        self._img_list = wx.ImageList(16, 16)
+        self._color_icons: dict[str, int] = {}
+        self.list.AssignImageList(self._img_list, wx.IMAGE_LIST_SMALL)
+
+        for lbl in self._labels:
+            idx = self.list.InsertItem(self.list.GetItemCount(), lbl.name)
+            img_idx = self._get_icon_index(lbl.color)
+            self.list.SetItemColumnImage(idx, 0, img_idx)
+            if lbl.name in selected:
+                self.list.CheckItem(idx)
+
+        self.list.Bind(wx.EVT_SIZE, self._on_list_size)
+
+        sizer = wx.BoxSizer(wx.VERTICAL)
+        sizer.Add(self.list, 1, wx.EXPAND | wx.ALL, 5)
+        btn_sizer = self.CreateStdDialogButtonSizer(wx.OK | wx.CANCEL)
+        if btn_sizer:
+            sizer.Add(btn_sizer, 0, wx.ALIGN_RIGHT | wx.ALL, 5)
+        self.SetSizer(sizer)
+        sizer.Fit(self)
+        self.SetMinSize(self.GetSize())
+        wx.CallAfter(self._resize_column)
+
+    def _get_icon_index(self, colour: str) -> int:
+        """Return image index for ``colour``, creating bitmap if needed."""
+        if colour not in self._color_icons:
+            bmp = wx.Bitmap(16, 16)
+            dc = wx.MemoryDC(bmp)
+            wx_colour = wx.Colour(colour)
+            dc.SetBrush(wx.Brush(wx_colour))
+            dc.SetPen(wx.Pen(wx_colour))
+            dc.DrawRectangle(0, 0, 16, 16)
+            dc.SelectObject(wx.NullBitmap)
+            self._color_icons[colour] = self._img_list.Add(bmp)
+        return self._color_icons[colour]
+
+    def _resize_column(self) -> None:
+        width = self.list.GetClientSize().width
+        if width > 0:
+            self.list.SetColumnWidth(0, width - 4)
+
+    def _on_list_size(self, _event: wx.Event) -> None:  # pragma: no cover - GUI event
+        self._resize_column()
+
+    def get_selected(self) -> list[str]:
+        """Return names of checked labels."""
+        return [self._labels[i].name for i in self.list.GetCheckedItems()]


### PR DESCRIPTION
## Summary
- add custom `LabelSelectionDialog` that displays label colors alongside names
- integrate colored label selection into requirement editor

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c43c9d84fc8320a00ab815017a2230