### PR TITLE
Fix label panel not clearing when requirement has no labels

### DIFF
--- a/app/ui/editor_panel.py
+++ b/app/ui/editor_panel.py
@@ -350,9 +350,13 @@ class EditorPanel(ScrolledPanel):
             mapping = getattr(locale, name.upper())
             code = data.get(name, next(iter(mapping)))
             choice.SetStringSelection(locale.code_to_label(name, code))
-        for key in self.extra:
-            if key in data:
-                self.extra[key] = data[key]
+        labels = data.get("labels")
+        self.extra = {
+            "labels": list(labels) if isinstance(labels, list) else [],
+            "revision": data.get("revision", 1),
+            "approved_at": data.get("approved_at"),
+            "notes": data.get("notes", ""),
+        }
         self.current_path = Path(path) if path else None
         self.mtime = mtime
         self.original_id = data.get("id")
@@ -453,7 +457,7 @@ class EditorPanel(ScrolledPanel):
             return
         sizer = self.labels_panel.GetSizer()
         if sizer:
-            sizer.Clear(False)
+            sizer.Clear(True)
         labels = self.extra.get("labels", [])
         if not labels:
             placeholder = wx.StaticText(self.labels_panel, label=_("(none)"))

--- a/tests/test_editor_panel.py
+++ b/tests/test_editor_panel.py
@@ -1,5 +1,6 @@
 import os
 import pytest
+from gettext import gettext as _
 
 from app.core.model import RequirementType, Status, Priority, Verification
 from app.core.labels import Label
@@ -141,4 +142,16 @@ def test_labels_selection_and_update():
     panel.update_labels_list([Label("docs", "#123456")])
     assert len(panel._label_defs) == 1
     assert panel.extra["labels"] == []
+
+
+def test_loading_requirement_without_labels_clears_display():
+    panel = _make_panel()
+    panel.update_labels_list([Label("ui", "#ff0000")])
+    panel.load({"id": 1, "labels": ["ui"]})
+    assert panel.extra["labels"] == ["ui"]
+    panel.load({"id": 2})
+    assert panel.extra["labels"] == []
+    children = panel.labels_panel.GetChildren()
+    assert len(children) == 1
+    assert children[0].GetLabel() == _("(none)")
 


### PR DESCRIPTION
## Summary
- reset extra metadata including labels when loading requirements
- destroy previous widgets when refreshing label display to avoid ghost labels
- cover loading without labels with a regression test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c4529f5c888320a8925a14ed24dd48