### PR TITLE
feat: log missing translations

### DIFF
--- a/app/cli.py
+++ b/app/cli.py
@@ -1,6 +1,10 @@
 """Command-line interface for CookaReq."""
 from __future__ import annotations
 
+import os
+import atexit
+from pathlib import Path
+from app import i18n
 from app.i18n import _
 
 import argparse
@@ -11,6 +15,11 @@ from .log import configure_logging
 from .settings import AppSettings, load_app_settings
 from .agent import LocalAgent
 from .confirm import confirm, set_confirm, auto_confirm
+
+APP_NAME = "CookaReq"
+LOCALE_DIR = os.path.join(os.path.dirname(__file__), "locale")
+MISSING_PATH = Path(LOCALE_DIR) / "missing.po"
+atexit.register(i18n.flush_missing, MISSING_PATH)
 
 set_confirm(auto_confirm)
 

--- a/app/i18n.py
+++ b/app/i18n.py
@@ -9,13 +9,45 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import Iterable
+import threading
+
+
+def _unescape(text: str) -> str:
+    """Unescape common sequences in PO file strings."""
+    return (
+        text.replace("\\n", "\n")
+        .replace("\\t", "\t")
+        .replace('\\"', '"')
+        .replace("\\\\", "\\")
+    )
+
+
+def _escape(text: str) -> str:
+    """Escape strings for writing to PO files."""
+    return (
+        text.replace("\\", "\\\\")
+        .replace('"', '\\"')
+        .replace("\n", "\\n")
+        .replace("\t", "\\t")
+    )
 
 _translations: dict[str, str] = {}
+_missing: set[str] = set()
+_lock = threading.Lock()
 
 
 def gettext(message: str) -> str:
-    """Return translated ``message`` or the original if not found."""
-    return _translations.get(message, message)
+    """Return translated ``message`` or the original if not found.
+
+    Untranslated messages are collected for later persistence in
+    ``missing.po`` so they can be added to the main catalog.
+    """
+    translated = _translations.get(message)
+    if translated is None:
+        with _lock:
+            _missing.add(message)
+        return message
+    return translated
 
 
 _ = gettext  # public alias used by UI modules
@@ -41,23 +73,55 @@ def _parse_po(path: Path) -> dict[str, str]:
                 msgid = msgstr = state = None
                 continue
             if line.startswith("msgid "):
-                msgid = line[6:].strip().strip('"')
+                msgid = _unescape(line[6:].strip().strip('"'))
                 msgstr = None
                 state = "msgid"
                 continue
             if line.startswith("msgstr "):
-                msgstr = line[7:].strip().strip('"')
+                msgstr = _unescape(line[7:].strip().strip('"'))
                 state = "msgstr"
                 continue
             if line.startswith('"') and state == "msgid":
-                msgid += line.strip('"')
+                msgid += _unescape(line.strip('"'))
                 continue
             if line.startswith('"') and state == "msgstr":
-                msgstr += line.strip('"')
+                msgstr += _unescape(line.strip('"'))
                 continue
     if msgid not in (None, "") and msgstr is not None:
         result[msgid] = msgstr
     return result
+
+
+def flush_missing(path: Path) -> None:
+    """Atomically write collected missing ``msgid`` values to ``path``.
+
+    The file is written in ``.po`` format with empty ``msgstr`` fields.  Only
+    new ``msgid`` values are appended; existing entries are preserved.
+    ``path`` is created along with its parent directories if needed.
+    """
+    with _lock:
+        if not _missing:
+            return
+        path.parent.mkdir(parents=True, exist_ok=True)
+        existing: set[str] = set()
+        if path.exists():
+            existing = set(_parse_po(path))
+            with path.open("r", encoding="utf-8") as f:
+                lines = f.readlines()
+        else:
+            lines = []
+        new = [m for m in sorted(_missing) if m not in existing]
+        if not new:
+            _missing.clear()
+            return
+        for msg in new:
+            lines.append(f'msgid "{_escape(msg)}"\n')
+            lines.append('msgstr ""\n\n')
+        tmp_path = path.with_suffix(path.suffix + ".tmp")
+        with tmp_path.open("w", encoding="utf-8") as f:
+            f.writelines(lines)
+        tmp_path.replace(path)
+        _missing.clear()
 
 
 def install(domain: str, localedir: str, languages: Iterable[str] | None = None) -> None:

--- a/app/locale/en/LC_MESSAGES/CookaReq.po
+++ b/app/locale/en/LC_MESSAGES/CookaReq.po
@@ -307,3 +307,254 @@ msgstr "show requirement details"
 
 msgid "text search query"
 msgstr "text search query"
+
+# Added missing translations
+msgid "&Tools"
+msgstr "&Tools"
+
+msgid "(Derived)"
+msgstr "(Derived)"
+
+msgid "(any)"
+msgstr "(any)"
+
+msgid "(none)"
+msgstr "(none)"
+
+msgid "Add"
+msgstr "Add"
+
+msgid "Add derived"
+msgstr "Add derived"
+
+msgid "Add presets"
+msgstr "Add presets"
+
+msgid "Agent Command"
+msgstr "Agent Command"
+
+msgid "Any field contains"
+msgstr "Any field contains"
+
+msgid "Applied margin."
+msgstr "Applied margin."
+
+msgid "Approved at"
+msgstr "Approved at"
+
+msgid "Assumptions"
+msgstr "Assumptions"
+
+msgid "Assumptions used during derivation."
+msgstr "Assumptions used during derivation."
+
+msgid "Attachments"
+msgstr "Attachments"
+
+msgid "Cancelled by user"
+msgstr "Cancelled by user"
+
+msgid "Check MCP"
+msgstr "Check MCP"
+
+msgid "Clear"
+msgstr "Clear"
+
+msgid "Clear all"
+msgstr "Clear all"
+
+msgid "Columns"
+msgstr "Columns"
+
+msgid "Confirm"
+msgstr "Confirm"
+
+msgid "Delete requirement?"
+msgstr "Delete requirement?"
+
+msgid "Derivation Graph"
+msgstr "Derivation Graph"
+
+msgid "Derivation method."
+msgstr "Derivation method."
+
+msgid "Derive"
+msgstr "Derive"
+
+msgid "Derived from"
+msgstr "Derived from"
+
+msgid "Derived only"
+msgstr "Derived only"
+
+msgid "File"
+msgstr "File"
+
+msgid "Filters"
+msgstr "Filters"
+
+msgid "General"
+msgstr "General"
+
+msgid "Graphviz 'dot' executable not found."
+msgstr "Graphviz 'dot' executable not found."
+
+msgid "Has derived"
+msgstr "Has derived"
+
+msgid "Host"
+msgstr "Host"
+
+msgid "Install networkx and graphviz to view the derivation graph."
+msgstr "Install networkx and graphviz to view the derivation graph."
+
+msgid "Label already exists"
+msgstr "Label already exists"
+
+msgid "Labels"
+msgstr "Labels"
+
+msgid "Labels in use will be removed from requirements:\n%s\nContinue?"
+msgstr "Labels in use will be removed from requirements:\n%s\nContinue?"
+
+msgid "MCP"
+msgstr "MCP"
+
+msgid "Manage Labels"
+msgstr "Manage Labels"
+
+msgid "Margin"
+msgstr "Margin"
+
+msgid "Match any labels"
+msgstr "Match any labels"
+
+msgid "Method"
+msgstr "Method"
+
+msgid "Name"
+msgstr "Name"
+
+msgid "New name"
+msgstr "New name"
+
+msgid "No Data"
+msgstr "No Data"
+
+msgid "No derivation links found."
+msgstr "No derivation links found."
+
+msgid "No requirements loaded"
+msgstr "No requirements loaded"
+
+msgid "Nominal"
+msgstr "Nominal"
+
+msgid "Nominal must be a number"
+msgstr "Nominal must be a number"
+
+msgid "Note"
+msgstr "Note"
+
+msgid "Notes"
+msgstr "Notes"
+
+msgid "Parent"
+msgstr "Parent"
+
+msgid "Path"
+msgstr "Path"
+
+msgid "Port"
+msgstr "Port"
+
+msgid "Quantity"
+msgstr "Quantity"
+
+msgid "Rationale"
+msgstr "Rationale"
+
+msgid "Reasoning for the derivation."
+msgstr "Reasoning for the derivation."
+
+msgid "Relates"
+msgstr "Relates"
+
+msgid "Remove"
+msgstr "Remove"
+
+msgid "Remove all labels?"
+msgstr "Remove all labels?"
+
+msgid "Rename"
+msgstr "Rename"
+
+msgid "Require token"
+msgstr "Require token"
+
+msgid "Run"
+msgstr "Run"
+
+msgid "Run Agent Command\tCtrl+K"
+msgstr "Run Agent Command\tCtrl+K"
+
+msgid "Select attachment"
+msgstr "Select attachment"
+
+msgid "Select requirements folder first"
+msgstr "Select requirements folder first"
+
+msgid "Set"
+msgstr "Set"
+
+msgid "Show Derivation Graph"
+msgstr "Show Derivation Graph"
+
+msgid "Start MCP"
+msgstr "Start MCP"
+
+msgid "Stop MCP"
+msgstr "Stop MCP"
+
+msgid "Suspect only"
+msgstr "Suspect only"
+
+msgid "Token"
+msgstr "Token"
+
+msgid "Tolerance"
+msgstr "Tolerance"
+
+msgid "Tolerance must be a number"
+msgstr "Tolerance must be a number"
+
+msgid "Units"
+msgstr "Units"
+
+msgid "Units require quantity and nominal"
+msgstr "Units require quantity and nominal"
+
+msgid "Update requirement?"
+msgstr "Update requirement?"
+
+msgid "Verifies"
+msgstr "Verifies"
+
+msgid "check only LLM"
+msgstr "check only LLM"
+
+msgid "check only MCP"
+msgstr "check only MCP"
+
+msgid "not running"
+msgstr "not running"
+
+msgid "path to JSON/TOML settings"
+msgstr "path to JSON/TOML settings"
+
+msgid "ready"
+msgstr "ready"
+
+msgid "verify LLM and MCP settings"
+msgstr "verify LLM and MCP settings"
+

