### PR TITLE
Expose MCPClient.call_tool API and isolate config path

### DIFF
--- a/app/agent/local_agent.py
+++ b/app/agent/local_agent.py
@@ -57,4 +57,4 @@ class LocalAgent:
             err = mcp_error(ErrorCode.VALIDATION_ERROR, str(exc))["error"]
             log_event("ERROR", {"error": err})
             return {"error": err}
-        return self._mcp._call_tool(name, arguments)
+        return self._mcp.call_tool(name, arguments)

--- a/app/config.py
+++ b/app/config.py
@@ -12,8 +12,13 @@ from app.settings import LLMSettings, MCPSettings, AppSettings, UISettings
 class ConfigManager:
     """Wrapper around :class:`wx.Config` with typed helpers."""
 
-    def __init__(self, app_name: str = "CookaReq") -> None:
-        self._cfg = wx.Config(appName=app_name)
+    def __init__(self, app_name: str = "CookaReq", path: Path | str | None = None) -> None:
+        if path is None:
+            self._cfg = wx.Config(appName=app_name)
+        else:
+            p = Path(path)
+            p.parent.mkdir(parents=True, exist_ok=True)
+            self._cfg = wx.FileConfig(appName=app_name, localFilename=str(p))
 
     # ------------------------------------------------------------------
     # basic ``wx.Config`` API

--- a/app/mcp/client.py
+++ b/app/mcp/client.py
@@ -71,7 +71,7 @@ class MCPClient:
             return err
 
     # ------------------------------------------------------------------
-    def _call_tool(self, name: str, arguments: Mapping[str, Any]) -> dict[str, Any]:
+    def call_tool(self, name: str, arguments: Mapping[str, Any]) -> dict[str, Any]:
         """Invoke *name* tool with *arguments* on the MCP server."""
 
         if name in {"delete_requirement", "patch_requirement"}:
@@ -120,4 +120,10 @@ class MCPClient:
             log_event("TOOL_RESULT", {"error": err}, start_time=start)
             log_event("ERROR", {"error": err})
             return {"error": err}
+
+    # ------------------------------------------------------------------
+    def _call_tool(self, name: str, arguments: Mapping[str, Any]) -> dict[str, Any]:
+        """Backward compatible wrapper for :meth:`call_tool`."""
+
+        return self.call_tool(name, arguments)
 

--- a/tests/test_command_dialog.py
+++ b/tests/test_command_dialog.py
@@ -14,7 +14,7 @@ def test_command_dialog_shows_result_and_saves_history(tmp_path):
             return "tool", {"a": 1}
 
     class DummyMCP:
-        def _call_tool(self, name, arguments):
+        def call_tool(self, name, arguments):
             return {"value": 42}
 
     agent = LocalAgent(llm=DummyLLM(), mcp=DummyMCP())
@@ -51,7 +51,7 @@ def test_command_dialog_shows_error(tmp_path):
             return "tool", {}
 
     class DummyMCP:
-        def _call_tool(self, name, arguments):
+        def call_tool(self, name, arguments):
             return {"error": {"code": "FAIL", "message": "bad"}}
 
     agent = LocalAgent(llm=DummyLLM(), mcp=DummyMCP())

--- a/tests/test_config_manager_proxies.py
+++ b/tests/test_config_manager_proxies.py
@@ -4,19 +4,23 @@ from app.config import ConfigManager
 
 
 def test_config_manager_proxy_methods(tmp_path):
-    cfg = ConfigManager("TestApp")
+    app = wx.App()
+    try:
+        cfg = ConfigManager(app_name="TestApp", path=tmp_path / "cfg.ini")
 
-    assert cfg.ReadInt("number", 5) == 5
-    cfg.WriteInt("number", 42)
-    cfg.Flush()
-    assert cfg.ReadInt("number", 0) == 42
+        assert cfg.ReadInt("number", 5) == 5
+        cfg.WriteInt("number", 42)
+        cfg.Flush()
+        assert cfg.ReadInt("number", 0) == 42
 
-    assert cfg.Read("text", "") == ""
-    cfg.Write("text", "hello")
-    cfg.Flush()
-    assert cfg.Read("text", "") == "hello"
+        assert cfg.Read("text", "") == ""
+        cfg.Write("text", "hello")
+        cfg.Flush()
+        assert cfg.Read("text", "") == "hello"
 
-    assert cfg.ReadBool("flag", False) is False
-    cfg.WriteBool("flag", True)
-    cfg.Flush()
-    assert cfg.ReadBool("flag", False) is True
+        assert cfg.ReadBool("flag", False) is False
+        cfg.WriteBool("flag", True)
+        cfg.Flush()
+        assert cfg.ReadBool("flag", False) is True
+    finally:
+        app.Destroy()

--- a/tests/test_main_frame_llm_integration.py
+++ b/tests/test_main_frame_llm_integration.py
@@ -17,11 +17,11 @@ def test_main_frame_creates_requirement_via_llm(tmp_path: Path, monkeypatch) -> 
     port = 8155
     stop_server()
     start_server(port=port, base_path=str(tmp_path))
+    app = wx.App()
     try:
         _wait_until_ready(port)
-        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "cfg"))
         settings = settings_from_env(tmp_path)
-        config = main_frame.ConfigManager(app_name="CookaReqTest")
+        config = main_frame.ConfigManager(app_name="CookaReqTest", path=tmp_path / "cfg.ini")
         config.set_llm_settings(settings.llm)
         config.set_mcp_settings(
             MCPSettings(
@@ -49,7 +49,6 @@ def test_main_frame_creates_requirement_via_llm(tmp_path: Path, monkeypatch) -> 
                 return wx.ID_OK
 
         monkeypatch.setattr(main_frame, "CommandDialog", AutoDialog)
-        app = wx.App()
         frame = main_frame.MainFrame(None, config=config)
         try:
             evt = wx.CommandEvent(wx.EVT_MENU.typeId, frame.navigation.run_command_id)
@@ -61,6 +60,6 @@ def test_main_frame_creates_requirement_via_llm(tmp_path: Path, monkeypatch) -> 
             assert "missing reports" in stmt
         finally:
             frame.Destroy()
-            app.Destroy()
     finally:
+        app.Destroy()
         stop_server()

--- a/tests/test_mcp_client.py
+++ b/tests/test_mcp_client.py
@@ -75,7 +75,7 @@ def test_call_tool_delete_requires_confirmation(monkeypatch) -> None:
 
     monkeypatch.setattr("app.mcp.client.HTTPConnection", DummyConn)
 
-    res = client._call_tool("delete_requirement", {"req_id": 1, "rev": 1})
+    res = client.call_tool("delete_requirement", {"req_id": 1, "rev": 1})
     assert res["error"]["code"] == "CANCELLED"
     assert called["msg"] is not None
 
@@ -120,7 +120,7 @@ def test_call_tool_delete_confirm_yes(monkeypatch) -> None:
 
     monkeypatch.setattr("app.mcp.client.HTTPConnection", factory)
 
-    res = client._call_tool("delete_requirement", {})
+    res = client.call_tool("delete_requirement", {})
     assert res == {}
     assert conns and conns[0].requested is True
     assert ("CONFIRM", {"tool": "delete_requirement"}) in events


### PR DESCRIPTION
## Summary
- add public `call_tool` to MCPClient and delegate old `_call_tool`
- update LocalAgent and tests to use the new API
- allow `ConfigManager` to use a custom config file path and update tests to isolate configs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c56515b6588320bc2e87b3f4dd8952