### PR TITLE
feat(mcp): unify tool error handling

### DIFF
--- a/app/mcp/server.py
+++ b/app/mcp/server.py
@@ -20,6 +20,7 @@ from fastapi.responses import JSONResponse
 import uvicorn
 from mcp.server.fastmcp import FastMCP
 from app.log import configure_logging, logger
+from app.mcp.utils import ErrorCode, mcp_error
 
 # Public FastAPI application and MCP server instances -----------------------
 
@@ -100,7 +101,10 @@ async def auth_middleware(request: Request, call_next):
     if token:
         header = request.headers.get("Authorization")
         if header != f"Bearer {token}":
-            response = JSONResponse({"error": "UNAUTHORIZED"}, status_code=401)
+            response = JSONResponse(
+                mcp_error(ErrorCode.UNAUTHORIZED, "unauthorized"),
+                status_code=401,
+            )
             _log_request(request, response.status_code)
             return response
     response = await call_next(request)

--- a/app/mcp/tools_write.py
+++ b/app/mcp/tools_write.py
@@ -13,6 +13,7 @@ from app.core.store import (
     filename_for,
     ConflictError,
 )
+from app.mcp.utils import ErrorCode, mcp_error
 
 # Fields that must not be modified directly through patching
 UNPATCHABLE_FIELDS = {"id", "revision", "derived_from"}
@@ -34,8 +35,15 @@ def create_requirement(directory: str | Path, data: Mapping[str, Any]) -> dict:
     """
     req = dict(data)
     req["revision"] = 1
-    obj = requirement_from_dict(req)
-    save(directory, obj)
+    try:
+        obj = requirement_from_dict(req)
+        save(directory, obj)
+    except ConflictError as exc:
+        return mcp_error(ErrorCode.CONFLICT, str(exc))
+    except (ValueError, KeyError) as exc:
+        return mcp_error(ErrorCode.VALIDATION_ERROR, str(exc))
+    except Exception as exc:  # pragma: no cover - defensive
+        return mcp_error(ErrorCode.INTERNAL, str(exc))
     return requirement_to_dict(obj)
 
 
@@ -51,31 +59,50 @@ def patch_requirement(
     ``rev`` must match the current revision. ``id`` and other service fields are
     immutable. Returns the updated requirement as a dictionary.
     """
-    data, mtime = _load_requirement(directory, req_id)
+    try:
+        data, mtime = _load_requirement(directory, req_id)
+    except FileNotFoundError:
+        return mcp_error(ErrorCode.NOT_FOUND, f"requirement {req_id} not found")
     current = data.get("revision")
     if current != rev:
-        raise ConflictError(f"revision mismatch: expected {rev}, have {current}")
+        return mcp_error(ErrorCode.CONFLICT, f"revision mismatch: expected {rev}, have {current}")
 
     for field in patches:
         if field in UNPATCHABLE_FIELDS:
-            raise ValueError(f"field is read-only: {field}")
+            return mcp_error(ErrorCode.VALIDATION_ERROR, f"field is read-only: {field}")
         if field not in KNOWN_FIELDS:
-            raise KeyError(field)
+            return mcp_error(ErrorCode.VALIDATION_ERROR, f"unknown field: {field}")
 
     data.update(patches)
     data["revision"] = current + 1
-    obj = requirement_from_dict(data)
-    save(directory, obj, mtime=mtime)
+    try:
+        obj = requirement_from_dict(data)
+        save(directory, obj, mtime=mtime)
+    except ConflictError as exc:
+        return mcp_error(ErrorCode.CONFLICT, str(exc))
+    except (ValueError, KeyError) as exc:
+        return mcp_error(ErrorCode.VALIDATION_ERROR, str(exc))
+    except Exception as exc:  # pragma: no cover - defensive
+        return mcp_error(ErrorCode.INTERNAL, str(exc))
     return requirement_to_dict(obj)
 
 
-def delete_requirement(directory: str | Path, req_id: int, *, rev: int) -> None:
+def delete_requirement(directory: str | Path, req_id: int, *, rev: int) -> dict | None:
     """Delete requirement ``req_id`` from ``directory`` if ``rev`` matches."""
