### PR TITLE
Add telemetry sanitization tests

### DIFF
--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -19,6 +19,22 @@ def test_sanitize_redacts_sensitive_keys() -> None:
     assert sanitized["user"] == "alice"
 
 
+def test_sanitize_redacts_nested_sensitive_keys() -> None:
+    data = {
+        "outer": {
+            "Token": "abc",
+            "inner": {"password": "p@ss", "value": 42},
+        },
+        "list": [{"secret": "s"}, {"Authorization": "Bearer"}],
+    }
+    sanitized = sanitize(data)
+    assert sanitized["outer"]["Token"] == REDACTED
+    assert sanitized["outer"]["inner"]["password"] == REDACTED
+    assert sanitized["outer"]["inner"]["value"] == 42
+    assert sanitized["list"][0]["secret"] == REDACTED
+    assert sanitized["list"][1]["Authorization"] == REDACTED
+
+
 def test_log_event_records_size_and_duration_and_sanitizes_payload(tmp_path: Path, monkeypatch) -> None:
     log_file = tmp_path / "telemetry.jsonl"
     handler = JsonlHandler(str(log_file))
@@ -27,15 +43,28 @@ def test_log_event_records_size_and_duration_and_sanitizes_payload(tmp_path: Pat
     logger.setLevel(logging.INFO)
     try:
         monkeypatch.setattr(telemetry.time, "monotonic", lambda: 2.0)
-        payload = {"token": "secret", "foo": "bar"}
+        payload = {
+            "token": "secret",
+            "foo": "bar",
+            "nested": {"password": "p@ss"},
+            "list": [{"api_key": "key"}],
+        }
         log_event("TEST_EVENT", payload, start_time=1.0)
     finally:
         logger.setLevel(prev_level)
         logger.removeHandler(handler)
     entry = json.loads(log_file.read_text().splitlines()[0])
-    sanitized_payload = {"token": REDACTED, "foo": "bar"}
+    sanitized_payload = {
+        "token": REDACTED,
+        "foo": "bar",
+        "nested": {"password": REDACTED},
+        "list": [{"api_key": REDACTED}],
+    }
     expected_size = len(json.dumps(sanitized_payload, ensure_ascii=False).encode("utf-8"))
     assert entry["payload"] == sanitized_payload
-    assert "secret" not in json.dumps(entry)
+    log_text = json.dumps(entry)
+    assert "secret" not in log_text
+    assert "p@ss" not in log_text
+    assert '"key"' not in log_text
     assert entry["size_bytes"] == expected_size
     assert entry["duration_ms"] == 1000


### PR DESCRIPTION
## Summary
- test sanitize() redacts sensitive keys
- verify log_event writes size and duration and redacts payload

## Testing
- `python3 -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c575368144832092dc6afa2b5f1069