### PR TITLE
feat: add advanced filter dialog

### DIFF
--- a/app/ui/filter_dialog.py
+++ b/app/ui/filter_dialog.py
@@ -1,0 +1,81 @@
+"""Dialog for configuring requirement filters."""
+from __future__ import annotations
+
+from gettext import gettext as _
+from typing import Dict
+
+import wx
+
+from app.core import search as core_search
+
+
+class FilterDialog(wx.Dialog):
+    """Dialog allowing to configure various filters."""
+
+    def __init__(self, parent: wx.Window, *, labels: list[str], values: Dict | None = None) -> None:
+        title = _("Filters")
+        super().__init__(parent, title=title)
+        self._labels = labels
+        self._build_ui(values or {})
+
+    def _build_ui(self, values: Dict) -> None:
+        sizer = wx.BoxSizer(wx.VERTICAL)
+
+        # Global query across all searchable fields
+        sizer.Add(wx.StaticText(self, label=_("Any field contains")), 0, wx.ALL, 5)
+        self.any_query = wx.TextCtrl(self)
+        self.any_query.SetValue(values.get("query", ""))
+        sizer.Add(self.any_query, 0, wx.EXPAND | wx.ALL, 5)
+
+        # Per-field queries
+        self.field_controls: Dict[str, wx.TextCtrl] = {}
+        for field in sorted(core_search.SEARCHABLE_FIELDS):
+            sizer.Add(wx.StaticText(self, label=field.title()), 0, wx.ALL, 5)
+            ctrl = wx.TextCtrl(self)
+            ctrl.SetValue(values.get("field_queries", {}).get(field, ""))
+            self.field_controls[field] = ctrl
+            sizer.Add(ctrl, 0, wx.EXPAND | wx.ALL, 5)
+
+        # Labels
+        sizer.Add(wx.StaticText(self, label=_("Labels")), 0, wx.ALL, 5)
+        self.labels_box = wx.CheckListBox(self, choices=self._labels)
+        for lbl in values.get("labels", []):
+            if lbl in self._labels:
+                idx = self._labels.index(lbl)
+                self.labels_box.Check(idx)
+        sizer.Add(self.labels_box, 0, wx.EXPAND | wx.ALL, 5)
+
+        self.match_any = wx.CheckBox(self, label=_("Match any labels"))
+        self.match_any.SetValue(values.get("match_any", False))
+        sizer.Add(self.match_any, 0, wx.ALL, 5)
+
+        # Derived filters
+        self.is_derived = wx.CheckBox(self, label=_("Derived only"))
+        self.is_derived.SetValue(values.get("is_derived", False))
+        sizer.Add(self.is_derived, 0, wx.ALL, 5)
+
+        self.has_derived = wx.CheckBox(self, label=_("Has derived"))
+        self.has_derived.SetValue(values.get("has_derived", False))
+        sizer.Add(self.has_derived, 0, wx.ALL, 5)
+
+        self.suspect_only = wx.CheckBox(self, label=_("Suspect only"))
+        self.suspect_only.SetValue(values.get("suspect_only", False))
+        sizer.Add(self.suspect_only, 0, wx.ALL, 5)
+
+        btns = self.CreateButtonSizer(wx.OK | wx.CANCEL)
+        sizer.Add(btns, 0, wx.ALIGN_RIGHT | wx.ALL, 5)
+        self.SetSizerAndFit(sizer)
+
+    def get_filters(self) -> Dict:
+        """Return chosen filters as a dict."""
+        labels = [self._labels[i] for i in range(self.labels_box.GetCount()) if self.labels_box.IsChecked(i)]
+        field_queries = {field: ctrl.GetValue() for field, ctrl in self.field_controls.items() if ctrl.GetValue()}
+        return {
+            "query": self.any_query.GetValue(),
+            "labels": labels,
+            "match_any": self.match_any.GetValue(),
+            "is_derived": self.is_derived.GetValue(),
+            "has_derived": self.has_derived.GetValue(),
+            "suspect_only": self.suspect_only.GetValue(),
+            "field_queries": field_queries,
+        }

--- a/app/ui/requirement_model.py
+++ b/app/ui/requirement_model.py
@@ -18,6 +18,7 @@ class RequirementModel:
         self._labels_match_all: bool = True
         self._query: str = ""
         self._fields: Sequence[str] | None = None
+        self._field_queries: dict[str, str] = {}
         self._is_derived: bool = False
         self._has_derived: bool = False
         self._suspect_only: bool = False
@@ -80,6 +81,11 @@ class RequirementModel:
         self._suspect_only = value
         self._refresh()
 
+    def set_field_queries(self, queries: dict[str, str]) -> None:
+        """Set per-field text filters."""
+        self._field_queries = queries
+        self._refresh()
+
     # sorting ---------------------------------------------------------
     def sort(self, field: str, ascending: bool = True) -> None:
         self._sort_field = field
@@ -93,6 +99,7 @@ class RequirementModel:
             labels=self._labels,
             query=self._query,
             fields=self._fields,
+            field_queries=self._field_queries,
             match_all=self._labels_match_all,
             is_derived=self._is_derived,
             has_derived=self._has_derived,

--- a/tests/test_list_panel_gui.py
+++ b/tests/test_list_panel_gui.py
@@ -42,11 +42,11 @@ def test_list_panel_real_widgets():
     from wx.lib.agw import ultimatelistctrl as ULC
 
     assert panel in frame.GetChildren()
-    assert isinstance(panel.search, wx.SearchCtrl)
+    assert isinstance(panel.filter_btn, wx.Button)
     assert isinstance(panel.list, ULC.UltimateListCtrl)
-    assert panel.search.GetParent() is panel
+    assert panel.filter_btn.GetParent() is panel
     assert panel.list.GetParent() is panel
-    assert panel.search.IsShown()
+    assert panel.filter_btn.IsShown()
     assert panel.list.IsShown()
 
     frame.Destroy()

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -121,3 +121,11 @@ def test_search_with_derived_filters():
     assert [r.id for r in search(reqs, has_derived=True, suspect_only=True)] == [2]
 
 
+def test_field_queries():
+    reqs = sample_requirements()
+    found = search(reqs, field_queries={"owner": "alice"})
+    assert [r.id for r in found] == [1]
+    found = search(reqs, field_queries={"title": "report", "owner": "carol"})
+    assert [r.id for r in found] == [3]
+
+


### PR DESCRIPTION
## Summary
- overhaul list filter UI with dedicated dialog
- support per-field text queries in model and core search
- update tests for new filtering system

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c459b865ec83209778cdee875bc5d5