### PR TITLE
feat: add MCP server controls

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -74,17 +74,21 @@ class ConfigManager:
 
     # ------------------------------------------------------------------
     # MCP server settings
-    def get_mcp_settings(self) -> tuple[str, int, str, str]:
+    def get_mcp_settings(self) -> tuple[str, int, str, bool, str]:
         host = self._cfg.Read("mcp_host", "127.0.0.1")
         port = self._cfg.ReadInt("mcp_port", 8000)
         base_path = self._cfg.Read("mcp_base_path", "")
+        require_token = self._cfg.ReadBool("mcp_require_token", False)
         token = self._cfg.Read("mcp_token", "")
-        return host, port, base_path, token
+        return host, port, base_path, require_token, token
 
-    def set_mcp_settings(self, host: str, port: int, base_path: str, token: str) -> None:
+    def set_mcp_settings(
+        self, host: str, port: int, base_path: str, require_token: bool, token: str
+    ) -> None:
         self._cfg.Write("mcp_host", host)
         self._cfg.WriteInt("mcp_port", port)
         self._cfg.Write("mcp_base_path", base_path)
+        self._cfg.WriteBool("mcp_require_token", require_token)
         self._cfg.Write("mcp_token", token)
         self._cfg.Flush()
 

--- a/app/mcp/client.py
+++ b/app/mcp/client.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-from dataclasses import dataclass
 from http.client import HTTPConnection
 from typing import Any, Mapping
 
@@ -9,28 +8,7 @@ import wx
 
 from app.log import logger
 from app.mcp.utils import ErrorCode, mcp_error, sanitize
-
-
-@dataclass
-class MCPSettings:
-    """Settings for connecting to the MCP server."""
-
-    host: str
-    port: int
-    base_path: str
-    require_token: bool
-    token: str
-
-    @classmethod
-    def from_config(cls, cfg: wx.Config) -> "MCPSettings":
-        """Load settings from ``wx.Config`` instance."""
-        return cls(
-            host=cfg.Read("mcp_host", "127.0.0.1"),
-            port=cfg.ReadInt("mcp_port", 8000),
-            base_path=cfg.Read("mcp_base_path", ""),
-            require_token=cfg.ReadBool("mcp_require_token", False),
-            token=cfg.Read("mcp_token", ""),
-        )
+from app.mcp.settings import MCPSettings
 
 
 class MCPClient:

--- a/app/mcp/client.py
+++ b/app/mcp/client.py
@@ -18,6 +18,7 @@ class MCPSettings:
     host: str
     port: int
     base_path: str
+    require_token: bool
     token: str
 
     @classmethod
@@ -27,6 +28,7 @@ class MCPSettings:
             host=cfg.Read("mcp_host", "127.0.0.1"),
             port=cfg.ReadInt("mcp_port", 8000),
             base_path=cfg.Read("mcp_base_path", ""),
+            require_token=cfg.ReadBool("mcp_require_token", False),
             token=cfg.Read("mcp_token", ""),
         )
 
@@ -53,7 +55,7 @@ class MCPClient:
             "host": self.settings.host,
             "port": self.settings.port,
             "base_path": self.settings.base_path,
-            "token": self.settings.token,
+            "token": self.settings.token if self.settings.require_token else "",
         }
         logger.info(
             "TOOL_CALL",
@@ -73,7 +75,7 @@ class MCPClient:
                     {"name": "list_requirements", "arguments": {"per_page": 1}}
                 )
                 headers = {"Content-Type": "application/json"}
-                if self.settings.token:
+                if self.settings.require_token and self.settings.token:
                     headers["Authorization"] = f"Bearer {self.settings.token}"
                 conn.request("POST", path, body=payload, headers=headers)
                 resp = conn.getresponse()
@@ -121,7 +123,7 @@ class MCPClient:
             try:
                 payload = json.dumps({"name": name, "arguments": dict(arguments)})
                 headers = {"Content-Type": "application/json"}
-                if self.settings.token:
+                if self.settings.require_token and self.settings.token:
                     headers["Authorization"] = f"Bearer {self.settings.token}"
                 conn.request("POST", "/mcp", body=payload, headers=headers)
                 resp = conn.getresponse()

