### PR TITLE
Unify ConfigManager interface

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -15,10 +15,28 @@ class ConfigManager:
     def __init__(self, app_name: str = "CookaReq") -> None:
         self._cfg = wx.Config(appName=app_name)
 
-    @property
-    def wx(self) -> wx.Config:  # pragma: no cover - simple property
-        """Expose underlying ``wx.Config`` for low-level operations."""
-        return self._cfg
+    # ------------------------------------------------------------------
+    # basic ``wx.Config`` API
+    def Read(self, key: str, default: str = "") -> str:
+        return self._cfg.Read(key, default)
+
+    def ReadInt(self, key: str, default: int = 0) -> int:
+        return self._cfg.ReadInt(key, default)
+
+    def ReadBool(self, key: str, default: bool = False) -> bool:
+        return self._cfg.ReadBool(key, default)
+
+    def Write(self, key: str, value: str) -> None:
+        self._cfg.Write(key, value)
+
+    def WriteInt(self, key: str, value: int) -> None:
+        self._cfg.WriteInt(key, value)
+
+    def WriteBool(self, key: str, value: bool) -> None:
+        self._cfg.WriteBool(key, value)
+
+    def Flush(self) -> None:  # pragma: no cover - simple wrapper
+        self._cfg.Flush()
 
     # ------------------------------------------------------------------
     # columns
@@ -198,8 +216,8 @@ class ConfigManager:
         client_w = frame.GetClientSize().width
         sash = max(100, min(sash, max(client_w - 100, 100)))
         splitter.SetSashPosition(sash)
-        panel.load_column_widths(self._cfg)
-        panel.load_column_order(self._cfg)
+        panel.load_column_widths(self)
+        panel.load_column_order(self)
         log_shown = self._cfg.ReadBool("log_shown", False)
         log_sash = self._cfg.ReadInt("log_sash", frame.GetClientSize().height - 150)
         if log_shown:
@@ -233,6 +251,6 @@ class ConfigManager:
             self._cfg.WriteInt("log_sash", main_splitter.GetSashPosition())
         else:
             self._cfg.WriteBool("log_shown", False)
-        panel.save_column_widths(self._cfg)
-        panel.save_column_order(self._cfg)
-        self._cfg.Flush()
+        panel.save_column_widths(self)
+        panel.save_column_order(self)
+        self.Flush()

--- a/app/ui/labels_dialog.py
+++ b/app/ui/labels_dialog.py
@@ -5,6 +5,7 @@ from app.i18n import _
 import wx
 
 from app.core.labels import Label, PRESET_SETS, PRESET_SET_TITLES
+from app.config import ConfigManager
 
 
 class LabelsDialog(wx.Dialog):
@@ -15,9 +16,10 @@ class LabelsDialog(wx.Dialog):
         super().__init__(parent, title=_("Labels"), style=style)
         # copy labels to avoid modifying caller until OK
         self._labels: list[Label] = [Label(l.name, l.color) for l in labels]
-        self._config = (
-            parent.config if hasattr(parent, "config") else wx.Config(appName="CookaReq")
-        )
+        cfg = getattr(parent, "config", None)
+        if cfg is None:
+            cfg = ConfigManager()
+        self._config = cfg
 
         self.list = wx.ListCtrl(self, style=wx.LC_REPORT | wx.BORDER_SUNKEN)
         self.list.InsertColumn(0, _("Name"))

--- a/app/ui/main_frame.py
+++ b/app/ui/main_frame.py
@@ -391,8 +391,8 @@ class MainFrame(wx.Frame):
         else:
             self.selected_fields.append(field)
         self.panel.set_columns(self.selected_fields)
-        self.panel.load_column_widths(self.config.wx)
-        self.panel.load_column_order(self.config.wx)
+        self.panel.load_column_widths(self.config)
+        self.panel.load_column_order(self.config)
         self.config.set_columns(self.selected_fields)
 
     def on_toggle_log_console(self, event: wx.CommandEvent) -> None:

--- a/tests/test_config_manager_proxies.py
+++ b/tests/test_config_manager_proxies.py
@@ -1,0 +1,22 @@
+import wx
+
+from app.config import ConfigManager
+
+
+def test_config_manager_proxy_methods(tmp_path):
+    cfg = ConfigManager("TestApp")
+
+    assert cfg.ReadInt("number", 5) == 5
+    cfg.WriteInt("number", 42)
+    cfg.Flush()
+    assert cfg.ReadInt("number", 0) == 42
+
+    assert cfg.Read("text", "") == ""
+    cfg.Write("text", "hello")
+    cfg.Flush()
+    assert cfg.Read("text", "") == "hello"
+
+    assert cfg.ReadBool("flag", False) is False
+    cfg.WriteBool("flag", True)
+    cfg.Flush()
+    assert cfg.ReadBool("flag", False) is True


### PR DESCRIPTION
## Summary
- expose basic wx.Config methods from ConfigManager
- use ConfigManager directly in LabelsDialog and MainFrame
- cover ConfigManager proxy API with tests

## Testing
- `python3 -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c558640d508320a7b0a85a51377516