### PR TITLE
feat: validate settings and enhance CLI

### DIFF
--- a/app/cli.py
+++ b/app/cli.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from .core import store, search, model
 from .log import configure_logging
 from .settings import AppSettings, load_app_settings
+from .agent import LocalAgent
 
 
 def _load_all(directory: str | Path) -> list[model.Requirement]:
@@ -60,6 +61,18 @@ def cmd_show(args: argparse.Namespace) -> None:
     print(json.dumps(data, ensure_ascii=False, indent=2, sort_keys=True))
 
 
+def cmd_check(args: argparse.Namespace) -> None:
+    """Verify LLM and MCP connectivity using loaded settings."""
+
+    agent = LocalAgent(settings=args.app_settings)
+    results: dict[str, object] = {}
+    if args.llm or not (args.llm or args.mcp):
+        results["llm"] = agent.check_llm()
+    if args.mcp or not (args.llm or args.mcp):
+        results["mcp"] = agent.check_tools()
+    print(json.dumps(results, ensure_ascii=False, indent=2, sort_keys=True))
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=_("CookaReq CLI"))
     parser.add_argument(
@@ -89,6 +102,11 @@ def build_parser() -> argparse.ArgumentParser:
     p_show.add_argument("directory", help=_("requirements directory"))
     p_show.add_argument("id", type=int, help=_("requirement id"))
     p_show.set_defaults(func=cmd_show)
+
+    p_check = sub.add_parser("check", help=_("verify LLM and MCP settings"))
+    p_check.add_argument("--llm", action="store_true", help=_("check only LLM"))
+    p_check.add_argument("--mcp", action="store_true", help=_("check only MCP"))
+    p_check.set_defaults(func=cmd_check)
 
     return parser
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ uvicorn
 mcp
 jsonpatch
 openai
+pydantic

--- a/tests/test_mcp_controller.py
+++ b/tests/test_mcp_controller.py
@@ -34,7 +34,9 @@ def test_controller_check(monkeypatch):
     )
 
     ctrl = MCPController()
-    settings = MCPSettings("localhost", 8123, "/tmp", True, "abc")
+    settings = MCPSettings(
+        host="localhost", port=8123, base_path="/tmp", require_token=True, token="abc"
+    )
     assert ctrl.check(settings) is MCPStatus.READY
     assert requests[0]["Authorization"] == "Bearer abc"
 
@@ -70,7 +72,7 @@ def test_controller_start_stop(monkeypatch):
     )
 
     ctrl = MCPController()
-    settings = MCPSettings("localhost", 8123, "/tmp", False, "")
+    settings = MCPSettings(host="localhost", port=8123, base_path="/tmp", token="")
     ctrl.start(settings)
     ctrl.stop()
     assert calls == [("start", "localhost", 8123, "/tmp", ""), ("stop",)]

--- a/tests/test_settings_validation.py
+++ b/tests/test_settings_validation.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+import json
+import pytest
+
+from app.settings import load_app_settings
+
+
+def test_invalid_settings_raises(tmp_path):
+    file = tmp_path / "settings.json"
+    file.write_text(json.dumps({"mcp": {"port": "not-int"}}))
+    with pytest.raises(ValueError):
+        load_app_settings(file)
+


### PR DESCRIPTION
## Summary
- add Pydantic-based settings models with validation
- expose `check` CLI command using LocalAgent to verify LLM/MCP config
- cover config errors and agent checks with tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c52dd2f948832095d8c3cbc0a00c8d