### PR TITLE
feat: add agent command dialog with history

### DIFF
--- a/app/ui/command_dialog.py
+++ b/app/ui/command_dialog.py
@@ -1,0 +1,138 @@
+"""Dialog for executing LocalAgent commands with persistent history."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, asdict
+from pathlib import Path
+from gettext import gettext as _
+
+import wx
+
+from app.agent import LocalAgent
+
+
+@dataclass
+class ChatEntry:
+    """Stored conversation entry."""
+
+    command: str
+    response: str
+    tokens: int
+
+
+def _default_history_path() -> Path:
+    """Return default path for chat history."""
+
+    return Path.home() / ".cookareq" / "agent_chats.json"
+
+
+def _token_count(text: str) -> int:
+    """Naive token count based on whitespace splitting."""
+
+    return len(text.split())
+
+
+class CommandDialog(wx.Dialog):
+    """Interface to run agent commands and manage chat history."""
+
+    def __init__(
+        self,
+        parent: wx.Window,
+        *,
+        agent: LocalAgent,
+        history_path: Path | None = None,
+    ) -> None:
+        super().__init__(parent, title=_("Agent Command"))
+        self._agent = agent
+        self._history_path = history_path or _default_history_path()
+        self.history: list[ChatEntry] = []
+        self._load_history()
+
+        self.input = wx.TextCtrl(self, style=wx.TE_PROCESS_ENTER)
+        self.output = wx.TextCtrl(
+            self, style=wx.TE_MULTILINE | wx.TE_READONLY | wx.HSCROLL
+        )
+        self.history_list = wx.ListBox(self)
+        self.history_list.Bind(wx.EVT_LISTBOX, self._on_select_history)
+
+        run_btn = wx.Button(self, label=_("Run"))
+        run_btn.Bind(wx.EVT_BUTTON, self._on_run)
+        clear_btn = wx.Button(self, label=_("Clear"))
+        clear_btn.Bind(wx.EVT_BUTTON, self._on_clear)
+        self.input.Bind(wx.EVT_TEXT_ENTER, self._on_run)
+
+        btn_sizer = wx.BoxSizer(wx.HORIZONTAL)
+        btn_sizer.Add(run_btn, 0, wx.RIGHT, 5)
+        btn_sizer.Add(clear_btn, 0)
+
+        right = wx.BoxSizer(wx.VERTICAL)
+        right.Add(self.input, 0, wx.ALL | wx.EXPAND, 5)
+        right.Add(btn_sizer, 0, wx.ALL | wx.ALIGN_RIGHT, 5)
+        right.Add(self.output, 1, wx.ALL | wx.EXPAND, 5)
+
+        main = wx.BoxSizer(wx.HORIZONTAL)
+        main.Add(self.history_list, 0, wx.ALL | wx.EXPAND, 5)
+        main.Add(right, 1, wx.EXPAND)
+        self.SetSizerAndFit(main)
+        self.SetSize((600, 400))
+        self._refresh_history_list()
+
+    def _on_run(self, event: wx.Event) -> None:
+        text = self.input.GetValue().strip()
+        if not text:
+            return
+        result = self._agent.run_command(text)
+        if "error" in result:
+            err = result["error"]
+            code = err.get("code", "")
+            msg = err.get("message", "")
+            display = f"{code}: {msg}".strip(": ")
+        else:
+            display = json.dumps(result, ensure_ascii=False, indent=2)
+        self.output.SetValue(display)
+        self.output.ShowPosition(self.output.GetLastPosition())
+        self._append_history(text, display)
+
+    def _on_clear(self, event: wx.Event) -> None:
+        self.input.SetValue("")
+        self.output.SetValue("")
+        self.history_list.SetSelection(wx.NOT_FOUND)
+
+    def _on_select_history(self, event: wx.CommandEvent) -> None:
+        idx = event.GetInt()
+        if idx < 0 or idx >= len(self.history):
+            return
+        entry = self.history[idx]
+        self.input.SetValue(entry.command)
+        self.output.SetValue(entry.response)
+        self.output.ShowPosition(self.output.GetLastPosition())
+
+    # ------------------------------------------------------------------
+    def _append_history(self, command: str, response: str) -> None:
+        tokens = _token_count(command) + _token_count(response)
+        entry = ChatEntry(command=command, response=response, tokens=tokens)
+        self.history.append(entry)
+        self._save_history()
+        self._refresh_history_list()
+        self.history_list.SetSelection(len(self.history) - 1)
+
+    def _refresh_history_list(self) -> None:
+        self.history_list.Clear()
+        for entry in self.history:
+            label = f"{entry.command[:20]} ({entry.tokens})"
+            self.history_list.Append(label)
+
+    def _load_history(self) -> None:
+        try:
+            data = json.loads(self._history_path.read_text(encoding="utf-8"))
+            self.history = [ChatEntry(**item) for item in data]
+        except FileNotFoundError:
+            self.history = []
+        except Exception:
+            self.history = []
+
+    def _save_history(self) -> None:
+        self._history_path.parent.mkdir(parents=True, exist_ok=True)
+        with self._history_path.open("w", encoding="utf-8") as fh:
+            json.dump([asdict(h) for h in self.history], fh, ensure_ascii=False, indent=2)

--- a/app/ui/main_frame.py
+++ b/app/ui/main_frame.py
@@ -16,13 +16,15 @@ from app.core import requirements as req_ops
 from app.core.model import Requirement, DerivationLink
 from app.core.labels import Label
 from app.mcp.controller import MCPController
-from app.settings import LLMSettings, MCPSettings
+from app.settings import AppSettings, LLMSettings, MCPSettings
+from app.agent import LocalAgent
 from .list_panel import ListPanel
 from .editor_panel import EditorPanel
 from .settings_dialog import SettingsDialog
 from .requirement_model import RequirementModel
 from .labels_dialog import LabelsDialog
 from .navigation import Navigation
+from .command_dialog import CommandDialog
 from .controllers import RequirementsController, LabelsController
 
 
@@ -94,6 +96,7 @@ class MainFrame(wx.Frame):
             on_toggle_log_console=self.on_toggle_log_console,
             on_show_derivation_graph=self.on_show_derivation_graph,
             on_new_requirement=self.on_new_requirement,
+            on_run_command=self.on_run_command,
         )
         self._recent_menu = self.navigation.recent_menu
         self._recent_menu_item = self.navigation.recent_menu_item
@@ -224,6 +227,13 @@ class MainFrame(wx.Frame):
                 self.mcp.stop()
                 self.mcp.start(self.mcp_settings)
             self._apply_language()
+        dlg.Destroy()
+
+    def on_run_command(self, event: wx.Event) -> None:
+        settings = AppSettings(llm=self.llm_settings, mcp=self.mcp_settings)
+        agent = LocalAgent(settings=settings)
+        dlg = CommandDialog(self, agent=agent)
+        dlg.ShowModal()
         dlg.Destroy()
 
     def _apply_language(self) -> None:

--- a/app/ui/navigation.py
+++ b/app/ui/navigation.py
@@ -29,6 +29,7 @@ class Navigation:
         on_toggle_log_console: Callable[[wx.CommandEvent], None],
         on_show_derivation_graph: Callable[[wx.Event], None],
         on_new_requirement: Callable[[wx.Event], None],
+        on_run_command: Callable[[wx.Event], None],
     ) -> None:
         self.frame = frame
         self.config = config
@@ -42,6 +43,7 @@ class Navigation:
         self.on_toggle_log_console = on_toggle_log_console
         self.on_show_derivation_graph = on_show_derivation_graph
         self.on_new_requirement = on_new_requirement
+        self.on_run_command = on_run_command
         self._recent_items: Dict[int, Path] = {}
         self._column_items: Dict[int, str] = {}
         self.menu_bar = wx.MenuBar()
@@ -49,6 +51,7 @@ class Navigation:
         self.log_menu_item: wx.MenuItem | None = None
         self.recent_menu = wx.Menu()
         self.recent_menu_item: wx.MenuItem | None = None
+        self.run_command_id: int | None = None
         self._build()
 
     # ------------------------------------------------------------------
@@ -87,6 +90,12 @@ class Navigation:
         graph_item = view_menu.Append(wx.ID_ANY, _("Show Derivation Graph"))
         self.frame.Bind(wx.EVT_MENU, self.on_show_derivation_graph, graph_item)
         menu_bar.Append(view_menu, _("&View"))
+
+        tools_menu = wx.Menu()
+        cmd_item = tools_menu.Append(wx.ID_ANY, _("Run Agent Command\tCtrl+K"))
+        self.frame.Bind(wx.EVT_MENU, self.on_run_command, cmd_item)
+        self.run_command_id = cmd_item.GetId()
+        menu_bar.Append(tools_menu, _("&Tools"))
         self.menu_bar = menu_bar
         self.frame.SetMenuBar(self.menu_bar)
 

--- a/tests/test_command_dialog.py
+++ b/tests/test_command_dialog.py
@@ -1,0 +1,107 @@
+import json
+import pytest
+
+from app.agent.local_agent import LocalAgent
+
+
+def test_command_dialog_shows_result_and_saves_history(tmp_path):
+    wx = pytest.importorskip("wx")
+    app = wx.App()
+    from app.ui.command_dialog import CommandDialog
+
+    class DummyLLM:
+        def parse_command(self, text):
+            return "tool", {"a": 1}
+
+    class DummyMCP:
+        def _call_tool(self, name, arguments):
+            return {"value": 42}
+
+    agent = LocalAgent(llm=DummyLLM(), mcp=DummyMCP())
+    history_file = tmp_path / "history.json"
+    dlg = CommandDialog(None, agent=agent, history_path=history_file)
+    dlg.input.SetValue("run")
+    dlg._on_run(None)
+    data = json.loads(dlg.output.GetValue())
+    assert data == {"value": 42}
+    assert dlg.history_list.GetCount() == 1
+    saved = json.loads(history_file.read_text())
+    assert saved[0]["command"] == "run"
+    assert saved[0]["tokens"] == len("run".split()) + len(dlg.output.GetValue().split())
+
+    # clear and reload from history
+    dlg._on_clear(None)
+    assert dlg.output.GetValue() == ""
+    evt = wx.CommandEvent(wx.EVT_LISTBOX.typeId, dlg.history_list.GetId())
+    evt.SetInt(0)
+    dlg._on_select_history(evt)
+    assert json.loads(dlg.output.GetValue()) == {"value": 42}
+
+    dlg.Destroy()
+    app.Destroy()
+
+
+def test_command_dialog_shows_error(tmp_path):
+    wx = pytest.importorskip("wx")
+    app = wx.App()
+    from app.ui.command_dialog import CommandDialog
+
+    class DummyLLM:
+        def parse_command(self, text):
+            return "tool", {}
+
+    class DummyMCP:
+        def _call_tool(self, name, arguments):
+            return {"error": {"code": "FAIL", "message": "bad"}}
+
+    agent = LocalAgent(llm=DummyLLM(), mcp=DummyMCP())
+    history_file = tmp_path / "history.json"
+    dlg = CommandDialog(None, agent=agent, history_path=history_file)
+    dlg.input.SetValue("run")
+    dlg._on_run(None)
+    assert "FAIL" in dlg.output.GetValue()
+    assert dlg.history[0].tokens == len("run".split()) + len(dlg.output.GetValue().split())
+    dlg.Destroy()
+    app.Destroy()
+
+
+def test_command_dialog_persists_between_instances(tmp_path):
+    wx = pytest.importorskip("wx")
+    app = wx.App()
+    from app.ui.command_dialog import CommandDialog
+
+    class DummyAgent:
+        def run_command(self, text):
+            return {"echo": text}
+
+    history_file = tmp_path / "history.json"
+
+    dlg1 = CommandDialog(None, agent=DummyAgent(), history_path=history_file)
+    dlg1.input.SetValue("hello")
+    dlg1._on_run(None)
+    dlg1.Destroy()
+
+    dlg2 = CommandDialog(None, agent=DummyAgent(), history_path=history_file)
+    assert len(dlg2.history) == 1
+    assert dlg2.history[0].command == "hello"
+    assert json.loads(dlg2.history[0].response)["echo"] == "hello"
+    dlg2.Destroy()
+    app.Destroy()
+
+
+def test_command_dialog_handles_invalid_history(tmp_path):
+    wx = pytest.importorskip("wx")
+    app = wx.App()
+    from app.ui.command_dialog import CommandDialog
+
+    bad_file = tmp_path / "history.json"
+    bad_file.write_text("{not json}")
+
+    class DummyAgent:
+        def run_command(self, text):
+            return {}
+
+    dlg = CommandDialog(None, agent=DummyAgent(), history_path=bad_file)
+    assert dlg.history == []
+    dlg.Destroy()
+    app.Destroy()

--- a/tests/test_main_frame_llm_integration.py
+++ b/tests/test_main_frame_llm_integration.py
@@ -1,0 +1,66 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from app.mcp.server import start_server, stop_server
+from app.settings import MCPSettings
+from tests.llm_utils import settings_from_env
+from tests.mcp_utils import _wait_until_ready
+import app.ui.main_frame as main_frame
+import app.ui.command_dialog as cmd
+
+
+
+def test_main_frame_creates_requirement_via_llm(tmp_path: Path, monkeypatch) -> None:
+    wx = pytest.importorskip("wx")
+    port = 8155
+    stop_server()
+    start_server(port=port, base_path=str(tmp_path))
+    try:
+        _wait_until_ready(port)
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "cfg"))
+        settings = settings_from_env(tmp_path)
+        config = main_frame.ConfigManager(app_name="CookaReqTest")
+        config.set_llm_settings(settings.llm)
+        config.set_mcp_settings(
+            MCPSettings(
+                host="127.0.0.1",
+                port=port,
+                base_path=str(tmp_path),
+                require_token=False,
+                token="",
+            )
+        )
+        history_file = tmp_path / "history.json"
+        monkeypatch.setattr(cmd, "_default_history_path", lambda: history_file)
+        command = (
+            "Our users complain about slow logins and missing reports. "
+            "Please create a requirement with id 99 titled 'Pain points test' "
+            "and statement 'The system shall fix slow logins and missing reports', "
+            "type requirement, status draft, owner bob, priority medium, source spec, "
+            "verification analysis."
+        )
+
+        class AutoDialog(cmd.CommandDialog):
+            def ShowModal(self) -> int:  # pragma: no cover - GUI side effect
+                self.input.SetValue(command)
+                self._on_run(None)
+                return wx.ID_OK
+
+        monkeypatch.setattr(main_frame, "CommandDialog", AutoDialog)
+        app = wx.App()
+        frame = main_frame.MainFrame(None, config=config)
+        try:
+            evt = wx.CommandEvent(wx.EVT_MENU.typeId, frame.navigation.run_command_id)
+            frame.ProcessEvent(evt)
+            data = json.loads((tmp_path / "99.json").read_text())
+            assert data["title"] == "Pain points test"
+            stmt = data["statement"].lower()
+            assert "slow logins" in stmt
+            assert "missing reports" in stmt
+        finally:
+            frame.Destroy()
+            app.Destroy()
+    finally:
+        stop_server()


### PR DESCRIPTION
## Summary
- persist agent command chats to disk with token counts
- show previous chats in dialog with scrollable output and clear button
- cover history, selection and error cases with new tests
- add tests for persistence across sessions and invalid history handling
- ensure main frame integrates run-command history properly
- verify main frame can create requirements via OpenRouter and capture user pain points

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5410bcd248320879658fa8aaedfe8