### PR TITLE
Ensure taskbar uses app icon

### DIFF
--- a/app/ui/main_frame.py
+++ b/app/ui/main_frame.py
@@ -60,8 +60,13 @@ class MainFrame(wx.Frame):
         self.sort_ascending = self.config.ReadBool("sort_ascending", True)
         self.labels: list[Label] = []
         super().__init__(parent=parent, title=self._base_title)
+        # Load all available icon sizes so that Windows taskbar and other
+        # platforms can pick the most appropriate resolution. Using
+        # ``SetIcons`` with an ``IconBundle`` ensures both the title bar and
+        # the taskbar use the custom application icon.
         with resources.as_file(resources.files("app.resources") / "app.ico") as icon_path:
-            self.SetIcon(wx.Icon(str(icon_path)))
+            icons = wx.IconBundle(str(icon_path), wx.BITMAP_TYPE_ANY)
+            self.SetIcons(icons)
         self.model = RequirementModel()
         self._create_menu()
         self._create_toolbar()

--- a/tests/test_app_icon.py
+++ b/tests/test_app_icon.py
@@ -1,0 +1,18 @@
+"""Tests for application icon handling."""
+
+import wx
+
+from app.ui.main_frame import MainFrame
+
+
+def test_main_frame_loads_multiple_icon_sizes():
+    """Main frame should expose all icon sizes for taskbar usage."""
+    app = wx.App()
+    frame = MainFrame(None)
+    try:
+        bundle = frame.GetIcons()
+        assert bundle.GetIconCount() >= 2
+    finally:
+        frame.Destroy()
+        app.Destroy()
+


### PR DESCRIPTION
## Summary
- Load all icon sizes from app.ico and set via SetIcons to display proper icon on taskbars
- Test that main frame exposes multiple icon sizes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c4450664b48320bde44a15ec23c19b