### PR TITLE
Add logging configuration tests

### DIFF
--- a/tests/test_logging_config.py
+++ b/tests/test_logging_config.py
@@ -1,0 +1,34 @@
+import logging
+import pytest
+
+from app.log import configure_logging, logger
+
+
+@pytest.fixture
+def reset_logger() -> None:
+    prev_handlers = list(logger.handlers)
+    prev_level = logger.level
+    logger.handlers.clear()
+    logger.setLevel(logging.NOTSET)
+    try:
+        yield
+    finally:
+        logger.handlers.clear()
+        logger.handlers.extend(prev_handlers)
+        logger.setLevel(prev_level)
+
+
+def test_configure_logging_adds_handler_once(reset_logger: None) -> None:
+    configure_logging()
+    assert len(logger.handlers) == 1
+    first_handler = logger.handlers[0]
+    configure_logging()
+    assert len(logger.handlers) == 1
+    assert logger.handlers[0] is first_handler
+
+
+def test_configure_logging_sets_level(reset_logger: None) -> None:
+    configure_logging(level=logging.DEBUG)
+    assert logger.level == logging.DEBUG
+    configure_logging(level=logging.WARNING)
+    assert logger.level == logging.DEBUG


### PR DESCRIPTION
## Summary
- test that configure_logging adds only one handler even when called multiple times
- test that configure_logging honors the initial logging level

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c579c38b5883209817cbf64b44480d