--- a/app/mcp/controller.py
+++ b/app/mcp/controller.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from enum import Enum
+from http.client import HTTPConnection
+
+from app.mcp.server import start_server, stop_server, is_running as server_is_running
+from app.mcp.settings import MCPSettings
+
+
+class MCPStatus(str, Enum):
+    """Status values returned by :class:`MCPController`."""
+
+    NOT_RUNNING = "not running"
+    READY = "ready"
+    ERROR = "error"
+
+
+class MCPController:
+    """Service layer controlling the MCP server."""
+
+    def start(self, settings: MCPSettings) -> None:
+        token = settings.token if settings.require_token else ""
+        start_server(settings.host, settings.port, settings.base_path, token)
+
+    def stop(self) -> None:
+        stop_server()
+
+    def is_running(self) -> bool:
+        return server_is_running()
+
+    def check(self, settings: MCPSettings) -> MCPStatus:
+        headers = {}
+        if settings.require_token and settings.token:
+            headers["Authorization"] = f"Bearer {settings.token}"
+        try:
+            conn = HTTPConnection(settings.host, settings.port, timeout=2)
+            try:
+                conn.request("GET", "/health", headers=headers)
+                resp = conn.getresponse()
+                resp.read()
+                if resp.status == 200:
+                    return MCPStatus.READY
+                return MCPStatus.ERROR
+            finally:
+                conn.close()
+        except Exception:
+            return MCPStatus.NOT_RUNNING

--- a/app/mcp/server.py
+++ b/app/mcp/server.py
@@ -266,6 +266,11 @@ _uvicorn_server: Optional[uvicorn.Server] = None
 _server_thread: Optional[threading.Thread] = None
 
 
+def is_running() -> bool:
+    """Return ``True`` if the MCP server is currently running."""
+    return _uvicorn_server is not None
+
+
 def start_server(
     host: str = "127.0.0.1",
     port: int = 8000,

--- a/app/mcp/settings.py
+++ b/app/mcp/settings.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import wx
+
+
+@dataclass
+class MCPSettings:
+    """Settings for configuring the MCP server and client."""
+
+    host: str
+    port: int
+    base_path: str
+    require_token: bool
+    token: str
+
+    @classmethod
+    def from_config(cls, cfg: wx.Config) -> "MCPSettings":
+        """Load settings from a :class:`wx.Config` instance."""
+        return cls(
+            host=cfg.Read("mcp_host", "127.0.0.1"),
+            port=cfg.ReadInt("mcp_port", 8000),
+            base_path=cfg.Read("mcp_base_path", ""),
+            require_token=cfg.ReadBool("mcp_require_token", False),
+            token=cfg.Read("mcp_token", ""),
+        )

--- a/app/ui/main_frame.py
+++ b/app/ui/main_frame.py
@@ -66,8 +66,19 @@ class MainFrame(wx.Frame):
         self.remember_sort = self.config.get_remember_sort()
         self.language = self.config.get_language()
         self.sort_column, self.sort_ascending = self.config.get_sort_settings()
-        self.mcp_host, self.mcp_port, self.mcp_base_path, self.mcp_token = self.config.get_mcp_settings()
-        start_server(self.mcp_host, self.mcp_port, self.mcp_base_path, self.mcp_token)
+        (
+            self.mcp_host,
+            self.mcp_port,
+            self.mcp_base_path,
+            self.mcp_require_token,
+            self.mcp_token,
+        ) = self.config.get_mcp_settings()
+        start_server(
+            self.mcp_host,
+            self.mcp_port,
+            self.mcp_base_path,
+            self.mcp_token if self.mcp_require_token else "",
+        )
         self.labels: list[Label] = []
         super().__init__(parent=parent, title=self._base_title)
         # Load all available icon sizes so that Windows taskbar and other
@@ -165,6 +176,7 @@ class MainFrame(wx.Frame):
             host=self.mcp_host,
             port=self.mcp_port,
             base_path=self.mcp_base_path,
+            require_token=self.mcp_require_token,
             token=self.mcp_token,
         )
         if dlg.ShowModal() == wx.ID_OK:
@@ -175,22 +187,35 @@ class MainFrame(wx.Frame):
                 host,
                 port,
                 base_path,
