### PR TITLE
refactor: extract UI requirement and label controllers

### DIFF
--- a/app/ui/controllers/__init__.py
+++ b/app/ui/controllers/__init__.py
@@ -1,0 +1,4 @@
+from .requirements import RequirementsController
+from .labels import LabelsController
+
+__all__ = ["RequirementsController", "LabelsController"]

--- a/app/ui/controllers/labels.py
+++ b/app/ui/controllers/labels.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict, List
+
+from app.config import ConfigManager
+from app.core import store
+from app.core.labels import Label
+from app.log import logger
+
+
+class LabelsController:
+    """Manage label persistence and synchronization."""
+
+    def __init__(self, config: ConfigManager, model, directory: Path) -> None:
+        self.config = config
+        self.model = model
+        self.directory = directory
+        self.labels: List[Label] = []
+
+    def load_labels(self) -> List[Label]:
+        self.labels = store.load_labels(self.directory)
+        return self.labels
+
+    def sync_labels(self) -> List[str]:
+        """Synchronize labels file with labels used by requirements."""
+        if not self.directory:
+            return []
+        existing_colors = {lbl.name: lbl.color for lbl in self.labels}
+        used_names = {l for req in self.model.get_all() for l in req.labels}
+        all_names = sorted(existing_colors.keys() | used_names)
+        self.labels = [Label(name=n, color=existing_colors.get(n, "#ffffff")) for n in all_names]
+        try:
+            store.save_labels(self.directory, self.labels)
+        except Exception as exc:
+            logger.warning("Failed to save labels: %s", exc)
+        return [lbl.name for lbl in self.labels]
+
+    def update_labels(
+        self, new_labels: List[Label], remove_from_requirements: bool
+    ) -> Dict[str, List[int]]:
+        """Update labels and optionally strip removed ones from requirements.
+
+        Returns a mapping of removed label name -> requirement ids using it.
+        When ``remove_from_requirements`` is ``True``, labels are removed from
+        requirements and data is saved to disk, and an empty mapping is
+        returned.
+        """
+        old_names = {lbl.name for lbl in self.labels}
+        new_names = {lbl.name for lbl in new_labels}
+        removed = old_names - new_names
+        used: Dict[str, List[int]] = {}
+        if removed:
+            for lbl in removed:
+                ids = [req.id for req in self.model.get_all() if lbl in req.labels]
+                if ids:
+                    used[lbl] = ids
+        if used and not remove_from_requirements:
+            return used
+        removed_set = set(used) if remove_from_requirements else set()
+        if remove_from_requirements:
+            for req in self.model.get_all():
+                before = list(req.labels)
+                req.labels = [l for l in req.labels if l not in removed_set]
+                if before != req.labels:
+                    try:
+                        store.save(self.directory, req)
+                    except Exception as exc:
+                        logger.warning("Failed to save %s: %s", req.id, exc)
+        self.labels = new_labels
+        try:
+            store.save_labels(self.directory, self.labels)
+        except Exception as exc:
+            logger.warning("Failed to save labels: %s", exc)
+        return {}
+
+    def get_label_names(self) -> List[str]:
+        return [lbl.name for lbl in self.labels]

--- a/app/ui/controllers/requirements.py
+++ b/app/ui/controllers/requirements.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from pathlib import Path
+from typing import Dict
+
+from gettext import gettext as _
+
+from app.config import ConfigManager
+from app.core import store
+from app.core.model import Requirement, requirement_from_dict
+from app.log import logger
+
+
+class RequirementsController:
+    """Handle loading and basic CRUD operations for requirements."""
+
+    def __init__(self, config: ConfigManager, model, directory: Path) -> None:
+        self.config = config
+        self.model = model
+        self.directory = directory
+
+    # loading ---------------------------------------------------------
+    def load_directory(self) -> Dict[int, list[int]]:
+        """Load requirements from ``directory`` and return derivation map."""
+        self.config.add_recent_dir(self.directory)
+        items: list[Requirement] = []
+        store.clear_index(self.directory)
+        for fp in self.directory.glob("*.json"):
+            if fp.name == store.LABELS_FILENAME:
+                continue
+            try:
+                data, _ = store.load(fp)
+                req = requirement_from_dict(data)
+                items.append(req)
+                store.add_to_index(self.directory, req.id)
+            except Exception as exc:
+                logger.warning("Failed to load %s: %s", fp, exc)
+                continue
+        derived_map: Dict[int, list[int]] = {}
+        for req in items:
+            for link in getattr(req, "derived_from", []):
+                derived_map.setdefault(link.source_id, []).append(req.id)
+        self.model.set_requirements(items)
+        return derived_map
+
+    # requirement creation -------------------------------------------
+    def generate_new_id(self) -> int:
+        existing = {req.id for req in self.model.get_all()}
+        return max(existing, default=0) + 1
+
+    def add_requirement(self, requirement: Requirement) -> None:
+        self.model.add(requirement)
+
+    def clone_requirement(self, req_id: int) -> Requirement | None:
+        source = self.model.get_by_id(req_id)
+        if not source:
+            return None
+        new_id = self.generate_new_id()
+        clone = replace(
+            source,
+            id=new_id,
+            title=f"{_('(Copy)')} {source.title}".strip(),
+            modified_at="",
+            revision=1,
+        )
+        self.model.add(clone)
+        return clone
+
+    def delete_requirement(self, req_id: int) -> bool:
+        req = self.model.get_by_id(req_id)
+        if not req:
+            return False
+        self.model.delete(req_id)
+        try:
+            store.delete(self.directory, req.id)
+        except Exception:
+            pass
+        return True


### PR DESCRIPTION
## Summary
- move requirement loading and CRUD logic into `RequirementsController`
- manage label persistence via new `LabelsController`
- adapt `MainFrame` to delegate actions to controllers

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5230bdadc8320b26e4813b49f8319