### PR TITLE
Add detailed JSONL logging for LLM and MCP

### DIFF
--- a/app/mcp/server.py
+++ b/app/mcp/server.py
@@ -20,7 +20,7 @@ from fastapi.responses import JSONResponse
 import uvicorn
 from mcp.server.fastmcp import FastMCP
 
-from app.log import configure_logging, logger
+from app.log import JsonlHandler, configure_logging, logger
 from app.mcp.utils import ErrorCode, mcp_error, sanitize
 from app.mcp import tools_read, tools_write
 
@@ -34,23 +34,6 @@ app.state.log_dir = "."
 
 _TEXT_LOG_NAME = "server.log"
 _JSONL_LOG_NAME = "server.jsonl"
-class JsonlHandler(logging.Handler):
-    """Write log records as JSON lines."""
-
-    def __init__(self, filename: str) -> None:
-        super().__init__(level=logging.INFO)
-        self.filename = filename
-
-    def emit(self, record: logging.LogRecord) -> None:  # pragma: no cover - simple IO
-        data = getattr(record, "json", None)
-        if data is None:
-            data = {
-                "message": record.getMessage(),
-                "level": record.levelname,
-            }
-        with open(self.filename, "a", encoding="utf-8") as fh:
-            json.dump(data, fh, ensure_ascii=False)
-            fh.write("\n")
 
 
 def _configure_request_logging(log_dir: str) -> None:

--- a/app/mcp/utils.py
+++ b/app/mcp/utils.py
@@ -7,28 +7,7 @@ from enum import Enum
 from typing import Any, Mapping
 
 from app.log import logger
-
-# Common keys that may contain sensitive information and should be redacted
-SENSITIVE_KEYS = {
-    "authorization",
-    "token",
-    "secret",
-    "password",
-    "api_key",
-    "cookie",
-}
-
-
-def sanitize(data: Mapping[str, Any]) -> dict[str, Any]:
-    """Return a copy of *data* with sensitive keys redacted."""
-
-    sanitized: dict[str, Any] = {}
-    for key, value in data.items():
-        if key.lower() in SENSITIVE_KEYS:
-            sanitized[key] = "***"
-        else:
-            sanitized[key] = value
-    return sanitized
+from app.telemetry import sanitize
 
 
 def log_tool(

--- a/app/telemetry.py
+++ b/app/telemetry.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import datetime
+import json
+import time
+from typing import Any, Mapping
+
+from app.log import logger
+
+# Keys that should be redacted when logging
+SENSITIVE_KEYS = {
+    "authorization",
+    "token",
+    "secret",
+    "password",
+    "api_key",
+    "cookie",
+}
+
+REDACTED = "[REDACTED]"
+
+
+def sanitize(data: Mapping[str, Any]) -> dict[str, Any]:
+    """Return a copy of *data* with sensitive keys replaced by ``[REDACTED]``."""
+
+    sanitized: dict[str, Any] = {}
+    for key, value in data.items():
+        if key.lower() in SENSITIVE_KEYS:
+            sanitized[key] = REDACTED
+        else:
+            sanitized[key] = value
+    return sanitized
+
+
+def log_event(
+    event: str,
+    payload: Mapping[str, Any] | None = None,
+    *,
+    start_time: float | None = None,
+) -> None:
+    """Log an event to the application logger.
+
+    Parameters
+    ----------
+    event:
+        The event type, e.g. ``"LLM_REQUEST"``.
+    payload:
+        Structured data associated with the event. Sensitive keys are redacted
+        automatically.
+    start_time:
+        Optional monotonic start time; if provided the elapsed time in
+        milliseconds is included in the log entry.
+    """
+
+    data: dict[str, Any] = {"event": event}
+    if payload:
+        sanitized = sanitize(dict(payload))
+        data["payload"] = sanitized
+        data["size_bytes"] = len(json.dumps(sanitized, ensure_ascii=False).encode("utf-8"))
+    else:
+        data["payload"] = {}
+        data["size_bytes"] = 0
+    if start_time is not None:
+        data["duration_ms"] = int((time.monotonic() - start_time) * 1000)
+    logger.info(event, extra={"json": data})

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -27,5 +27,7 @@ def test_check_llm(tmp_path: Path) -> None:
     entries = [json.loads(line) for line in log_file.read_text().splitlines()]
     req = next(e for e in entries if e.get("event") == "LLM_REQUEST")
     res = next(e for e in entries if e.get("event") == "LLM_RESPONSE")
-    assert req["api_key"] == "[REDACTED]"
-    assert res["ok"] is True
+    assert req["payload"]["api_key"] == "[REDACTED]"
+    assert res["payload"]["ok"] is True
+    assert "timestamp" in req and "size_bytes" in req
+    assert "duration_ms" in res

--- a/tests/test_mcp_client.py
+++ b/tests/test_mcp_client.py
@@ -45,8 +45,9 @@ def test_check_tools_success(tmp_path: Path) -> None:
         entries = [json.loads(line) for line in lines]
         call = next(e for e in entries if e.get("event") == "TOOL_CALL")
         res = next(e for e in entries if e.get("event") == "TOOL_RESULT")
-        assert call["params"]["token"] == "***"
-        assert res["ok"] is True
+        assert call["payload"]["params"]["token"] == "[REDACTED]"
+        assert res["payload"]["ok"] is True
+        assert "duration_ms" in res
     finally:
         stop_server()
 

--- a/tests/test_mcp_logging.py
+++ b/tests/test_mcp_logging.py
@@ -33,5 +33,5 @@ def test_request_logged_and_token_masked():
         entry = json.loads(line)
         headers = entry["headers"]
         auth = headers.get("Authorization") or headers.get("authorization")
-        assert auth == "***"
+        assert auth == "[REDACTED]"
         assert "secret" not in json.dumps(entry)

--- a/tests/test_tool_logging.py
+++ b/tests/test_tool_logging.py
@@ -39,5 +39,5 @@ def test_log_tool_sanitizes_and_truncates(tmp_path: Path) -> None:
         logger.setLevel(prev_level)
         logger.removeHandler(handler)
     data = json.loads(log_file.read_text().splitlines()[0])
-    assert data["params"]["token"] == "***"
+    assert data["params"]["token"] == "[REDACTED]"
     assert data["result"] == "xxxxxxxxxx..."


### PR DESCRIPTION
## Summary
- centralize JSON lines logging with timestamped `JsonlHandler`
- add telemetry module with secret redaction and structured event logging
- record request/response payloads, sizes, and durations for LLM and MCP clients
- mask sensitive data uniformly in server logs and tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c50fa711648320a30590856af44ec7