+                require_token,
                 token,
             ) = dlg.get_values()
             changed = (
                 host != self.mcp_host
                 or port != self.mcp_port
                 or base_path != self.mcp_base_path
+                or require_token != self.mcp_require_token
                 or token != self.mcp_token
             )
-            self.mcp_host, self.mcp_port, self.mcp_base_path, self.mcp_token = host, port, base_path, token
+            self.mcp_host, self.mcp_port, self.mcp_base_path, self.mcp_require_token, self.mcp_token = (
+                host,
+                port,
+                base_path,
+                require_token,
+                token,
+            )
             self.config.set_auto_open_last(self.auto_open_last)
             self.config.set_remember_sort(self.remember_sort)
             self.config.set_language(self.language)
-            self.config.set_mcp_settings(host, port, base_path, token)
+            self.config.set_mcp_settings(host, port, base_path, require_token, token)
             if changed:
                 stop_server()
-                start_server(self.mcp_host, self.mcp_port, self.mcp_base_path, self.mcp_token)
+                start_server(
+                    self.mcp_host,
+                    self.mcp_port,
+                    self.mcp_base_path,
+                    self.mcp_token if self.mcp_require_token else "",
+                )
             self._apply_language()
         dlg.Destroy()
 

--- a/app/ui/settings_dialog.py
+++ b/app/ui/settings_dialog.py
@@ -1,9 +1,12 @@
-"""Dialog for application settings."""
+"""Dialog for application settings with MCP controls."""
 
 from gettext import gettext as _
 from importlib import resources
+from http.client import HTTPConnection
 
 import wx
+
+from app.mcp.server import is_running, start_server, stop_server
 
 
 def available_translations() -> list[tuple[str, str]]:
@@ -20,7 +23,7 @@ def available_translations() -> list[tuple[str, str]]:
 
 
 class SettingsDialog(wx.Dialog):
-    """Simple dialog with application preferences."""
+    """Dialog providing general preferences and MCP server controls."""
 
     def __init__(
         self,
@@ -32,58 +35,137 @@ class SettingsDialog(wx.Dialog):
         host: str,
         port: int,
         base_path: str,
+        require_token: bool,
         token: str,
     ) -> None:
         super().__init__(parent, title=_("Settings"))
-        self._open_last = wx.CheckBox(self, label=_("Open last folder on startup"))
-        self._open_last.SetValue(open_last)
-        self._remember_sort = wx.CheckBox(self, label=_("Remember sort order"))
-        self._remember_sort.SetValue(remember_sort)
 
-        self._host = wx.TextCtrl(self, value=host)
-        self._port = wx.SpinCtrl(self, min=1, max=65535, initial=port)
-        self._base_path = wx.TextCtrl(self, value=base_path)
-        self._token = wx.TextCtrl(self, value=token)
-
+        # General settings -------------------------------------------------
         self._languages = available_translations()
         choices = [name for _, name in self._languages]
-        self._language_choice = wx.Choice(self, choices=choices)
         try:
             idx = [code for code, _ in self._languages].index(language)
         except ValueError:
             idx = 0
+
+        nb = wx.Notebook(self)
+        general = wx.Panel(nb)
+        self._open_last = wx.CheckBox(general, label=_("Open last folder on startup"))
+        self._open_last.SetValue(open_last)
+        self._remember_sort = wx.CheckBox(general, label=_("Remember sort order"))
+        self._remember_sort.SetValue(remember_sort)
+        self._language_choice = wx.Choice(general, choices=choices)
         self._language_choice.SetSelection(idx)
 
