### PR TITLE
fix: update editor when selecting any list column

### DIFF
--- a/app/ui/main_frame.py
+++ b/app/ui/main_frame.py
@@ -353,7 +353,10 @@ class MainFrame(wx.Frame):
     # recent directories -------------------------------------------------
 
     def on_requirement_selected(self, event: wx.ListEvent) -> None:
-        req_id = event.GetData()
+        index = event.GetIndex()
+        if index == wx.NOT_FOUND:
+            return
+        req_id = self.panel.list.GetItemData(index)
         req = self.model.get_by_id(req_id)
         if req:
             self.editor.load(req)

--- a/tests/test_main_frame_gui.py
+++ b/tests/test_main_frame_gui.py
@@ -400,3 +400,32 @@ def test_main_frame_delete_requirement_removes_file(monkeypatch, tmp_path):
 
     frame.Destroy()
     app.Destroy()
+
+
+def test_main_frame_select_any_column_updates_editor(monkeypatch, tmp_path):
+    from app.core.store import save
+
+    save(tmp_path, _sample_requirement())
+
+    wx, app, frame = _prepare_frame(monkeypatch, tmp_path)
+
+    # Add an extra column so clicks on it should still update the editor
+    frame.panel.set_columns(["id"])
+    frame.panel.set_requirements(frame.model.get_all())
+
+    class DummyEvent:
+        def GetData(self):
+            return 0
+
+        def GetIndex(self):
+            return 0
+
+    frame.editor.Hide()
+    frame.editor.fields["title"].SetValue("")
+
+    frame.on_requirement_selected(DummyEvent())
+
+    assert frame.editor.fields["title"].GetValue() == "Title"
+
+    frame.Destroy()
+    app.Destroy()


### PR DESCRIPTION
## Summary
- fix requirement selection handler to always lookup row index
- add regression test ensuring editor updates when clicking non-title columns

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c56b2bd47c83209e181af3b2b4cb67