--- a/app/locale/ru/LC_MESSAGES/CookaReq.po
+++ b/app/locale/ru/LC_MESSAGES/CookaReq.po
@@ -298,3 +298,254 @@ msgstr "показать детали требования"
 
 msgid "requirement id"
 msgstr "идентификатор требования"
+
+# Added missing translations
+msgid "&Tools"
+msgstr "&Инструменты"
+
+msgid "(Derived)"
+msgstr "(производное)"
+
+msgid "(any)"
+msgstr "(любое)"
+
+msgid "(none)"
+msgstr "(нет)"
+
+msgid "Add"
+msgstr "Добавить"
+
+msgid "Add derived"
+msgstr "Добавить производное"
+
+msgid "Add presets"
+msgstr "Добавить пресеты"
+
+msgid "Agent Command"
+msgstr "Команда агента"
+
+msgid "Any field contains"
+msgstr "Любое поле содержит"
+
+msgid "Applied margin."
+msgstr "Применённый запас."
+
+msgid "Approved at"
+msgstr "Утверждено"
+
+msgid "Assumptions"
+msgstr "Допущения"
+
+msgid "Assumptions used during derivation."
+msgstr "Допущения, использованные при выводе."
+
+msgid "Attachments"
+msgstr "Вложения"
+
+msgid "Cancelled by user"
+msgstr "Отменено пользователем"
+
+msgid "Check MCP"
+msgstr "Проверить MCP"
+
+msgid "Clear"
+msgstr "Очистить"
+
+msgid "Clear all"
+msgstr "Очистить всё"
+
+msgid "Columns"
+msgstr "Колонки"
+
+msgid "Confirm"
+msgstr "Подтвердить"
+
+msgid "Delete requirement?"
+msgstr "Удалить требование?"
+
+msgid "Derivation Graph"
+msgstr "Граф выводов"
+
+msgid "Derivation method."
+msgstr "Метод вывода."
+
+msgid "Derive"
+msgstr "Вывести"
+
+msgid "Derived from"
+msgstr "Получено из"
+
+msgid "Derived only"
+msgstr "Только производные"
+
+msgid "File"
+msgstr "Файл"
+
+msgid "Filters"
+msgstr "Фильтры"
+
+msgid "General"
+msgstr "Общее"
+
+msgid "Graphviz 'dot' executable not found."
+msgstr "Не найден исполняемый файл Graphviz 'dot'."
+
+msgid "Has derived"
+msgstr "Имеет производные"
+
+msgid "Host"
+msgstr "Хост"
+
+msgid "Install networkx and graphviz to view the derivation graph."
+msgstr "Установите networkx и graphviz для просмотра графа выводов."
+
+msgid "Label already exists"
+msgstr "Метка уже существует"
+
+msgid "Labels"
+msgstr "Метки"
+
+msgid "Labels in use will be removed from requirements:\n%s\nContinue?"
+msgstr "Используемые метки будут удалены из требований:\n%s\nПродолжить?"
+
+msgid "MCP"
+msgstr "MCP"
+
+msgid "Manage Labels"
+msgstr "Управление метками"
+
+msgid "Margin"
+msgstr "Запас"
+
+msgid "Match any labels"
+msgstr "Совпадает с любой меткой"
+
+msgid "Method"
+msgstr "Метод"
+
+msgid "Name"
+msgstr "Имя"
+
+msgid "New name"
+msgstr "Новое имя"
+
+msgid "No Data"
+msgstr "Нет данных"
+
+msgid "No derivation links found."
+msgstr "Связи вывода не найдены."
+
+msgid "No requirements loaded"
+msgstr "Требования не загружены"
+
+msgid "Nominal"
+msgstr "Номинал"
+
+msgid "Nominal must be a number"
+msgstr "Номинал должен быть числом"
+
+msgid "Note"
+msgstr "Примечание"
+
+msgid "Notes"
+msgstr "Примечания"
+
+msgid "Parent"
+msgstr "Родитель"
+
+msgid "Path"
+msgstr "Путь"
+
+msgid "Port"
+msgstr "Порт"
+
+msgid "Quantity"
+msgstr "Количество"
+
+msgid "Rationale"
+msgstr "Обоснование"
+
+msgid "Reasoning for the derivation."
+msgstr "Обоснование вывода."
+
+msgid "Relates"
+msgstr "Связи"
+
+msgid "Remove"
+msgstr "Удалить"
+
+msgid "Remove all labels?"
+msgstr "Удалить все метки?"
+
+msgid "Rename"
+msgstr "Переименовать"
+
+msgid "Require token"
+msgstr "Требуется токен"
+
+msgid "Run"
+msgstr "Запустить"
+
+msgid "Run Agent Command\tCtrl+K"
+msgstr "Запустить команду агента\tCtrl+K"
+
+msgid "Select attachment"
+msgstr "Выберите вложение"
+
+msgid "Select requirements folder first"
+msgstr "Сначала выберите папку требований"
+
+msgid "Set"
+msgstr "Установить"
+
+msgid "Show Derivation Graph"
+msgstr "Показать граф выводов"
+
+msgid "Start MCP"
+msgstr "Запустить MCP"
+
+msgid "Stop MCP"
+msgstr "Остановить MCP"
+
+msgid "Suspect only"
+msgstr "Только подозрительные"
+
+msgid "Token"
+msgstr "Токен"
+
+msgid "Tolerance"
+msgstr "Допуск"
+
+msgid "Tolerance must be a number"
+msgstr "Допуск должен быть числом"
+
+msgid "Units"
+msgstr "Единицы"
+
+msgid "Units require quantity and nominal"
+msgstr "Для единиц требуются количество и номинал"
+
+msgid "Update requirement?"
+msgstr "Обновить требование?"
+
+msgid "Verifies"
+msgstr "Проверяет"
+
+msgid "check only LLM"
+msgstr "проверить только LLM"
+
+msgid "check only MCP"
+msgstr "проверить только MCP"
+
+msgid "not running"
+msgstr "не запущен"
+
+msgid "path to JSON/TOML settings"
+msgstr "путь к настройкам JSON/TOML"
+
+msgid "ready"
+msgstr "готов"
+
+msgid "verify LLM and MCP settings"
+msgstr "проверить настройки LLM и MCP"
+