-    data, _ = _load_requirement(directory, req_id)
+    try:
+        data, _ = _load_requirement(directory, req_id)
+    except FileNotFoundError:
+        return mcp_error(ErrorCode.NOT_FOUND, f"requirement {req_id} not found")
     current = data.get("revision")
     if current != rev:
-        raise ConflictError(f"revision mismatch: expected {rev}, have {current}")
-    delete_file(directory, req_id)
+        return mcp_error(ErrorCode.CONFLICT, f"revision mismatch: expected {rev}, have {current}")
+    try:
+        delete_file(directory, req_id)
+    except FileNotFoundError:
+        return mcp_error(ErrorCode.NOT_FOUND, f"requirement {req_id} not found")
+    except Exception as exc:  # pragma: no cover - defensive
+        return mcp_error(ErrorCode.INTERNAL, str(exc))
+    return {"id": req_id}
 
 
 def link_requirements(
@@ -91,18 +118,31 @@ def link_requirements(
     the current revision of the source requirement. Returns the updated derived
     requirement as a dictionary.
     """
-    src_data, _ = _load_requirement(directory, source_id)
+    try:
+        src_data, _ = _load_requirement(directory, source_id)
+    except FileNotFoundError:
+        return mcp_error(ErrorCode.NOT_FOUND, f"requirement {source_id} not found")
     src_revision = src_data.get("revision", 1)
 
-    data, mtime = _load_requirement(directory, derived_id)
+    try:
+        data, mtime = _load_requirement(directory, derived_id)
+    except FileNotFoundError:
+        return mcp_error(ErrorCode.NOT_FOUND, f"requirement {derived_id} not found")
     current = data.get("revision")
     if current != rev:
-        raise ConflictError(f"revision mismatch: expected {rev}, have {current}")
+        return mcp_error(ErrorCode.CONFLICT, f"revision mismatch: expected {rev}, have {current}")
 
     links = [l for l in data.get("derived_from", []) if l.get("source_id") != source_id]
     links.append({"source_id": source_id, "source_revision": src_revision, "suspect": False})
     data["derived_from"] = links
     data["revision"] = current + 1
-    obj = requirement_from_dict(data)
-    save(directory, obj, mtime=mtime)
+    try:
+        obj = requirement_from_dict(data)
+        save(directory, obj, mtime=mtime)
+    except ConflictError as exc:
+        return mcp_error(ErrorCode.CONFLICT, str(exc))
+    except (ValueError, KeyError) as exc:
+        return mcp_error(ErrorCode.VALIDATION_ERROR, str(exc))
+    except Exception as exc:  # pragma: no cover - defensive
+        return mcp_error(ErrorCode.INTERNAL, str(exc))
     return requirement_to_dict(obj)

--- a/app/mcp/utils.py
+++ b/app/mcp/utils.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from enum import Enum
+from typing import Any, Mapping
+
+
+class ErrorCode(str, Enum):
+    """Standardized error codes for MCP tools."""
+
+    VALIDATION_ERROR = "VALIDATION_ERROR"
+    CONFLICT = "CONFLICT"
+    NOT_FOUND = "NOT_FOUND"
+    UNAUTHORIZED = "UNAUTHORIZED"
+    INTERNAL = "INTERNAL"
+
+
+def mcp_error(code: ErrorCode | str, message: str, details: Mapping[str, Any] | None = None) -> dict[str, Any]:
+    """Return a structured error payload for MCP responses."""
+
+    code_str = code.value if isinstance(code, ErrorCode) else str(code)
+    err: dict[str, Any] = {"code": code_str, "message": message}
+    if details:
+        err["details"] = dict(details)
+    return {"error": err}


### PR DESCRIPTION
## Summary
- add ErrorCode enum and mcp_error helper for structured MCP errors
- use mcp_error across read/write tools and server auth middleware
- adjust requirement operation tests for new error format

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c47f11765083208aa4ca862f4f40b4