### PR TITLE
Extend requirement links to support multiple relationship types

### DIFF
--- a/app/core/schema.py
+++ b/app/core/schema.py
@@ -71,6 +71,45 @@ SCHEMA: dict[str, Any] = {
                 },
             },
         },
+        "parent": {
+            "type": "object",
+            "required": ["source_id", "source_revision"],
+            "properties": {
+                "source_id": {"type": "integer"},
+                "source_revision": {"type": "integer"},
+                "suspect": {"type": "boolean"},
+            },
+        },
+        "links": {
+            "type": "object",
+            "properties": {
+                "verifies": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "required": ["source_id", "source_revision"],
+                        "properties": {
+                            "source_id": {"type": "integer"},
+                            "source_revision": {"type": "integer"},
+                            "suspect": {"type": "boolean"},
+                        },
+                    },
+                },
+                "relates": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "required": ["source_id", "source_revision"],
+                        "properties": {
+                            "source_id": {"type": "integer"},
+                            "source_revision": {"type": "integer"},
+                            "suspect": {"type": "boolean"},
+                        },
+                    },
+                },
+            },
+            "additionalProperties": False,
+        },
         "derivation": {
             "type": "object",
             "required": ["rationale", "assumptions", "method", "margin"],

--- a/app/mcp/server.py
+++ b/app/mcp/server.py
@@ -206,6 +206,7 @@ def link_requirements(
     *,
     source_id: int,
     derived_id: int,
+    link_type: str,
     rev: int,
 ) -> dict:
     """Link one requirement to another."""
@@ -214,6 +215,7 @@ def link_requirements(
         directory,
         source_id=source_id,
         derived_id=derived_id,
+        link_type=link_type,
         rev=rev,
     )
 

--- a/tests/test_mcp_http_tools.py
+++ b/tests/test_mcp_http_tools.py
@@ -140,7 +140,7 @@ def test_link_requirements_via_http(tmp_path: Path) -> None:
     start_server(port=port, base_path=str(tmp_path))
     try:
         _wait_until_ready(port)
-        status, body = _call_tool(port, "link_requirements", {"source_id": 1, "derived_id": 2, "rev": 1})
+        status, body = _call_tool(port, "link_requirements", {"source_id": 1, "derived_id": 2, "link_type": "derived_from", "rev": 1})
         assert status == 200
         assert body["revision"] == 2
         assert body["derived_from"] == [{"source_id": 1, "source_revision": 1, "suspect": False}]


### PR DESCRIPTION
## Summary
- add generic `RequirementLink` and `Links` models with `parent`, `derived_from`, `verifies`, and `relates`
- allow `link_requirements` tool to accept a `link_type` parameter and update the proper field
- validate and persist the new link types, updating schema, store, and server interfaces

## Testing
- `python3 -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c48bb41c9c8320b2e53a8f6272f15f