### PR TITLE
feat: centralize confirmation handling

### DIFF
--- a/app/agent/local_agent.py
+++ b/app/agent/local_agent.py
@@ -2,13 +2,14 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Callable
 
 from app.llm.client import LLMClient
 from app.mcp.client import MCPClient
 from app.mcp.utils import ErrorCode, mcp_error
 from app.settings import AppSettings
 from app.telemetry import log_event
+from app.confirm import confirm as default_confirm
 
 
 class LocalAgent:
@@ -20,12 +21,15 @@ class LocalAgent:
         settings: AppSettings | None = None,
         llm: LLMClient | None = None,
         mcp: MCPClient | None = None,
+        confirm: Callable[[str], bool] | None = None,
     ) -> None:
         if settings is not None:
+            if confirm is None:
+                confirm = default_confirm
             if llm is None:
                 llm = LLMClient(settings.llm)
             if mcp is None:
-                mcp = MCPClient(settings.mcp)
+                mcp = MCPClient(settings.mcp, confirm=confirm)
         if llm is None or mcp is None:
             raise TypeError("settings or clients must be provided")
         self._llm = llm

--- a/app/cli.py
+++ b/app/cli.py
@@ -11,6 +11,9 @@ from .core import model, requirements as req_ops
 from .log import configure_logging
 from .settings import AppSettings, load_app_settings
 from .agent import LocalAgent
+from .confirm import confirm, set_confirm, auto_confirm
+
+set_confirm(auto_confirm)
 
 
 def cmd_list(args: argparse.Namespace) -> None:
@@ -53,7 +56,7 @@ def cmd_show(args: argparse.Namespace) -> None:
 def cmd_check(args: argparse.Namespace) -> None:
     """Verify LLM and MCP connectivity using loaded settings."""
 
-    agent = LocalAgent(settings=args.app_settings)
+    agent = LocalAgent(settings=args.app_settings, confirm=confirm)
     results: dict[str, object] = {}
     if args.llm or not (args.llm or args.mcp):
         results["llm"] = agent.check_llm()

--- a/app/confirm.py
+++ b/app/confirm.py
@@ -1,0 +1,39 @@
+from typing import Callable
+
+ConfirmCallback = Callable[[str], bool]
+_callback: ConfirmCallback | None = None
+
+
+def set_confirm(callback: ConfirmCallback) -> None:
+    """Register confirmation *callback* returning True to proceed."""
+    global _callback
+    _callback = callback
+
+
+def confirm(message: str) -> bool:
+    """Invoke registered confirmation callback with *message*.
+    Raises ``RuntimeError`` if no callback configured.
+    """
+    if _callback is None:
+        raise RuntimeError("Confirmation callback not configured")
+    return _callback(message)
+
+
+def wx_confirm(message: str) -> bool:
+    """GUI confirmation dialog using wxWidgets."""
+    import wx  # type: ignore
+    from app.i18n import _
+
+    return (
+        wx.MessageBox(
+            message,
+            _("Confirm"),
+            style=wx.YES_NO | wx.ICON_WARNING,
+        )
+        == wx.YES
+    )
+
+
+def auto_confirm(_message: str) -> bool:
+    """Confirmation callback that always returns True."""
+    return True

--- a/app/main.py
+++ b/app/main.py
@@ -8,6 +8,7 @@ from .log import configure_logging
 from .config import ConfigManager
 from .ui.requirement_model import RequirementModel
 from . import i18n
+from .confirm import set_confirm, wx_confirm
 
 
 APP_NAME = "CookaReq"
@@ -35,6 +36,7 @@ def main() -> None:
     """Run wx application with the main frame."""
     configure_logging()
     app = wx.App()
+    set_confirm(wx_confirm)
     config = ConfigManager(APP_NAME)
     language = config.get_language()
     app.locale = init_locale(language)

--- a/app/mcp/client.py
+++ b/app/mcp/client.py
@@ -4,9 +4,8 @@ import json
 
 import time
 from http.client import HTTPConnection
-from typing import Any, Mapping
+from typing import Any, Mapping, Callable
 
-import wx
 from app.i18n import _
 from app.telemetry import log_event
 from app.mcp.utils import ErrorCode, mcp_error, sanitize
@@ -16,8 +15,9 @@ from app.settings import MCPSettings
 class MCPClient:
     """Simple HTTP client for the MCP server."""
 
-    def __init__(self, settings: MCPSettings) -> None:
+    def __init__(self, settings: MCPSettings, *, confirm: Callable[[str], bool]) -> None:
         self.settings = settings
+        self._confirm = confirm
 
     # ------------------------------------------------------------------
     def check_tools(self) -> dict[str, Any]:
@@ -80,8 +80,7 @@ class MCPClient:
                 msg = _("Delete requirement?")
             else:
                 msg = _("Update requirement?")
