### PR TITLE
feat: manage requirement links and filter by status

### DIFF
--- a/app/ui/filter_dialog.py
+++ b/app/ui/filter_dialog.py
@@ -7,6 +7,8 @@ from typing import Dict
 import wx
 
 from app.core import requirements as req_ops
+from app.core.model import Status
+from . import locale
 
 
 class FilterDialog(wx.Dialog):
@@ -49,6 +51,17 @@ class FilterDialog(wx.Dialog):
         self.match_any.SetValue(values.get("match_any", False))
         sizer.Add(self.match_any, 0, wx.ALL, 5)
 
+        # Status filter
+        sizer.Add(wx.StaticText(self, label=_("Status")), 0, wx.ALL, 5)
+        self._status_values = [s.value for s in Status]
+        status_choices = [_("(any)")] + [locale.STATUS[v] for v in self._status_values]
+        self.status_choice = wx.Choice(self, choices=status_choices)
+        selected = 0
+        if values.get("status") in self._status_values:
+            selected = self._status_values.index(values["status"]) + 1
+        self.status_choice.SetSelection(selected)
+        sizer.Add(self.status_choice, 0, wx.EXPAND | wx.ALL, 5)
+
         # Derived filters
         self.is_derived = wx.CheckBox(self, label=_("Derived only"))
         self.is_derived.SetValue(values.get("is_derived", False))
@@ -74,6 +87,8 @@ class FilterDialog(wx.Dialog):
             "query": self.any_query.GetValue(),
             "labels": labels,
             "match_any": self.match_any.GetValue(),
+            "status": (self._status_values[self.status_choice.GetSelection() - 1]
+                        if self.status_choice.GetSelection() > 0 else None),
             "is_derived": self.is_derived.GetValue(),
             "has_derived": self.has_derived.GetValue(),
             "suspect_only": self.suspect_only.GetValue(),

--- a/app/ui/requirement_model.py
+++ b/app/ui/requirement_model.py
@@ -23,6 +23,7 @@ class RequirementModel:
         self._is_derived: bool = False
         self._has_derived: bool = False
         self._suspect_only: bool = False
+        self._status: str | None = None
         self._sort_field: str | None = None
         self._sort_ascending: bool = True
 
@@ -82,6 +83,10 @@ class RequirementModel:
         self._suspect_only = value
         self._refresh()
 
+    def set_status(self, status: str | None) -> None:
+        self._status = status
+        self._refresh()
+
     def set_field_queries(self, queries: dict[str, str]) -> None:
         """Set per-field text filters."""
         self._field_queries = queries
@@ -95,8 +100,9 @@ class RequirementModel:
 
     # helpers ---------------------------------------------------------
     def _refresh(self) -> None:
