### PR TITLE
Refactor MCP test helpers and ensure pytest summary output

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import time
 from pathlib import Path
 
 # Ensure project root is on sys.path for imports
@@ -25,3 +26,19 @@ def _virtual_display():
         yield
     finally:
         display.stop()
+
+
+@pytest.hookimpl(tryfirst=True)
+def pytest_sessionstart(session):
+    session.config._start_time = time.time()
+
+
+@pytest.hookimpl(trylast=True)
+def pytest_terminal_summary(terminalreporter, exitstatus):
+    passed = len(terminalreporter.stats.get("passed", []))
+    failed = len(terminalreporter.stats.get("failed", []))
+    skipped = len(terminalreporter.stats.get("skipped", []))
+    duration = time.time() - terminalreporter.config._start_time
+    terminalreporter.write_sep(
+        "=", f"{passed} passed, {failed} failed, {skipped} skipped in {duration:.2f}s"
+    )

--- a/tests/mcp_utils.py
+++ b/tests/mcp_utils.py
@@ -1,0 +1,20 @@
+import time
+from http.client import HTTPConnection
+
+
+def _request(port, headers=None):
+    conn = HTTPConnection("127.0.0.1", port)
+    conn.request("GET", "/health", headers=headers or {})
+    resp = conn.getresponse()
+    body = resp.read().decode()
+    conn.close()
+    return resp.status, body
+
+
+def _wait_until_ready(port, headers=None):
+    for _ in range(50):
+        try:
+            _request(port, headers=headers)
+            return
+        except ConnectionRefusedError:
+            time.sleep(0.1)

--- a/tests/test_mcp_auth.py
+++ b/tests/test_mcp_auth.py
@@ -1,17 +1,5 @@
-import time
-import time
-from http.client import HTTPConnection
-
 from app.mcp.server import start_server, stop_server
-
-
-def _request(port, headers=None):
-    conn = HTTPConnection("127.0.0.1", port)
-    conn.request("GET", "/health", headers=headers or {})
-    resp = conn.getresponse()
-    body = resp.read().decode()
-    conn.close()
-    return resp.status, body
+from tests.mcp_utils import _request, _wait_until_ready
 
 
 def test_authorization_header_rejected_without_valid_token():
@@ -19,13 +7,7 @@ def test_authorization_header_rejected_without_valid_token():
     stop_server()  # ensure clean state
     start_server(port=port, token="secret")
     try:
-        # wait for server to be ready
-        for _ in range(50):
-            try:
-                _request(port, {"Authorization": "Bearer wrong"})
-                break
-            except ConnectionRefusedError:
-                time.sleep(0.1)
+        _wait_until_ready(port, {"Authorization": "Bearer wrong"})
         status, body = _request(port, {"Authorization": "Bearer wrong"})
         assert status == 401
         assert "UNAUTHORIZED" in body

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1,0 +1,30 @@
+import json
+
+from app.mcp.server import start_server, stop_server
+from tests.mcp_utils import _request, _wait_until_ready
+
+
+def test_background_server_health_endpoint():
+    port = 8125
+    stop_server()
+    start_server(port=port)
+    try:
+        _wait_until_ready(port)
+        status, body = _request(port)
+        assert status == 200
+        assert json.loads(body) == {"status": "ok"}
+    finally:
+        stop_server()
+
+
+def test_missing_token_results_in_unauthorized():
+    port = 8126
+    stop_server()
+    start_server(port=port, token="secret")
+    try:
+        _wait_until_ready(port)
+        status, body = _request(port)
+        assert status == 401
+        assert "UNAUTHORIZED" in body
+    finally:
+        stop_server()


### PR DESCRIPTION
## Summary
- consolidate MCP test helper functions into `tests/mcp_utils.py`
- reuse shared helpers across MCP test modules
- add pytest hooks to always print final test summary in quiet mode

## Testing
- `pytest -q`
- `pytest tests/test_mcp_server.py -vv`


------
https://chatgpt.com/codex/tasks/task_e_68c4753e07148320bcdbbe4a5dacd652