### PR TITLE
feat: apply JSON Patch in requirement API

### DIFF
--- a/app/mcp/server.py
+++ b/app/mcp/server.py
@@ -185,13 +185,13 @@ def create_requirement(data: Mapping[str, object]) -> dict:
 @mcp_server.tool()
 def patch_requirement(
     req_id: int,
-    patches: Mapping[str, object],
+    patch: list[dict],
     *,
     rev: int,
 ) -> dict:
-    """Apply patches to a requirement."""
+    """Apply JSON Patch to a requirement."""
     directory = app.state.base_path
-    return tools_write.patch_requirement(directory, req_id, patches, rev=rev)
+    return tools_write.patch_requirement(directory, req_id, patch, rev=rev)
 
 
 @mcp_server.tool()

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ pydot>=1.4
 fastapi
 uvicorn
 mcp
+jsonpatch

--- a/tests/test_mcp_http_tools.py
+++ b/tests/test_mcp_http_tools.py
@@ -105,7 +105,11 @@ def test_patch_requirement_via_http(tmp_path: Path) -> None:
     start_server(port=port, base_path=str(tmp_path))
     try:
         _wait_until_ready(port)
-        status, body = _call_tool(port, "patch_requirement", {"req_id": 1, "patches": {"title": "A2"}, "rev": 1})
+        status, body = _call_tool(
+            port,
+            "patch_requirement",
+            {"req_id": 1, "patch": [{"op": "replace", "path": "/title", "value": "A2"}], "rev": 1},
+        )
         assert status == 200
         assert body["title"] == "A2"
         assert body["revision"] == 2


### PR DESCRIPTION
## Summary
- use RFC 6902 JSON Patch for requirement updates
- validate patch operations and forbid editing id, revision or derived_from
- cover new behaviour with tests and add jsonpatch dependency

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c48a6474748320bf4f1866da6fe27a