-        sizer = wx.BoxSizer(wx.VERTICAL)
-        sizer.Add(self._open_last, 0, wx.ALL, 5)
-        sizer.Add(self._remember_sort, 0, wx.ALL, 5)
-        host_sizer = wx.BoxSizer(wx.HORIZONTAL)
-        host_sizer.Add(wx.StaticText(self, label=_("Host")), 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, 5)
-        host_sizer.Add(self._host, 1, wx.ALIGN_CENTER_VERTICAL)
-        sizer.Add(host_sizer, 0, wx.ALL | wx.EXPAND, 5)
-        port_sizer = wx.BoxSizer(wx.HORIZONTAL)
-        port_sizer.Add(wx.StaticText(self, label=_("Port")), 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, 5)
-        port_sizer.Add(self._port, 1, wx.ALIGN_CENTER_VERTICAL)
-        sizer.Add(port_sizer, 0, wx.ALL | wx.EXPAND, 5)
-        base_sizer = wx.BoxSizer(wx.HORIZONTAL)
-        base_sizer.Add(wx.StaticText(self, label=_("Base path")), 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, 5)
-        base_sizer.Add(self._base_path, 1, wx.ALIGN_CENTER_VERTICAL)
-        sizer.Add(base_sizer, 0, wx.ALL | wx.EXPAND, 5)
-        token_sizer = wx.BoxSizer(wx.HORIZONTAL)
-        token_sizer.Add(wx.StaticText(self, label=_("Token")), 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, 5)
-        token_sizer.Add(self._token, 1, wx.ALIGN_CENTER_VERTICAL)
-        sizer.Add(token_sizer, 0, wx.ALL | wx.EXPAND, 5)
+        gen_sizer = wx.BoxSizer(wx.VERTICAL)
+        gen_sizer.Add(self._open_last, 0, wx.ALL, 5)
+        gen_sizer.Add(self._remember_sort, 0, wx.ALL, 5)
         lang_sizer = wx.BoxSizer(wx.HORIZONTAL)
-        lang_sizer.Add(wx.StaticText(self, label=_("Language")), 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, 5)
+        lang_sizer.Add(wx.StaticText(general, label=_("Language")), 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, 5)
         lang_sizer.Add(self._language_choice, 1, wx.ALIGN_CENTER_VERTICAL)
-        sizer.Add(lang_sizer, 0, wx.ALL | wx.EXPAND, 5)
+        gen_sizer.Add(lang_sizer, 0, wx.ALL | wx.EXPAND, 5)
+        general.SetSizer(gen_sizer)
+
+        # MCP settings ----------------------------------------------------
+        mcp = wx.Panel(nb)
+        self._host = wx.TextCtrl(mcp, value=host)
+        self._port = wx.SpinCtrl(mcp, min=1, max=65535, initial=port)
+        self._base_path = wx.TextCtrl(mcp, value=base_path)
+        self._require_token = wx.CheckBox(mcp, label=_("Require token"))
+        self._require_token.SetValue(require_token)
+        self._token = wx.TextCtrl(mcp, value=token)
+        self._token.Enable(require_token)
+
+        start_stop_label = _("Stop MCP") if is_running() else _("Start MCP")
+        self._start_stop = wx.Button(mcp, label=start_stop_label)
+        self._check = wx.Button(mcp, label=_("Check MCP"))
+        self._status = wx.StaticText(mcp, label=_("not running"))
+
+        self._require_token.Bind(wx.EVT_CHECKBOX, self._on_toggle_token)
+        self._start_stop.Bind(wx.EVT_BUTTON, self._on_start_stop)
+        self._check.Bind(wx.EVT_BUTTON, self._on_check)
+
+        mcp_sizer = wx.BoxSizer(wx.VERTICAL)
+        host_sz = wx.BoxSizer(wx.HORIZONTAL)
+        host_sz.Add(wx.StaticText(mcp, label=_("Host")), 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, 5)
+        host_sz.Add(self._host, 1, wx.ALIGN_CENTER_VERTICAL)
+        mcp_sizer.Add(host_sz, 0, wx.ALL | wx.EXPAND, 5)
+        port_sz = wx.BoxSizer(wx.HORIZONTAL)
+        port_sz.Add(wx.StaticText(mcp, label=_("Port")), 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, 5)
+        port_sz.Add(self._port, 1, wx.ALIGN_CENTER_VERTICAL)
+        mcp_sizer.Add(port_sz, 0, wx.ALL | wx.EXPAND, 5)
+        base_sz = wx.BoxSizer(wx.HORIZONTAL)
+        base_sz.Add(wx.StaticText(mcp, label=_("Path")), 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, 5)
+        base_sz.Add(self._base_path, 1, wx.ALIGN_CENTER_VERTICAL)
+        mcp_sizer.Add(base_sz, 0, wx.ALL | wx.EXPAND, 5)
+        mcp_sizer.Add(self._require_token, 0, wx.ALL, 5)
+        token_sz = wx.BoxSizer(wx.HORIZONTAL)
+        token_sz.Add(wx.StaticText(mcp, label=_("Token")), 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, 5)
+        token_sz.Add(self._token, 1, wx.ALIGN_CENTER_VERTICAL)
+        mcp_sizer.Add(token_sz, 0, wx.ALL | wx.EXPAND, 5)
+        btn_sz = wx.BoxSizer(wx.HORIZONTAL)
+        btn_sz.Add(self._start_stop, 0, wx.RIGHT, 5)
+        btn_sz.Add(self._check, 0)
+        mcp_sizer.Add(btn_sz, 0, wx.ALL, 5)
+        mcp_sizer.Add(self._status, 0, wx.ALL, 5)
+        mcp.SetSizer(mcp_sizer)
+
+        # Notebook --------------------------------------------------------
+        nb.AddPage(general, _("General"))
+        nb.AddPage(mcp, _("MCP"))
+
+        dlg_sizer = wx.BoxSizer(wx.VERTICAL)
+        dlg_sizer.Add(nb, 1, wx.EXPAND | wx.ALL, 5)
         btn_sizer = self.CreateStdDialogButtonSizer(wx.OK | wx.CANCEL)
         if btn_sizer:
-            sizer.Add(btn_sizer, 0, wx.ALIGN_CENTER | wx.ALL, 5)
-        self.SetSizerAndFit(sizer)
+            dlg_sizer.Add(btn_sizer, 0, wx.ALIGN_CENTER | wx.ALL, 5)
+        self.SetSizerAndFit(dlg_sizer)
 
-    def get_values(self) -> tuple[bool, bool, str, str, int, str, str]:
-        """Return (open_last_folder, remember_sort, language, host, port, base_path, token)."""
+    # ------------------------------------------------------------------
+    def _on_toggle_token(self, event: wx.Event) -> None:  # pragma: no cover - GUI event
+        self._token.Enable(self._require_token.GetValue())
+
+    def _update_start_stop_label(self) -> None:
+        label = _("Stop MCP") if is_running() else _("Start MCP")
+        self._start_stop.SetLabel(label)
+
+    def _on_start_stop(self, event: wx.Event) -> None:  # pragma: no cover - GUI event
+        if is_running():
+            stop_server()
+            self._status.SetLabel(_("not running"))
+        else:
+            token = self._token.GetValue() if self._require_token.GetValue() else ""
+            start_server(
+                self._host.GetValue(),
+                self._port.GetValue(),
+                self._base_path.GetValue(),
+                token,
+            )
+            self._status.SetLabel(_("not running"))
+        self._update_start_stop_label()
+
+    def _on_check(self, event: wx.Event) -> None:  # pragma: no cover - GUI event
+        headers = {}
+        if self._require_token.GetValue() and self._token.GetValue():
+            headers["Authorization"] = f"Bearer {self._token.GetValue()}"
+        try:
+            conn = HTTPConnection(self._host.GetValue(), self._port.GetValue(), timeout=2)
+            try:
+                conn.request("GET", "/health", headers=headers)
+                resp = conn.getresponse()
+                resp.read()
+                if resp.status == 200:
+                    self._status.SetLabel(_("ready"))
+                else:
+                    self._status.SetLabel(_("error"))
+            finally:
+                conn.close()
+        except Exception:
+            self._status.SetLabel(_("not running"))
+
+    # ------------------------------------------------------------------
+    def get_values(self) -> tuple[bool, bool, str, str, int, str, bool, str]:
+        """Return configured options."""
         lang_code = self._languages[self._language_choice.GetSelection()][0]
         return (
             self._open_last.GetValue(),
@@ -92,5 +174,7 @@ class SettingsDialog(wx.Dialog):
             self._host.GetValue(),
             self._port.GetValue(),
             self._base_path.GetValue(),
+            self._require_token.GetValue(),
             self._token.GetValue(),
         )
+

--- a/tests/llm_utils.py
+++ b/tests/llm_utils.py
@@ -16,12 +16,21 @@ def cfg_from_env(app_name: str) -> wx.Config:
     return cfg
 
 