-            res = wx.MessageBox(msg, _("Confirm"), style=wx.YES_NO | wx.ICON_WARNING)
-            confirmed = res == wx.YES
+            confirmed = self._confirm(msg)
             log_event("CONFIRM_RESULT", {"tool": name, "confirmed": confirmed})
             if not confirmed:
                 err = mcp_error("CANCELLED", _("Cancelled by user"))["error"]

--- a/app/ui/labels_dialog.py
+++ b/app/ui/labels_dialog.py
@@ -1,6 +1,7 @@
 """Dialog for managing label colors."""
 
 from app.i18n import _
+from app.confirm import confirm
 
 import wx
 
@@ -140,12 +141,7 @@ class LabelsDialog(wx.Dialog):
         self.color_picker.Disable()
 
     def _on_clear_all(self, _event: wx.Event) -> None:  # pragma: no cover - GUI event
-        res = wx.MessageBox(
-            _("Remove all labels?"),
-            _("Confirm"),
-            style=wx.YES_NO | wx.ICON_WARNING,
-        )
-        if res == wx.YES:
+        if confirm(_("Remove all labels?")):
             self._labels.clear()
             self._populate()
             self.color_picker.Disable()

--- a/app/ui/main_frame.py
+++ b/app/ui/main_frame.py
@@ -18,6 +18,7 @@ from app.core.labels import Label
 from app.mcp.controller import MCPController
 from app.settings import AppSettings, LLMSettings, MCPSettings
 from app.agent import LocalAgent
+from app.confirm import confirm
 from .list_panel import ListPanel
 from .editor_panel import EditorPanel
 from .settings_dialog import SettingsDialog
@@ -231,7 +232,7 @@ class MainFrame(wx.Frame):
 
     def on_run_command(self, event: wx.Event) -> None:
         settings = AppSettings(llm=self.llm_settings, mcp=self.mcp_settings)
-        agent = LocalAgent(settings=settings)
+        agent = LocalAgent(settings=settings, confirm=confirm)
         dlg = CommandDialog(self, agent=agent)
         dlg.ShowModal()
         dlg.Destroy()
@@ -298,10 +299,7 @@ class MainFrame(wx.Frame):
                 msg = _(
                     "Labels in use will be removed from requirements:\n%s\nContinue?"
                 ) % "\n".join(lines)