--- a/app/main.py
+++ b/app/main.py
@@ -1,6 +1,8 @@
 """Application entry point for CookaReq."""
 
 import os
+import atexit
+from pathlib import Path
 import wx
 
 from .ui.main_frame import MainFrame
@@ -13,6 +15,8 @@ from .confirm import set_confirm, wx_confirm
 
 APP_NAME = "CookaReq"
 LOCALE_DIR = os.path.join(os.path.dirname(__file__), "locale")
+MISSING_PATH = Path(LOCALE_DIR) / "missing.po"
+atexit.register(i18n.flush_missing, MISSING_PATH)
 
 
 def init_locale(language: str | None = None) -> wx.Locale:

--- a/tests/test_i18n_escape.py
+++ b/tests/test_i18n_escape.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+from app import i18n
+
+def test_parse_po_unescape(tmp_path):
+    po = tmp_path / "sample.po"
+    po.write_text('msgid "Line\\nBreak\\tTab"\nmsgstr "Перевод\\nСтрока\\tТаб"\n', encoding="utf-8")
+    data = i18n._parse_po(po)
+    assert data["Line\nBreak\tTab"] == "Перевод\nСтрока\tТаб"
+
+def test_flush_missing_escape(tmp_path):
+    i18n._missing.clear()
+    i18n._missing.add("Line\nBreak\tTab")
+    path = tmp_path / "missing.po"
+    i18n.flush_missing(path)
+    content = path.read_text(encoding="utf-8")
+    assert 'Line\\nBreak\\tTab' in content
+    parsed = i18n._parse_po(path)
+    assert "Line\nBreak\tTab" in parsed
+    i18n._missing.clear()

