### PR TITLE
Add MCP health check and configurable server settings

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -73,6 +73,20 @@ class ConfigManager:
         self._cfg.Flush()
 
     # ------------------------------------------------------------------
+    # MCP server settings
+    def get_mcp_settings(self) -> tuple[str, int, str]:
+        host = self._cfg.Read("mcp_host", "127.0.0.1")
+        port = self._cfg.ReadInt("mcp_port", 8000)
+        base_path = self._cfg.Read("mcp_base_path", "")
+        return host, port, base_path
+
+    def set_mcp_settings(self, host: str, port: int, base_path: str) -> None:
+        self._cfg.Write("mcp_host", host)
+        self._cfg.WriteInt("mcp_port", port)
+        self._cfg.Write("mcp_base_path", base_path)
+        self._cfg.Flush()
+
+    # ------------------------------------------------------------------
     # sort settings
     def get_sort_settings(self) -> tuple[int, bool]:
         column = self._cfg.ReadInt("sort_column", -1)

--- a/app/ui/settings_dialog.py
+++ b/app/ui/settings_dialog.py
@@ -29,12 +29,19 @@ class SettingsDialog(wx.Dialog):
         open_last: bool,
         remember_sort: bool,
         language: str,
+        host: str,
+        port: int,
+        base_path: str,
     ) -> None:
         super().__init__(parent, title=_("Settings"))
         self._open_last = wx.CheckBox(self, label=_("Open last folder on startup"))
         self._open_last.SetValue(open_last)
         self._remember_sort = wx.CheckBox(self, label=_("Remember sort order"))
         self._remember_sort.SetValue(remember_sort)
+
+        self._host = wx.TextCtrl(self, value=host)
+        self._port = wx.SpinCtrl(self, min=1, max=65535, initial=port)
+        self._base_path = wx.TextCtrl(self, value=base_path)
 
         self._languages = available_translations()
         choices = [name for _, name in self._languages]
@@ -48,6 +55,18 @@ class SettingsDialog(wx.Dialog):
         sizer = wx.BoxSizer(wx.VERTICAL)
         sizer.Add(self._open_last, 0, wx.ALL, 5)
         sizer.Add(self._remember_sort, 0, wx.ALL, 5)
+        host_sizer = wx.BoxSizer(wx.HORIZONTAL)
+        host_sizer.Add(wx.StaticText(self, label=_("Host")), 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, 5)
+        host_sizer.Add(self._host, 1, wx.ALIGN_CENTER_VERTICAL)
+        sizer.Add(host_sizer, 0, wx.ALL | wx.EXPAND, 5)
+        port_sizer = wx.BoxSizer(wx.HORIZONTAL)
+        port_sizer.Add(wx.StaticText(self, label=_("Port")), 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, 5)
+        port_sizer.Add(self._port, 1, wx.ALIGN_CENTER_VERTICAL)
+        sizer.Add(port_sizer, 0, wx.ALL | wx.EXPAND, 5)
+        base_sizer = wx.BoxSizer(wx.HORIZONTAL)
+        base_sizer.Add(wx.StaticText(self, label=_("Base path")), 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, 5)
+        base_sizer.Add(self._base_path, 1, wx.ALIGN_CENTER_VERTICAL)
+        sizer.Add(base_sizer, 0, wx.ALL | wx.EXPAND, 5)
         lang_sizer = wx.BoxSizer(wx.HORIZONTAL)
         lang_sizer.Add(wx.StaticText(self, label=_("Language")), 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, 5)
         lang_sizer.Add(self._language_choice, 1, wx.ALIGN_CENTER_VERTICAL)
@@ -57,7 +76,14 @@ class SettingsDialog(wx.Dialog):
             sizer.Add(btn_sizer, 0, wx.ALIGN_CENTER | wx.ALL, 5)
         self.SetSizerAndFit(sizer)
 
-    def get_values(self) -> tuple[bool, bool, str]:
-        """Return (open_last_folder, remember_sort, language_code)."""
+    def get_values(self) -> tuple[bool, bool, str, str, int, str]:
+        """Return (open_last_folder, remember_sort, language, host, port, base_path)."""
         lang_code = self._languages[self._language_choice.GetSelection()][0]
-        return self._open_last.GetValue(), self._remember_sort.GetValue(), lang_code
+        return (
+            self._open_last.GetValue(),
+            self._remember_sort.GetValue(),
+            lang_code,
+            self._host.GetValue(),
+            self._port.GetValue(),
+            self._base_path.GetValue(),
+        )

--- a/tests/test_health_endpoint.py
+++ b/tests/test_health_endpoint.py
@@ -1,0 +1,8 @@
+def test_health_endpoint_returns_ok():
+    from app.mcp.server import app
+    from fastapi.testclient import TestClient
+
+    client = TestClient(app)
+    resp = client.get('/health')
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "ok"}

--- a/tests/test_language_switch.py
+++ b/tests/test_language_switch.py
@@ -33,7 +33,14 @@ def test_switch_to_russian_updates_ui(monkeypatch):
         def ShowModal(self):
             return wx.ID_OK
         def get_values(self):
-            return frame.auto_open_last, frame.remember_sort, "ru"
+            return (
+                frame.auto_open_last,
+                frame.remember_sort,
+                "ru",
+                frame.mcp_host,
+                frame.mcp_port,
+                frame.mcp_base_path,
+            )
         def Destroy(self):
             pass
 

--- a/tests/test_settings_dialog.py
+++ b/tests/test_settings_dialog.py
@@ -16,7 +16,15 @@ def test_settings_dialog_returns_language():
     _app = wx.App()
     from app.ui.settings_dialog import SettingsDialog
 
-    dlg = SettingsDialog(None, open_last=True, remember_sort=False, language="ru")
+    dlg = SettingsDialog(
+        None,
+        open_last=True,
+        remember_sort=False,
+        language="ru",
+        host="127.0.0.1",
+        port=8000,
+        base_path="/tmp",
+    )
     values = dlg.get_values()
-    assert values == (True, False, "ru")
+    assert values == (True, False, "ru", "127.0.0.1", 8000, "/tmp")
     dlg.Destroy()


### PR DESCRIPTION
## Summary
- expose `/health` endpoint for the MCP FastAPI app
- persist host, port and base path via `wx.Config` and restart server on change
- extend settings dialog/UI and main window to manage server options
- add regression tests including a health endpoint check

## Testing
- `python3 -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c46cd22f308320b272184347f406da