### PR TITLE
feat: add local agent for LLM and MCP

### DIFF
--- a/app/agent/__init__.py
+++ b/app/agent/__init__.py
@@ -1,0 +1,5 @@
+"""Local agent aggregating LLM and MCP clients."""
+
+from .local_agent import LocalAgent
+
+__all__ = ["LocalAgent"]

--- a/app/agent/local_agent.py
+++ b/app/agent/local_agent.py
@@ -1,0 +1,58 @@
+"""Local agent that combines LLM parsing with MCP tool execution."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import wx
+
+from app.llm.client import LLMClient
+from app.mcp.client import MCPClient
+from app.mcp.utils import ErrorCode, mcp_error
+from app.telemetry import log_event
+
+
+class LocalAgent:
+    """High-level agent aggregating LLM and MCP clients."""
+
+    def __init__(
+        self,
+        cfg: wx.Config | None = None,
+        *,
+        llm: LLMClient | None = None,
+        mcp: MCPClient | None = None,
+    ) -> None:
+        if llm is None:
+            if cfg is None:
+                raise TypeError("cfg or llm must be provided")
+            llm = LLMClient(cfg)
+        if mcp is None:
+            if cfg is None:
+                raise TypeError("cfg or mcp must be provided")
+            mcp = MCPClient(cfg)
+        self._llm = llm
+        self._mcp = mcp
+
+    # ------------------------------------------------------------------
+    def check_llm(self) -> dict[str, Any]:
+        """Delegate to :class:`LLMClient.check_llm`."""
+
+        return self._llm.check_llm()
+
+    # ------------------------------------------------------------------
+    def check_tools(self) -> dict[str, Any]:
+        """Delegate to :class:`MCPClient.check_tools`."""
+
+        return self._mcp.check_tools()
+
+    # ------------------------------------------------------------------
+    def run_command(self, text: str) -> dict[str, Any]:
+        """Use the LLM to parse *text* and execute the resulting tool call."""
+
+        try:
+            name, arguments = self._llm.parse_command(text)
+        except Exception as exc:
+            err = mcp_error(ErrorCode.VALIDATION_ERROR, str(exc))["error"]
+            log_event("ERROR", {"error": err})
+            return {"error": err}
+        return self._mcp._call_tool(name, arguments)

--- a/app/mcp/client.py
+++ b/app/mcp/client.py
@@ -135,17 +135,3 @@ class MCPClient:
             log_event("ERROR", {"error": err})
             return {"error": err}
 
-    # ------------------------------------------------------------------
-    def run_command(self, text: str) -> dict[str, Any]:
-        """Use an LLM to parse *text* and execute the resulting tool call."""
-
-        from app.llm.client import LLMClient
-
-        try:
-            name, arguments = LLMClient(self._cfg).parse_command(text)
-        except Exception as exc:
-            err = mcp_error(ErrorCode.VALIDATION_ERROR, str(exc))["error"]
-            log_event("ERROR", {"error": err})
-            return {"error": err}
-        return self._call_tool(name, arguments)
-

--- a/tests/test_mcp_llm_integration.py
+++ b/tests/test_mcp_llm_integration.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import wx
 
 from app.log import logger
-from app.mcp.client import MCPClient
+from app.agent import LocalAgent
 from app.mcp.server import JsonlHandler, start_server, stop_server
 from tests.llm_utils import cfg_with_mcp
 from tests.mcp_utils import _wait_until_ready
@@ -18,7 +18,7 @@ def test_create_and_delete_requirement_via_llm(tmp_path: Path, monkeypatch) -> N
     try:
         _wait_until_ready(port)
         cfg = cfg_with_mcp("127.0.0.1", port, str(tmp_path), "", app_name="CookaReq-LLM-Int")
-        client = MCPClient(cfg)
+        client = LocalAgent(cfg)
         log_file = tmp_path / "integration.jsonl"
         handler = JsonlHandler(str(log_file))
         logger.addHandler(handler)

--- a/tests/test_mcp_text_commands.py
+++ b/tests/test_mcp_text_commands.py
@@ -3,7 +3,7 @@ import logging
 from pathlib import Path
 
 from app.log import logger
-from app.mcp.client import MCPClient
+from app.agent import LocalAgent
 from app.mcp.server import JsonlHandler, start_server, stop_server
 from tests.llm_utils import cfg_with_mcp
 from tests.mcp_utils import _wait_until_ready
@@ -16,7 +16,7 @@ def test_run_command_list_logs(tmp_path: Path) -> None:
     try:
         _wait_until_ready(port)
         cfg = cfg_with_mcp("127.0.0.1", port, str(tmp_path), "", app_name="CookaReq-Cmd-Test")
-        client = MCPClient(cfg)
+        client = LocalAgent(cfg)
         log_file = tmp_path / "cmd.jsonl"
         handler = JsonlHandler(str(log_file))
         logger.addHandler(handler)
@@ -42,7 +42,7 @@ def test_run_command_error_logs(tmp_path: Path) -> None:
     try:
         _wait_until_ready(port)
         cfg = cfg_with_mcp("127.0.0.1", port, str(tmp_path), "", app_name="CookaReq-Cmd-Test")
-        client = MCPClient(cfg)
+        client = LocalAgent(cfg)
         log_file = tmp_path / "err.jsonl"
         handler = JsonlHandler(str(log_file))
         logger.addHandler(handler)


### PR DESCRIPTION
## Summary
- introduce `LocalAgent` combining LLM parsing with MCP tool execution
- simplify `MCPClient` to direct HTTP calls only
- update tests to use the new agent

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c51d4d47948320977378f06d5daa89