### PR TITLE
Move pytest to optional dev dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,14 @@ Each requirement is stored in its own `<id>.json` file and contains the followin
 
 The interface uses `gettext`. If the corresponding `.mo` files are available, the language is selected automatically based on system settings.
 
+## Development
+
+Install the package along with development dependencies:
+
+```bash
+pip install .[dev]
+```
+
 ## License
 
 This project is distributed under the [Apache License 2.0](LICENSE).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,9 +5,11 @@ authors = [{ name = "Maksim Lashkevich & Codex" }]
 license = { file = "LICENSE" }
 dependencies = [
     "wxPython",
-    "pytest",
     "jsonschema",
 ]
+
+[project.optional-dependencies]
+dev = ["pytest"]
 
 [build-system]
 requires = ["setuptools", "wheel"]


### PR DESCRIPTION
## Summary
- shift pytest to a new [project.optional-dependencies] dev group
- document installing development extras with `pip install .[dev]`

## Testing
- `python3 -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c4649b9f14832081580793d8507d32