### PR TITLE
Log MCP tool usage to JSONL

### DIFF
--- a/app/mcp/server.py
+++ b/app/mcp/server.py
@@ -21,7 +21,7 @@ import uvicorn
 from mcp.server.fastmcp import FastMCP
 
 from app.log import configure_logging, logger
-from app.mcp.utils import ErrorCode, mcp_error
+from app.mcp.utils import ErrorCode, mcp_error, sanitize
 from app.mcp import tools_read, tools_write
 
 # Public FastAPI application and MCP server instances -----------------------
@@ -34,9 +34,6 @@ app.state.log_dir = "."
 
 _TEXT_LOG_NAME = "server.log"
 _JSONL_LOG_NAME = "server.jsonl"
-_SENSITIVE_KEYS = {"authorization", "token", "secret", "password", "api_key", "cookie"}
-
-
 class JsonlHandler(logging.Handler):
     """Write log records as JSON lines."""
 
@@ -78,13 +75,9 @@ def _configure_request_logging(log_dir: str) -> None:
     logger.addHandler(json_handler)
 
 
-def _sanitize(data: Mapping[str, str]) -> dict[str, str]:
-    return {k: ("***" if k.lower() in _SENSITIVE_KEYS else v) for k, v in data.items()}
-
-
 def _log_request(request: Request, status: int) -> None:
-    headers = _sanitize(dict(request.headers))
-    query = _sanitize(dict(request.query_params))
+    headers = sanitize(dict(request.headers))
+    query = sanitize(dict(request.query_params))
     entry = {
         "timestamp": datetime.datetime.now(datetime.UTC).isoformat(),
         "method": request.method,

--- a/tests/test_tool_logging.py
+++ b/tests/test_tool_logging.py
@@ -1,0 +1,43 @@
+import json
+from pathlib import Path
+
+import logging
+
+from app.log import logger
+from app.mcp.server import JsonlHandler
+from app.mcp.tools_read import list_requirements
+from app.mcp.utils import log_tool
+
+def test_tool_logging(tmp_path: Path) -> None:
+    log_file = tmp_path / "server.jsonl"
+    handler = JsonlHandler(str(log_file))
+    logger.addHandler(handler)
+    prev_level = logger.level
+    logger.setLevel(logging.INFO)
+    try:
+        result = list_requirements(tmp_path)
+    finally:
+        logger.setLevel(prev_level)
+        logger.removeHandler(handler)
+    data = json.loads(log_file.read_text().splitlines()[0])
+    assert data["tool"] == "list_requirements"
+    assert data["params"]["directory"] == str(tmp_path)
+    assert "result" in data
+    assert data["result"] == result
+    assert "timestamp" in data
+
+
+def test_log_tool_sanitizes_and_truncates(tmp_path: Path) -> None:
+    log_file = tmp_path / "server.jsonl"
+    handler = JsonlHandler(str(log_file))
+    logger.addHandler(handler)
+    prev_level = logger.level
+    logger.setLevel(logging.INFO)
+    try:
+        log_tool("dummy", {"token": "secret"}, "x" * 20, max_result_length=10)
+    finally:
+        logger.setLevel(prev_level)
+        logger.removeHandler(handler)
+    data = json.loads(log_file.read_text().splitlines()[0])
+    assert data["params"]["token"] == "***"
+    assert data["result"] == "xxxxxxxxxx..."


### PR DESCRIPTION
## Summary
- centralize tool logging with `log_tool` helper and optional truncation of long results
- update MCP read/write tools to reuse shared logger
- extend tests to cover parameter masking and result size limits

## Testing
- `python3 -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c48dea6b1883209a082ec7ae931fd3