-def cfg_with_mcp(host: str, port: int, base_path: str, token: str, *, app_name: str) -> wx.Config:
+def cfg_with_mcp(
+    host: str,
+    port: int,
+    base_path: str,
+    token: str,
+    *,
+    app_name: str,
+    require_token: bool = False,
+) -> wx.Config:
     """Return wx.Config with both MCP and LLM settings."""
     cfg = cfg_from_env(app_name)
     cfg.Write("mcp_host", host)
     cfg.WriteInt("mcp_port", port)
     cfg.Write("mcp_base_path", base_path)
+    cfg.WriteBool("mcp_require_token", require_token)
     cfg.Write("mcp_token", token)
     cfg.Flush()
     return cfg

--- a/tests/test_language_switch.py
+++ b/tests/test_language_switch.py
@@ -40,6 +40,7 @@ def test_switch_to_russian_updates_ui(monkeypatch):
                 frame.mcp_host,
                 frame.mcp_port,
                 frame.mcp_base_path,
+                frame.mcp_require_token,
                 frame.mcp_token,
             )
         def Destroy(self):

--- a/tests/test_mcp_controller.py
+++ b/tests/test_mcp_controller.py
@@ -1,0 +1,76 @@
+import pytest
+
+def test_controller_check(monkeypatch):
+    from app.mcp.controller import MCPController, MCPStatus
+    from app.mcp.settings import MCPSettings
+
+    requests = []
+
+    class FakeResponse:
+        def __init__(self, status):
+            self.status = status
+
+        def read(self):
+            return None
+
+    class FakeConnection:
+        def __init__(self, host, port, timeout=2):
+            self.host = host
+            self.port = port
+            self.timeout = timeout
+
+        def request(self, method, path, headers=None):
+            requests.append(headers or {})
+
+        def getresponse(self):
+            return FakeResponse(200)
+
+        def close(self):
+            return None
+
+    monkeypatch.setattr(
+        "app.mcp.controller.HTTPConnection",
+        lambda host, port, timeout=2: FakeConnection(host, port, timeout),
+    )
+
+    ctrl = MCPController()
+    settings = MCPSettings("localhost", 8123, "/tmp", True, "abc")
+    assert ctrl.check(settings) is MCPStatus.READY
+    assert requests[0]["Authorization"] == "Bearer abc"
+
+    class BadConnection(FakeConnection):
+        def getresponse(self):
+            return FakeResponse(500)
+
+    monkeypatch.setattr(
+        "app.mcp.controller.HTTPConnection",
+        lambda host, port, timeout=2: BadConnection(host, port, timeout),
+    )
+    assert ctrl.check(settings) is MCPStatus.ERROR
+
+    def ErrorConnection(host, port, timeout=2):
+        raise OSError("fail")
+
+    monkeypatch.setattr("app.mcp.controller.HTTPConnection", ErrorConnection)
+    assert ctrl.check(settings) is MCPStatus.NOT_RUNNING
+
+
+def test_controller_start_stop(monkeypatch):
+    from app.mcp.controller import MCPController
+    from app.mcp.settings import MCPSettings
+
+    calls = []
+
+    monkeypatch.setattr(
+        "app.mcp.controller.start_server",
+        lambda host, port, base_path, token: calls.append(("start", host, port, base_path, token)),
+    )
+    monkeypatch.setattr(
+        "app.mcp.controller.stop_server", lambda: calls.append(("stop",))
+    )
+
+    ctrl = MCPController()
+    settings = MCPSettings("localhost", 8123, "/tmp", False, "")
+    ctrl.start(settings)
+    ctrl.stop()
+    assert calls == [("start", "localhost", 8123, "/tmp", ""), ("stop",)]

--- a/tests/test_settings_dialog.py
+++ b/tests/test_settings_dialog.py
@@ -24,8 +24,130 @@ def test_settings_dialog_returns_language():
         host="127.0.0.1",
         port=8000,
         base_path="/tmp",
+        require_token=True,
         token="abc",
     )
     values = dlg.get_values()