+        base = req_ops.filter_by_status(self._all, self._status)
         self._visible = req_ops.search_loaded(
-            self._all,
+            base,
             labels=self._labels,
             query=self._query,
             fields=self._fields,

--- a/tests/test_editor_panel_gui.py
+++ b/tests/test_editor_panel_gui.py
@@ -179,6 +179,23 @@ def test_editor_toggle_derived_link_updates_data(tmp_path):
     assert result.derived_from[0].suspect is True
 
 
+def test_editor_loads_links(tmp_path):
+    panel = _make_panel()
+    data = {
+        "id": 5,
+        "parent": {"source_id": 1, "source_revision": 1, "suspect": False},
+        "links": {
+            "verifies": [{"source_id": 2, "source_revision": 1, "suspect": False}],
+            "relates": [{"source_id": 3, "source_revision": 1, "suspect": False}],
+        },
+    }
+    panel.load(data, path=tmp_path / "req.json", mtime=0.0)
+    result = panel.get_data()
+    assert result.parent is not None and result.parent.source_id == 1
+    assert result.links.verifies and result.links.verifies[0].source_id == 2
+    assert result.links.relates and result.links.relates[0].source_id == 3
+
+
 def test_multiline_fields_resize_dynamically():
     panel = _make_panel()
     wx = pytest.importorskip("wx")

--- a/tests/test_list_panel.py
+++ b/tests/test_list_panel.py
@@ -381,6 +381,32 @@ def test_apply_filters(monkeypatch):
     assert [r.id for r in panel.model.get_visible()] == [2]
 
 
+def test_apply_status_filter(monkeypatch):
+    wx_stub, mixins, ulc = _build_wx_stub()
+    agw = types.SimpleNamespace(ultimatelistctrl=ulc)
+    monkeypatch.setitem(sys.modules, "wx", wx_stub)
+    monkeypatch.setitem(sys.modules, "wx.lib.mixins.listctrl", mixins)
+    monkeypatch.setitem(sys.modules, "wx.lib.agw", agw)
+    monkeypatch.setitem(sys.modules, "wx.lib.agw.ultimatelistctrl", ulc)
+
+    list_panel_module = importlib.import_module("app.ui.list_panel")
+    importlib.reload(list_panel_module)
+    RequirementModel = importlib.import_module("app.ui.requirement_model").RequirementModel
+    ListPanel = list_panel_module.ListPanel
+
+    frame = wx_stub.Panel(None)
+    panel = ListPanel(frame, model=RequirementModel())
+    panel.set_requirements([
+        _req(1, "A", status=Status.DRAFT),
+        _req(2, "B", status=Status.APPROVED),
+    ])
+
+    panel.apply_filters({"status": "approved"})
+    assert [r.id for r in panel.model.get_visible()] == [2]
+    panel.apply_filters({"status": None})
+    assert [r.id for r in panel.model.get_visible()] == [1, 2]
+
+
 def test_labels_column_renders_joined(monkeypatch):
     wx_stub, mixins, ulc = _build_wx_stub()
     agw = types.SimpleNamespace(ultimatelistctrl=ulc)

--- a/tests/test_requirement_model.py
+++ b/tests/test_requirement_model.py
@@ -1,0 +1,27 @@
+import pytest
+from app.ui.requirement_model import RequirementModel
+from app.core.model import Requirement, RequirementType, Status, Priority, Verification
+
+
+def _req(id: int, status: Status) -> Requirement:
+    return Requirement(
+        id=id,
+        title="T",
+        statement="S",
+        type=RequirementType.REQUIREMENT,
+        status=status,
+        owner="o",
+        priority=Priority.MEDIUM,
+        source="s",
+        verification=Verification.ANALYSIS,
+    )
+
+
+def test_status_filter():
+    model = RequirementModel()
+    model.set_requirements([_req(1, Status.DRAFT), _req(2, Status.APPROVED)])
+    assert [r.id for r in model.get_visible()] == [1, 2]
+    model.set_status("approved")
+    assert [r.id for r in model.get_visible()] == [2]
+    model.set_status(None)
+    assert [r.id for r in model.get_visible()] == [1, 2]

--- a/tests/test_requirement_ops.py
+++ b/tests/test_requirement_ops.py
@@ -191,3 +191,21 @@ def test_link_requirements_types(tmp_path: Path) -> None:
     data, _ = load(tmp_path / filename_for(6))
     assert data["links"]["relates"] == [{"source_id": 5, "source_revision": 1, "suspect": False}]
     assert data["revision"] == 2
+
+
+def test_patch_parent_and_links_forbidden(tmp_path: Path) -> None:
+    create_requirement(tmp_path, _base_req(1))
+    create_requirement(tmp_path, _base_req(2))
+    link_requirements(tmp_path, source_id=1, derived_id=2, link_type="parent", rev=1)
+    err = patch_requirement(
+        tmp_path, 2, [{"op": "replace", "path": "/parent", "value": None}], rev=2
+    )
+    assert err["error"]["code"] == ErrorCode.VALIDATION_ERROR
+
+    create_requirement(tmp_path, _base_req(3))
+    create_requirement(tmp_path, _base_req(4))
+    link_requirements(tmp_path, source_id=3, derived_id=4, link_type="verifies", rev=1)
+    err = patch_requirement(
+        tmp_path, 4, [{"op": "replace", "path": "/links", "value": {}}], rev=2
+    )
+    assert err["error"]["code"] == ErrorCode.VALIDATION_ERROR

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -13,6 +13,7 @@ from app.core.search import (
     search,
     search_text,
 )
+from app.core.requirements import filter_by_status
 
 
 def sample_requirements():
@@ -127,5 +128,13 @@ def test_field_queries():
     assert [r.id for r in found] == [1]
     found = search(reqs, field_queries={"title": "report", "owner": "carol"})
     assert [r.id for r in found] == [3]
+
+
+def test_filter_by_status_function():
+    reqs = sample_requirements()
+    reqs[1].status = Status.APPROVED
+    filtered = filter_by_status(reqs, "approved")
+    assert [r.id for r in filtered] == [2]
+    assert filter_by_status(reqs, None) == reqs
 
 


### PR DESCRIPTION
## Summary
- add Parent/Verifies/Relates sections to requirement editor with add/remove controls
- support status-based filtering in UI and model
- show new links and localized statuses in requirement list
- cover new link types and status filter with tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c554ce07c08320a6eb040712ede184