### PR TITLE
feat: add OpenAI-compatible LLM client

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -89,6 +89,22 @@ class ConfigManager:
         self._cfg.Flush()
 
     # ------------------------------------------------------------------
+    # LLM client settings
+    def get_llm_settings(self) -> tuple[str, str, str, int]:
+        api_base = self._cfg.Read("llm_api_base", "")
+        model = self._cfg.Read("llm_model", "")
+        api_key = self._cfg.Read("llm_api_key", "")
+        timeout = self._cfg.ReadInt("llm_timeout", 60)
+        return api_base, model, api_key, timeout
+
+    def set_llm_settings(self, api_base: str, model: str, api_key: str, timeout: int) -> None:
+        self._cfg.Write("llm_api_base", api_base)
+        self._cfg.Write("llm_model", model)
+        self._cfg.Write("llm_api_key", api_key)
+        self._cfg.WriteInt("llm_timeout", timeout)
+        self._cfg.Flush()
+
+    # ------------------------------------------------------------------
     # sort settings
     def get_sort_settings(self) -> tuple[int, bool]:
         column = self._cfg.ReadInt("sort_column", -1)

--- a/app/llm/__init__.py
+++ b/app/llm/__init__.py
@@ -1,0 +1,5 @@
+"""LLM integration utilities."""
+
+from .client import LLMClient
+
+__all__ = ["LLMClient"]

--- a/app/llm/client.py
+++ b/app/llm/client.py
@@ -1,0 +1,70 @@
+"""Client for interacting with an OpenAI-compatible LLM API."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import wx
+from openai import OpenAI
+
+from app.log import logger
+
+
+@dataclass
+class LLMSettings:
+    """Settings for connecting to an LLM service."""
+
+    api_base: str
+    model: str
+    api_key: str
+    timeout: int
+
+    @classmethod
+    def from_config(cls, cfg: wx.Config) -> "LLMSettings":
+        """Load settings from ``wx.Config`` instance."""
+        return cls(
+            api_base=cfg.Read("llm_api_base", ""),
+            model=cfg.Read("llm_model", ""),
+            api_key=cfg.Read("llm_api_key", ""),
+            timeout=cfg.ReadInt("llm_timeout", 60),
+        )
+
+
+class LLMClient:
+    """High-level client for LLM operations."""
+
+    def __init__(self, cfg: wx.Config) -> None:
+        self.settings = LLMSettings.from_config(cfg)
+        self._client = OpenAI(
+            base_url=self.settings.api_base or None,
+            api_key=self.settings.api_key or None,
+            timeout=self.settings.timeout,
+        )
+
+    # ------------------------------------------------------------------
+    def check_llm(self) -> dict[str, Any]:
+        """Perform a minimal request to verify connectivity."""
+        request_entry = {
+            "event": "LLM_REQUEST",
+            "api_base": self.settings.api_base,
+            "model": self.settings.model,
+            "api_key": "[REDACTED]",
+        }
+        logger.info("LLM_REQUEST", extra={"json": request_entry})
+        try:
+            self._client.chat.completions.create(
+                model=self.settings.model,
+                messages=[{"role": "user", "content": "ping"}],
+                max_tokens=1,
+            )
+        except Exception as exc:  # pragma: no cover - network errors
+            response_entry = {
+                "event": "LLM_RESPONSE",
+                "error": {"type": type(exc).__name__, "message": str(exc)},
+            }
+            logger.info("LLM_RESPONSE", extra={"json": response_entry})
+            return {"ok": False, "error": response_entry["error"]}
+        response_entry = {"event": "LLM_RESPONSE", "ok": True}
+        logger.info("LLM_RESPONSE", extra={"json": response_entry})
+        return {"ok": True}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
     "fastapi",
     "uvicorn",
     "mcp",
+    "openai",
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ fastapi
 uvicorn
 mcp
 jsonpatch
+openai


### PR DESCRIPTION
## Summary
- add LLM client that reads API settings from wx.Config
- log sanitized LLM requests/responses and provide connectivity check
- expose LLM settings in ConfigManager and declare `openai` dependency

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c4fb3afd4883208766d1ce10fb0ec4