-                res = wx.MessageBox(
-                    msg, _("Confirm"), style=wx.YES_NO | wx.ICON_WARNING
-                )
-                if res != wx.YES:
+                if not confirm(msg):
                     dlg.Destroy()
                     return
                 self.labels_controller.update_labels(

--- a/app/ui/settings_dialog.py
+++ b/app/ui/settings_dialog.py
@@ -215,7 +215,7 @@ class SettingsDialog(wx.Dialog):
         self._llm_status.SetLabel(label)
 
     def _on_check_tools(self, event: wx.Event) -> None:  # pragma: no cover - GUI event
-        client = MCPClient(settings=self._current_settings())
+        client = MCPClient(settings=self._current_settings(), confirm=lambda _m: True)
         result = client.check_tools()
         label = _("ok") if result.get("ok") else _("error")
         self._tools_status.SetLabel(label)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,6 +23,7 @@ _load_dotenv()
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 import pytest
+from app.confirm import set_confirm, auto_confirm
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -42,6 +43,12 @@ def _virtual_display():
         yield
     finally:
         display.stop()
+
+
+@pytest.fixture(autouse=True)
+def _auto_confirm():
+    set_confirm(auto_confirm)
+    yield
 
 
 @pytest.hookimpl(tryfirst=True)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -87,7 +87,7 @@ def test_cli_check_uses_agent(tmp_path, monkeypatch, capsys):
     called: dict[str, object] = {}
 
     class DummyAgent:
-        def __init__(self, settings):
+        def __init__(self, settings, confirm):
             called["settings"] = settings
 
         def check_llm(self):

--- a/tests/test_labels_dialog.py
+++ b/tests/test_labels_dialog.py
@@ -76,13 +76,12 @@ def test_labels_dialog_deletes_selected():
     app.Destroy()
 
 
-def test_labels_dialog_clear_all(monkeypatch):
+def test_labels_dialog_clear_all():
     wx = pytest.importorskip("wx")
     app = wx.App()
     from app.ui.labels_dialog import LabelsDialog
 
     dlg = LabelsDialog(None, [Label("a", "#111111")])
-    monkeypatch.setattr(wx, "MessageBox", lambda *a, **k: wx.YES)
     dlg._on_clear_all(None)
     assert dlg.get_labels() == []
     dlg.Destroy()
@@ -221,12 +220,13 @@ def test_main_frame_manage_labels_deletes_used(monkeypatch, tmp_path):
 
     calls = {}
 
-    def fake_message(msg, *args, **kwargs):
+    def fake_confirm(msg: str) -> bool:
         calls["msg"] = msg
-        return wx.YES
+        return True
 
     monkeypatch.setattr(main_frame_mod, "LabelsDialog", DummyLabelsDialog)
-    monkeypatch.setattr(wx, "MessageBox", fake_message)
+    from app import confirm as confirm_mod
+    confirm_mod.set_confirm(fake_confirm)
 
     evt = wx.CommandEvent(wx.EVT_MENU.typeId, frame.manage_labels_id)
     frame.ProcessEvent(evt)

--- a/tests/test_main_frame_gui.py
+++ b/tests/test_main_frame_gui.py
@@ -95,7 +95,7 @@ def test_main_frame_run_command_menu(monkeypatch):
             called["destroy"] = True
 
     class DummyAgent:
-        def __init__(self, settings):
+        def __init__(self, settings, confirm):
             called["agent"] = True
 
     import app.ui.main_frame as main_frame
@@ -124,7 +124,7 @@ def test_main_frame_run_command_history_persists(monkeypatch, tmp_path):
     monkeypatch.setattr(cmd, "_default_history_path", lambda: history_file)
 
     class DummyAgent:
-        def __init__(self, settings=None):
+        def __init__(self, settings=None, confirm=None):
             pass
         def run_command(self, text):
             return {"ok": 1}

--- a/tests/test_mcp_llm_integration.py
+++ b/tests/test_mcp_llm_integration.py
@@ -2,8 +2,6 @@ import json
 import logging
 from pathlib import Path
 
-import wx
-
 from app.log import logger
 from app.agent import LocalAgent
 from app.mcp.server import JsonlHandler, start_server, stop_server
@@ -20,7 +18,7 @@ def test_create_and_delete_requirement_via_llm(tmp_path: Path, monkeypatch) -> N
         settings = settings_with_mcp(
             "127.0.0.1", port, str(tmp_path), "", tmp_path=tmp_path
         )
-        client = LocalAgent(settings=settings)
+        client = LocalAgent(settings=settings, confirm=lambda _m: True)
         log_file = tmp_path / "integration.jsonl"
         handler = JsonlHandler(str(log_file))
         logger.addHandler(handler)
@@ -38,7 +36,6 @@ def test_create_and_delete_requirement_via_llm(tmp_path: Path, monkeypatch) -> N
             assert data["title"] == "LLM test"
             assert data["owner"] == "alice"
             rev = data["revision"]
-            monkeypatch.setattr(wx, "MessageBox", lambda *a, **k: wx.YES)
             text_delete = f"Delete requirement 10 with revision {rev}. I confirm the deletion."
             delete_result = client.run_command(text_delete)
             assert delete_result["id"] == 10

--- a/tests/test_mcp_text_commands.py
+++ b/tests/test_mcp_text_commands.py
@@ -18,7 +18,7 @@ def test_run_command_list_logs(tmp_path: Path) -> None:
         settings = settings_with_mcp(
             "127.0.0.1", port, str(tmp_path), "", tmp_path=tmp_path
         )
-        client = LocalAgent(settings=settings)
+        client = LocalAgent(settings=settings, confirm=lambda _m: True)
         log_file = tmp_path / "cmd.jsonl"
         handler = JsonlHandler(str(log_file))
         logger.addHandler(handler)
@@ -46,7 +46,7 @@ def test_run_command_error_logs(tmp_path: Path) -> None:
         settings = settings_with_mcp(
             "127.0.0.1", port, str(tmp_path), "", tmp_path=tmp_path
         )
-        client = LocalAgent(settings=settings)
+        client = LocalAgent(settings=settings, confirm=lambda _m: True)
         log_file = tmp_path / "err.jsonl"
         handler = JsonlHandler(str(log_file))
         logger.addHandler(handler)

--- a/tests/test_settings_dialog.py
+++ b/tests/test_settings_dialog.py
@@ -195,7 +195,10 @@ def test_llm_agent_checks(monkeypatch):
             return {"ok": True}
 
     monkeypatch.setattr("app.ui.settings_dialog.LLMClient", lambda *, settings: DummyLLM(settings=settings))
-    monkeypatch.setattr("app.ui.settings_dialog.MCPClient", lambda *, settings: DummyMCP(settings=settings))
+    monkeypatch.setattr(
+        "app.ui.settings_dialog.MCPClient",
+        lambda *, settings, confirm: DummyMCP(settings=settings),
+    )
 
     dlg = SettingsDialog(
         None,


### PR DESCRIPTION
## Summary
- introduce configurable `confirm` service with wx and CLI implementations
- route MainFrame and Labels dialog prompts through the new service
- configure CLI and GUI startup to register appropriate confirmation callbacks

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c55fc32f988320a5a0c1af1cc47928