### PR TITLE
Add confirmation module tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ Thumbs.db
 
 # Localization
 *.mo
+app/locale/missing.po
 
 # Logs
 server.log

--- a/tests/test_confirm.py
+++ b/tests/test_confirm.py
@@ -1,0 +1,35 @@
+import pytest
+
+from app import confirm as confirm_mod
+from app.confirm import set_confirm, auto_confirm, wx_confirm
+
+
+def test_confirm_without_callback_raises(monkeypatch):
+    monkeypatch.setattr(confirm_mod, "_callback", None, raising=False)
+    with pytest.raises(RuntimeError):
+        confirm_mod.confirm("Are you sure?")
+
+
+def test_set_confirm_and_auto_confirm_work():
+    captured = {}
+
+    def fake_callback(message: str) -> bool:
+        captured["message"] = message
+        return False
+
+    set_confirm(fake_callback)
+    assert confirm_mod.confirm("no") is False
+    assert captured["message"] == "no"
+
+    set_confirm(auto_confirm)
+    assert confirm_mod.confirm("yes") is True
+
+
+def test_wx_confirm(monkeypatch):
+    import wx
+
+    monkeypatch.setattr(wx, "MessageBox", lambda *a, **k: wx.YES)
+    assert wx_confirm("Proceed?") is True
+
+    monkeypatch.setattr(wx, "MessageBox", lambda *a, **k: wx.NO)
+    assert wx_confirm("Proceed?") is False


### PR DESCRIPTION
## Summary
- add tests for confirmation callback behavior
- test wx-based confirmation dialog with mocked MessageBox
- ignore missing translation file

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c575329bf08320b52081c23c517cee