-    assert values == (True, False, "ru", "127.0.0.1", 8000, "/tmp", "abc")
+    assert values == (True, False, "ru", "127.0.0.1", 8000, "/tmp", True, "abc")
+    dlg.Destroy()
+
+
+def test_mcp_start_stop_server(monkeypatch):
+    wx = pytest.importorskip("wx")
+    _app = wx.App()
+    from gettext import gettext as _
+    from app.ui.settings_dialog import SettingsDialog
+
+    state = {"running": False}
+    calls: list[tuple] = []
+
+    def fake_is_running():
+        return state["running"]
+
+    def fake_start_server(host, port, base_path, token):
+        calls.append(("start", host, port, base_path, token))
+        state["running"] = True
+
+    def fake_stop_server():
+        calls.append(("stop",))
+        state["running"] = False
+
+    monkeypatch.setattr("app.ui.settings_dialog.is_running", fake_is_running)
+    monkeypatch.setattr("app.ui.settings_dialog.start_server", fake_start_server)
+    monkeypatch.setattr("app.ui.settings_dialog.stop_server", fake_stop_server)
+
+    dlg = SettingsDialog(
+        None,
+        open_last=False,
+        remember_sort=False,
+        language="en",
+        host="localhost",
+        port=8123,
+        base_path="/tmp",
+        require_token=False,
+        token="",
+    )
+
+    assert dlg._start_stop.GetLabel() == _("Start MCP")
+
+    dlg._on_start_stop(wx.CommandEvent())
+    assert calls == [("start", "localhost", 8123, "/tmp", "")]
+    assert dlg._start_stop.GetLabel() == _("Stop MCP")
+
+    dlg._on_start_stop(wx.CommandEvent())
+    assert calls[-1] == ("stop",)
+    assert dlg._start_stop.GetLabel() == _("Start MCP")
+
+    dlg.Destroy()
+
+
+def test_mcp_check_status(monkeypatch):
+    wx = pytest.importorskip("wx")
+    _app = wx.App()
+    from gettext import gettext as _
+    from app.ui.settings_dialog import SettingsDialog
+
+    requests: list[dict] = []
+
+    class FakeResponse:
+        def __init__(self, status: int) -> None:
+            self.status = status
+
+        def read(self) -> None:  # pragma: no cover - no data
+            return None
+
+    class FakeConnection:
+        def __init__(self, host, port, timeout=2) -> None:
+            self.host = host
+            self.port = port
+            self.timeout = timeout
+
+        def request(self, method, path, headers=None):
+            requests.append(headers or {})
+
+        def getresponse(self):
+            return FakeResponse(200)
+
+        def close(self) -> None:  # pragma: no cover - nothing to close
+            return None
+
+    monkeypatch.setattr(
+        "app.ui.settings_dialog.HTTPConnection",
+        lambda host, port, timeout=2: FakeConnection(host, port, timeout),
+    )
+
+    dlg = SettingsDialog(
+        None,
+        open_last=False,
+        remember_sort=False,
+        language="en",
+        host="localhost",
+        port=8123,
+        base_path="/tmp",
+        require_token=True,
+        token="abc",
+    )
+
+    dlg._on_check(wx.CommandEvent())
+    assert dlg._status.GetLabel() == _("ready")
+    assert requests[0]["Authorization"] == "Bearer abc"
+
+    class BadConnection(FakeConnection):
+        def getresponse(self):
+            return FakeResponse(500)
+
+    monkeypatch.setattr(
+        "app.ui.settings_dialog.HTTPConnection",
+        lambda host, port, timeout=2: BadConnection(host, port, timeout),
+    )
+    dlg._on_check(wx.CommandEvent())
+    assert dlg._status.GetLabel() == _("error")
+
+    def ErrorConnection(host, port, timeout=2):
+        raise OSError("fail")
+
+    monkeypatch.setattr("app.ui.settings_dialog.HTTPConnection", ErrorConnection)
+    dlg._on_check(wx.CommandEvent())
+    assert dlg._status.GetLabel() == _("not running")
+
     dlg.Destroy()


### PR DESCRIPTION
## Summary
- add MCP tab in settings dialog with server controls
- persist token requirements in configuration and client
- expose MCP server running status
- extend tests for MCP server controls

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c50fd8856883209324f15c3c797c42