--- a/tests/test_missing_translations.py
+++ b/tests/test_missing_translations.py
@@ -1,0 +1,30 @@
+import threading
+from app import i18n
+
+
+def test_flush_missing_writes_unique_msgids(tmp_path):
+    """Missing msgids are collected once and flushed to file atomically."""
+    i18n._translations = {}
+    i18n._missing.clear()
+
+    def worker():
+        for _ in range(5):
+            i18n.gettext("untranslated")
+
+    threads = [threading.Thread(target=worker) for _ in range(3)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    path = tmp_path / "missing.po"
+    i18n.flush_missing(path)
+    data = path.read_text(encoding="utf-8")
+    assert data.count('msgid "untranslated"') == 1
+
+    i18n.gettext("untranslated")
+    i18n.gettext("second")
+    i18n.flush_missing(path)
+    data = path.read_text(encoding="utf-8")
+    assert data.count('msgid "untranslated"') == 1
+    assert 'msgid "second"' in data


### PR DESCRIPTION
## Summary
- handle escape sequences in `.po` files and when flushing missing msgids
- translate all previously missing strings and update English catalog
- cover escape handling with dedicated tests

## Testing
- `python3 -m pytest tests/test_i18n_escape.py -q`
- `python3 -m pytest tests/test_missing_translations.py -q`
- `python3 -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5718b619c8320b504bd5221131da9