### PR TITLE
Centralize requirement operations via requirements module

### DIFF
--- a/app/core/requirements.py
+++ b/app/core/requirements.py
@@ -1,0 +1,149 @@
+"""High-level operations on requirement files.
+
+This module centralizes business logic for loading, searching and
+modifying requirements. It is used by CLI, MCP tools and can be reused by
+GUI components.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable, Mapping, Sequence, Tuple
+
+from .model import Requirement, requirement_from_dict, Status
+from .labels import Label
+from . import search as core_search
+from .store import (
+    load,
+    load_index,
+    filename_for,
+    save,
+    delete,
+    ConflictError,
+    load_labels as store_load_labels,
+    save_labels as store_save_labels,
+)
+
+# Re-export searchable fields for UI components
+SEARCHABLE_FIELDS = core_search.SEARCHABLE_FIELDS
+
+
+def load_all(directory: str | Path) -> list[Requirement]:
+    """Load all requirements from *directory*.
+
+    Raises :class:`FileNotFoundError` if the directory does not exist.
+    """
+    path = Path(directory)
+    if not path.is_dir():
+        raise FileNotFoundError(str(directory))
+    reqs: list[Requirement] = []
+    for req_id in sorted(load_index(path)):
+        data, _ = load(path / filename_for(req_id))
+        reqs.append(requirement_from_dict(data))
+    return reqs
+
+
+def filter_by_status(
+    requirements: Iterable[Requirement], status: str | Status | None
+) -> list[Requirement]:
+    """Filter ``requirements`` by ``status`` if provided."""
+    reqs = list(requirements)
+    if not status:
+        return reqs
+    try:
+        st = Status(status)
+    except ValueError:
+        return []
+    return [r for r in reqs if r.status == st]
+
+
+def search_requirements(
+    directory: str | Path,
+    *,
+    query: str | None = None,
+    labels: Sequence[str] | None = None,
+    fields: Sequence[str] | None = None,
+    status: str | None = None,
+) -> list[Requirement]:
+    """Load and filter requirements from *directory*.
+
+    ``labels`` and ``query`` parameters mirror :func:`core.search.search`.
+    ``status`` performs additional filtering before the search step.
+    """
+    reqs = load_all(directory)
+    reqs = filter_by_status(reqs, status)
+    return core_search.search(reqs, labels=list(labels or []), query=query, fields=fields)
+
+
+def load_requirement(directory: str | Path, req_id: int) -> Tuple[dict, float]:
+    """Return raw requirement data and mtime for ``req_id``.
+
+    Raises :class:`FileNotFoundError` when either the directory or file does not
+    exist.
+    """
+    path = Path(directory)
+    if not path.is_dir():
+        raise FileNotFoundError(str(directory))
+    return load(path / filename_for(req_id))
+
+
+def get_requirement(directory: str | Path, req_id: int) -> Requirement:
+    """Return :class:`Requirement` with ``req_id`` from ``directory``."""
+    data, _ = load_requirement(directory, req_id)
+    return requirement_from_dict(data)
+
+
+def save_requirement(
+    directory: str | Path, data: Mapping | Requirement, *, mtime: float | None = None
+):
+    """Persist ``data`` as requirement in ``directory`` and return file path."""
+    if isinstance(data, Requirement):
+        obj = data
+    else:
+        obj = requirement_from_dict(dict(data))
+    return save(directory, obj, mtime=mtime)
+
+
+def delete_requirement(directory: str | Path, req_id: int) -> None:
+    """Remove requirement ``req_id`` from ``directory``."""
+    delete(directory, req_id)
+
+
+def list_ids(directory: str | Path) -> set[int]:
+    """Return set of requirement ids present in ``directory``."""
+    return set(load_index(directory))
+
+
+def search_loaded(
+    requirements: Iterable[Requirement],
+    *,
+    labels: Sequence[str] | None = None,
+    query: str | None = None,
+    fields: Sequence[str] | None = None,
+    field_queries: Mapping[str, str] | None = None,
+    match_all: bool = True,
+    is_derived: bool = False,
+    has_derived: bool = False,
+    suspect_only: bool = False,
+) -> list[Requirement]:
+    """Filter ``requirements`` in memory using search criteria."""
+    return core_search.search(
+        requirements,
+        labels=labels,
+        query=query,
+        fields=fields,
+        field_queries=field_queries,
+        match_all=match_all,
+        is_derived=is_derived,
+        has_derived=has_derived,
+        suspect_only=suspect_only,
+    )
+
+
+def load_labels(directory: str | Path) -> list[Label]:
+    """Load labels from ``directory``."""
+    return store_load_labels(directory)
+
+
+def save_labels(directory: str | Path, labels: list[Label]):
+    """Persist ``labels`` into ``directory``."""
+    return store_save_labels(directory, labels)

--- a/app/ui/controllers/labels.py
+++ b/app/ui/controllers/labels.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from typing import Dict, List
 
 from app.config import ConfigManager
-from app.core import store
+from app.core import requirements as req_ops
 from app.core.labels import Label
 from app.log import logger
 
@@ -19,7 +19,7 @@ class LabelsController:
         self.labels: List[Label] = []
 
     def load_labels(self) -> List[Label]:
-        self.labels = store.load_labels(self.directory)
+        self.labels = req_ops.load_labels(self.directory)
         return self.labels
 
     def sync_labels(self) -> List[str]:
@@ -31,7 +31,7 @@ class LabelsController:
         all_names = sorted(existing_colors.keys() | used_names)
         self.labels = [Label(name=n, color=existing_colors.get(n, "#ffffff")) for n in all_names]
         try:
-            store.save_labels(self.directory, self.labels)
+            req_ops.save_labels(self.directory, self.labels)
         except Exception as exc:
             logger.warning("Failed to save labels: %s", exc)
         return [lbl.name for lbl in self.labels]
@@ -64,12 +64,12 @@ class LabelsController:
                 req.labels = [l for l in req.labels if l not in removed_set]
                 if before != req.labels:
                     try:
-                        store.save(self.directory, req)
+                        req_ops.save_requirement(self.directory, req)
                     except Exception as exc:
                         logger.warning("Failed to save %s: %s", req.id, exc)
         self.labels = new_labels
         try:
-            store.save_labels(self.directory, self.labels)
+            req_ops.save_labels(self.directory, self.labels)
         except Exception as exc:
             logger.warning("Failed to save labels: %s", exc)
         return {}

--- a/app/ui/editor_panel.py
+++ b/app/ui/editor_panel.py
@@ -11,7 +11,7 @@ import wx
 from wx.lib.dialogs import ScrolledMessageDialog
 from wx.lib.scrolledpanel import ScrolledPanel
 
-from app.core import store
+from app.core import requirements as req_ops
 from app.core.labels import Label
 from app.core.model import (
     Requirement,
@@ -497,10 +497,9 @@ class EditorPanel(ScrolledPanel):
             return
         revision = 1
         if self.directory:
-            path = self.directory / f"{src_id}.json"
             try:
-                data, _ = store.load(path)
-                revision = data.get("revision", 1)
+                req = req_ops.get_requirement(self.directory, src_id)
+                revision = req.revision or 1
             except Exception:
                 pass
         self.derived_from.append(
@@ -540,7 +539,7 @@ class EditorPanel(ScrolledPanel):
             ctrl.SetBackgroundColour(wx.Colour(255, 200, 200))
             ctrl.Refresh()
             return
-        ids = set(store.load_index(self.directory))
+        ids = req_ops.list_ids(self.directory)
         if self.original_id is not None:
             ids.discard(self.original_id)
         if req_id in ids:
@@ -557,7 +556,7 @@ class EditorPanel(ScrolledPanel):
 
     def save(self, directory: str | Path) -> Path:
         req = self.get_data()
-        path = store.save(directory, req, mtime=self.mtime)
+        path = req_ops.save_requirement(directory, req, mtime=self.mtime)
         self.current_path = path
         self.mtime = path.stat().st_mtime
         self.directory = Path(directory)
@@ -567,7 +566,7 @@ class EditorPanel(ScrolledPanel):
 
     def delete(self) -> None:
         if self.current_path and self.current_path.exists():
-            store.delete(self.current_path.parent, int(self.current_path.stem))
+            req_ops.delete_requirement(self.current_path.parent, int(self.current_path.stem))
         self.current_path = None
         self.mtime = None
         self.original_id = None

--- a/app/ui/filter_dialog.py
+++ b/app/ui/filter_dialog.py
@@ -6,7 +6,7 @@ from typing import Dict
 
 import wx
 
-from app.core import search as core_search
+from app.core import requirements as req_ops
 
 
 class FilterDialog(wx.Dialog):
@@ -29,7 +29,7 @@ class FilterDialog(wx.Dialog):
 
         # Per-field queries
         self.field_controls: Dict[str, wx.TextCtrl] = {}
-        for field in sorted(core_search.SEARCHABLE_FIELDS):
+        for field in sorted(req_ops.SEARCHABLE_FIELDS):
             sizer.Add(wx.StaticText(self, label=field.title()), 0, wx.ALL, 5)
             ctrl = wx.TextCtrl(self)
             ctrl.SetValue(values.get("field_queries", {}).get(field, ""))

--- a/app/ui/main_frame.py
+++ b/app/ui/main_frame.py
@@ -12,7 +12,7 @@ import wx
 from app.log import logger
 
 from app.config import ConfigManager
-from app.core import store
+from app.core import requirements as req_ops
 from app.core.model import Requirement, DerivationLink
 from app.core.labels import Label
 from app.mcp.controller import MCPController
@@ -370,7 +370,7 @@ class MainFrame(wx.Frame):
             return
         try:
             self.editor.save(self.current_dir)
-        except store.ConflictError:  # pragma: no cover - GUI event
+        except req_ops.ConflictError:  # pragma: no cover - GUI event
             wx.MessageBox(
                 _("File was modified on disk. Save cancelled."),
                 _("Error"),

--- a/app/ui/requirement_model.py
+++ b/app/ui/requirement_model.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from typing import List, Sequence
 from enum import Enum
 
-from app.core import search as core_search
+from app.core import requirements as req_ops
 from app.core.model import Requirement
 
 
@@ -94,7 +94,7 @@ class RequirementModel:
 
     # helpers ---------------------------------------------------------
     def _refresh(self) -> None:
-        self._visible = core_search.search(
+        self._visible = req_ops.search_loaded(
             self._all,
             labels=self._labels,
             query=self._query,

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -44,7 +44,7 @@ def test_list_requirements_errors(tmp_path: Path, monkeypatch) -> None:
     def not_found(_):  # noqa: ANN001
         raise FileNotFoundError
 
-    monkeypatch.setattr("app.mcp.tools_read._load_all", not_found)
+    monkeypatch.setattr("app.core.requirements.load_all", not_found)
     err = list_requirements(tmp_path / "missing")
     assert err["error"]["code"] == ErrorCode.NOT_FOUND
 
@@ -52,7 +52,7 @@ def test_list_requirements_errors(tmp_path: Path, monkeypatch) -> None:
     def boom(_):  # noqa: ANN001
         raise RuntimeError("boom")
 
-    monkeypatch.setattr("app.mcp.tools_read._load_all", boom)
+    monkeypatch.setattr("app.core.requirements.load_all", boom)
     err = list_requirements(tmp_path)
     assert err["error"]["code"] == ErrorCode.INTERNAL
 
@@ -72,7 +72,7 @@ def test_get_requirement_errors(tmp_path: Path, monkeypatch) -> None:
     def boom(*args, **kwargs):  # noqa: ANN001, ANN002
         raise RuntimeError("boom")
 
-    monkeypatch.setattr("app.mcp.tools_read.store.load", boom)
+    monkeypatch.setattr("app.core.requirements.load_requirement", boom)
     err = get_requirement(tmp_path, 1)
     assert err["error"]["code"] == ErrorCode.INTERNAL
 
@@ -93,13 +93,13 @@ def test_search_requirements_errors(tmp_path: Path, monkeypatch) -> None:
     def not_found(_):  # noqa: ANN001
         raise FileNotFoundError
 
-    monkeypatch.setattr("app.mcp.tools_read._load_all", not_found)
+    monkeypatch.setattr("app.core.requirements.load_all", not_found)
     err = search_requirements(tmp_path / "nope", query="login")
     assert err["error"]["code"] == ErrorCode.NOT_FOUND
 
     def boom(_):  # noqa: ANN001
         raise RuntimeError("boom")
 
-    monkeypatch.setattr("app.mcp.tools_read._load_all", boom)
+    monkeypatch.setattr("app.core.requirements.load_all", boom)
     err = search_requirements(tmp_path)
     assert err["error"]["code"] == ErrorCode.INTERNAL

--- a/tests/test_requirement_ops.py
+++ b/tests/test_requirement_ops.py
@@ -85,7 +85,7 @@ def test_create_requirement_errors(tmp_path: Path, monkeypatch) -> None:
     def conflict(*args, **kwargs):  # noqa: ANN001, ANN002
         raise ConflictError("exists")
 
-    monkeypatch.setattr(tools_write, "save", conflict)
+    monkeypatch.setattr("app.core.requirements.save_requirement", conflict)
     err = create_requirement(tmp_path, _base_req(1))
     assert err["error"]["code"] == ErrorCode.CONFLICT
 
@@ -95,7 +95,7 @@ def test_create_requirement_errors(tmp_path: Path, monkeypatch) -> None:
     def boom(*args, **kwargs):  # noqa: ANN001, ANN002
         raise RuntimeError("boom")
 
-    monkeypatch.setattr(tools_write, "save", boom)
+    monkeypatch.setattr("app.core.requirements.save_requirement", boom)
     err = create_requirement(tmp_path, _base_req(3))
     assert err["error"]["code"] == ErrorCode.INTERNAL
 
@@ -114,7 +114,7 @@ def test_patch_requirement_errors(tmp_path: Path, monkeypatch) -> None:
     def boom(*args, **kwargs):  # noqa: ANN001, ANN002
         raise RuntimeError("boom")
 
-    monkeypatch.setattr(tools_write, "save", boom)
+    monkeypatch.setattr("app.core.requirements.save_requirement", boom)
     err = patch_requirement(tmp_path, 1, [{"op": "replace", "path": "/title", "value": "X"}], rev=1)
     assert err["error"]["code"] == ErrorCode.INTERNAL
 
@@ -128,7 +128,7 @@ def test_delete_requirement_errors(tmp_path: Path, monkeypatch) -> None:
     def boom(*args, **kwargs):  # noqa: ANN001, ANN002
         raise RuntimeError("boom")
 
-    monkeypatch.setattr(tools_write, "delete_file", boom)
+    monkeypatch.setattr("app.core.requirements.delete_requirement", boom)
     err = delete_requirement(tmp_path, 1, rev=1)
     assert err["error"]["code"] == ErrorCode.INTERNAL
 
@@ -157,7 +157,7 @@ def test_link_requirements_errors(tmp_path: Path, monkeypatch) -> None:
     def boom(*args, **kwargs):  # noqa: ANN001, ANN002
         raise RuntimeError("boom")
 
-    monkeypatch.setattr(tools_write, "save", boom)
+    monkeypatch.setattr("app.core.requirements.save_requirement", boom)
     err = link_requirements(tmp_path, source_id=1, derived_id=2, link_type="derived_from", rev=1)
     assert err["error"]["code"] == ErrorCode.INTERNAL
 


### PR DESCRIPTION
## Summary
- rename `app.core.service` to explicit `app.core.requirements`
- update CLI, MCP tools and GUI components to use the new `requirements` module
- adjust tests and monkeypatch paths for renamed module

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c530050a408320ba71b065422eb3b6