### PR TITLE
feat(ui): expose more requirement fields

### DIFF
--- a/app/ui/list_panel.py
+++ b/app/ui/list_panel.py
@@ -275,6 +275,20 @@ class ListPanel(wx.Panel, ColumnSorterMixin):
                     count = len(self.derived_map.get(req.id, []))
                     self.list.SetStringItem(index, col, str(count))
                     continue
+                if field == "attachments":
+                    value = ", ".join(getattr(a, "path", "") for a in getattr(req, "attachments", []))
+                    self.list.SetStringItem(index, col, value)
+                    continue
+                if field == "units":
+                    u = getattr(req, "units", None)
+                    if u:
+                        value = f"{u.quantity} {u.nominal}"
+                        if getattr(u, "tolerance", None) is not None:
+                            value += f" ±{u.tolerance}"
+                    else:
+                        value = ""
+                    self.list.SetStringItem(index, col, value)
+                    continue
                 value = getattr(req, field, "")
                 if isinstance(value, Enum):
                     value = value.value

--- a/app/ui/requirement_model.py
+++ b/app/ui/requirement_model.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from typing import List, Sequence
 from enum import Enum
+from dataclasses import asdict, is_dataclass
 
 from app.core import requirements as req_ops
 from app.core.model import Requirement
@@ -122,6 +123,10 @@ class RequirementModel:
                     return 0
             if self._sort_field == "labels" and isinstance(value, list):
                 return "|".join(value)
+            if isinstance(value, list):
+                return "|".join(str(v) for v in value)
+            if is_dataclass(value):
+                return str(asdict(value))
             return value
 
         self._visible.sort(key=get_value, reverse=not self._sort_ascending)

--- a/tests/test_editor_panel.py
+++ b/tests/test_editor_panel.py
@@ -38,6 +38,14 @@ def test_editor_save_and_delete(tmp_path):
     panel.fields["owner"].SetValue("owner")
     panel.fields["source"].SetValue("src")
     panel.fields["acceptance"].SetValue("Acc")
+    panel.units_fields["quantity"].SetValue("kg")
+    panel.units_fields["nominal"].SetValue("1.0")
+    panel.units_fields["tolerance"].SetValue("0.1")
+    wx = pytest.importorskip("wx")
+    dt = wx.DateTime()
+    dt.ParseISODate("2025-01-01")
+    panel.approved_picker.SetValue(dt)
+    panel.notes_ctrl.SetValue("Note")
 
     attachments_dir = tmp_path / "attachments"
     attachments_dir.mkdir()
@@ -51,6 +59,9 @@ def test_editor_save_and_delete(tmp_path):
     data, _ = store.load(path)
     assert data["id"] == 1
     assert data["attachments"][0]["path"] == f"attachments{os.sep}{att.name}"
+    assert data["units"] == {"quantity": "kg", "nominal": 1.0, "tolerance": 0.1}
+    assert data["approved_at"] == "2025-01-01"
+    assert data["notes"] == "Note"
 
     panel.delete()
     assert not path.exists()

--- a/tests/test_editor_panel_gui.py
+++ b/tests/test_editor_panel_gui.py
@@ -20,6 +20,7 @@ def test_editor_new_requirement_resets(tmp_path):
         "title": "T",
         "statement": "S",
         "attachments": [{"path": "a.txt", "note": "n"}],
+        "units": {"quantity": "kg", "nominal": 1.0, "tolerance": 0.1},
         "labels": ["L1"],
         "revision": 5,
         "approved_at": "2025-01-01",
@@ -29,6 +30,7 @@ def test_editor_new_requirement_resets(tmp_path):
     panel.new_requirement()
 
     assert all(ctrl.GetValue() == "" for ctrl in panel.fields.values())
+    assert all(ctrl.GetValue() == "" for ctrl in panel.units_fields.values())
     panel.fields["id"].SetValue("1")
     defaults = panel.get_data()
     assert defaults.type == RequirementType.REQUIREMENT
@@ -42,6 +44,7 @@ def test_editor_new_requirement_resets(tmp_path):
     assert defaults.revision == 1
     assert defaults.approved_at is None
     assert defaults.notes == ""
+    assert defaults.units is None
 
 
 def test_editor_add_attachment_included():
@@ -103,6 +106,7 @@ def test_editor_load_populates_fields(tmp_path):
         "revision": 2,
         "approved_at": "2025-01-02",
         "notes": "Note",
+        "units": {"quantity": "kg", "nominal": 2.0, "tolerance": 0.5},
     }
     path = tmp_path / "req.json"
     panel.update_labels_list([Label("L", "#000000")])
@@ -124,6 +128,9 @@ def test_editor_load_populates_fields(tmp_path):
     assert result.revision == data["revision"]
     assert result.approved_at == data["approved_at"]
     assert result.notes == data["notes"]
+    assert result.units.quantity == "kg"
+    assert result.units.nominal == 2.0
+    assert result.units.tolerance == 0.5
     assert panel.current_path == path
     assert panel.mtime == 42.0
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -24,6 +24,9 @@ def test_requirement_defaults():
     assert req.revision == 1
     assert req.labels == []
     assert req.attachments == []
+    assert req.units is None
+    assert req.approved_at is None
+    assert req.notes == ""
     assert req.conditions == ""
     assert req.trace_up == ""
     assert req.trace_down == ""

--- a/tests/test_requirement_ops.py
+++ b/tests/test_requirement_ops.py
@@ -23,6 +23,10 @@ def _base_req(req_id: int) -> dict:
         "priority": "medium",
         "source": "spec",
         "verification": "analysis",
+        "units": {"quantity": "kg", "nominal": 1.0, "tolerance": 0.1},
+        "attachments": [{"path": "a.txt", "note": "n"}],
+        "approved_at": "2025-01-01",
+        "notes": "note",
         "labels": [],
         "revision": 1,
     }
@@ -39,6 +43,10 @@ def test_create_patch_delete(tmp_path: Path):
     data, _ = load(path)
     assert data["title"] == "New"
     assert data["revision"] == 2
+    assert data["units"] == {"quantity": "kg", "nominal": 1.0, "tolerance": 0.1}
+    assert data["attachments"] == [{"path": "a.txt", "note": "n"}]
+    assert data["approved_at"] == "2025-01-01"
+    assert data["notes"] == "note"
 
     # conflicting revision
     err = patch_requirement(tmp_path, 1, [{"op": "replace", "path": "/title", "value": "Other"}], rev=1)

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -36,6 +36,10 @@ def sample(req_id: int = 1) -> dict:
         "source": "spec",
         "verification": "analysis",
         "revision": 1,
+        "units": {"quantity": "kg", "nominal": 1.0, "tolerance": 0.1},
+        "attachments": [{"path": "a.txt", "note": "n"}],
+        "approved_at": "2025-01-01",
+        "notes": "note",
     }
 
 


### PR DESCRIPTION
## Summary
- allow editing units, attachments, approval date and notes in requirement editor
- support sorting/displaying complex fields in models and lists
- cover new fields with tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c53d7849348320950649f3e5592ad7