### PR TITLE
test: share wx app via fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -51,6 +51,14 @@ def _auto_confirm():
     yield
 
 
+@pytest.fixture(scope="session")
+def wx_app():
+    wx = pytest.importorskip("wx")
+    app = wx.App()
+    yield app
+    app.Destroy()
+
+
 @pytest.hookimpl(tryfirst=True)
 def pytest_sessionstart(session):
     session.config._start_time = time.time()

--- a/tests/test_app_icon.py
+++ b/tests/test_app_icon.py
@@ -5,14 +5,12 @@ import wx
 from app.ui.main_frame import MainFrame
 
 
-def test_main_frame_loads_multiple_icon_sizes():
+def test_main_frame_loads_multiple_icon_sizes(wx_app):
     """Main frame should expose all icon sizes for taskbar usage."""
-    app = wx.App()
     frame = MainFrame(None)
     try:
         bundle = frame.GetIcons()
         assert bundle.GetIconCount() >= 2
     finally:
         frame.Destroy()
-        app.Destroy()
 

--- a/tests/test_command_dialog.py
+++ b/tests/test_command_dialog.py
@@ -4,9 +4,8 @@ import pytest
 from app.agent.local_agent import LocalAgent
 
 
-def test_command_dialog_shows_result_and_saves_history(tmp_path):
+def test_command_dialog_shows_result_and_saves_history(tmp_path, wx_app):
     wx = pytest.importorskip("wx")
-    app = wx.App()
     from app.ui.command_dialog import CommandDialog
 
     class DummyLLM:
@@ -38,12 +37,10 @@ def test_command_dialog_shows_result_and_saves_history(tmp_path):
     assert json.loads(dlg.output.GetValue()) == {"value": 42}
 
     dlg.Destroy()
-    app.Destroy()
 
 
-def test_command_dialog_shows_error(tmp_path):
+def test_command_dialog_shows_error(tmp_path, wx_app):
     wx = pytest.importorskip("wx")
-    app = wx.App()
     from app.ui.command_dialog import CommandDialog
 
     class DummyLLM:
@@ -62,12 +59,10 @@ def test_command_dialog_shows_error(tmp_path):
     assert "FAIL" in dlg.output.GetValue()
     assert dlg.history[0].tokens == len("run".split()) + len(dlg.output.GetValue().split())
     dlg.Destroy()
-    app.Destroy()
 
 
-def test_command_dialog_persists_between_instances(tmp_path):
+def test_command_dialog_persists_between_instances(tmp_path, wx_app):
     wx = pytest.importorskip("wx")
-    app = wx.App()
     from app.ui.command_dialog import CommandDialog
 
     class DummyAgent:
@@ -86,12 +81,10 @@ def test_command_dialog_persists_between_instances(tmp_path):
     assert dlg2.history[0].command == "hello"
     assert json.loads(dlg2.history[0].response)["echo"] == "hello"
     dlg2.Destroy()
-    app.Destroy()
 
 
-def test_command_dialog_handles_invalid_history(tmp_path):
+def test_command_dialog_handles_invalid_history(tmp_path, wx_app):
     wx = pytest.importorskip("wx")
-    app = wx.App()
     from app.ui.command_dialog import CommandDialog
 
     bad_file = tmp_path / "history.json"
@@ -104,4 +97,3 @@ def test_command_dialog_handles_invalid_history(tmp_path):
     dlg = CommandDialog(None, agent=DummyAgent(), history_path=bad_file)
     assert dlg.history == []
     dlg.Destroy()
-    app.Destroy()

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -27,8 +27,7 @@ class DummyListPanel:
 
 
 @pytest.mark.parametrize("log_shown", [True, False])
-def test_save_and_restore_layout(tmp_path, log_shown):
-    app = wx.App()
+def test_save_and_restore_layout(tmp_path, log_shown, wx_app):
     cfg = ConfigManager(app_name="TestApp", path=tmp_path / "cfg.ini")
 
     frame = wx.Frame(None)
@@ -78,8 +77,7 @@ def test_save_and_restore_layout(tmp_path, log_shown):
         assert not new_log.IsShown()
 
 
-def test_app_settings_round_trip(tmp_path):
-    app = wx.App()
+def test_app_settings_round_trip(tmp_path, wx_app):
     cfg = ConfigManager(app_name="TestApp", path=tmp_path / "cfg.ini")
 
     app_settings = AppSettings(
@@ -101,8 +99,7 @@ def test_app_settings_round_trip(tmp_path):
     assert loaded == app_settings
 
 
-def test_sort_settings_round_trip(tmp_path):
-    app = wx.App()
+def test_sort_settings_round_trip(tmp_path, wx_app):
     cfg = ConfigManager(app_name="TestApp", path=tmp_path / "cfg.ini")
 
     cfg.set_sort_settings(3, False)
@@ -111,8 +108,7 @@ def test_sort_settings_round_trip(tmp_path):
     assert cfg.ReadBool("sort_ascending") is False
 
 
-def test_restore_layout_without_show(tmp_path):
-    app = wx.App()
+def test_restore_layout_without_show(tmp_path, wx_app):
     cfg = ConfigManager(app_name="TestApp", path=tmp_path / "cfg.ini")
 
     # Save initial layout with a known sash position

--- a/tests/test_config_manager_proxies.py
+++ b/tests/test_config_manager_proxies.py
@@ -3,24 +3,20 @@ import wx
 from app.config import ConfigManager
 
 
-def test_config_manager_proxy_methods(tmp_path):
-    app = wx.App()
-    try:
-        cfg = ConfigManager(app_name="TestApp", path=tmp_path / "cfg.ini")
+def test_config_manager_proxy_methods(tmp_path, wx_app):
+    cfg = ConfigManager(app_name="TestApp", path=tmp_path / "cfg.ini")
 
-        assert cfg.ReadInt("number", 5) == 5
-        cfg.WriteInt("number", 42)
-        cfg.Flush()
-        assert cfg.ReadInt("number", 0) == 42
+    assert cfg.ReadInt("number", 5) == 5
+    cfg.WriteInt("number", 42)
+    cfg.Flush()
+    assert cfg.ReadInt("number", 0) == 42
 
-        assert cfg.Read("text", "") == ""
-        cfg.Write("text", "hello")
-        cfg.Flush()
-        assert cfg.Read("text", "") == "hello"
+    assert cfg.Read("text", "") == ""
+    cfg.Write("text", "hello")
+    cfg.Flush()
+    assert cfg.Read("text", "") == "hello"
 
-        assert cfg.ReadBool("flag", False) is False
-        cfg.WriteBool("flag", True)
-        cfg.Flush()
-        assert cfg.ReadBool("flag", False) is True
-    finally:
-        app.Destroy()
+    assert cfg.ReadBool("flag", False) is False
+    cfg.WriteBool("flag", True)
+    cfg.Flush()
+    assert cfg.ReadBool("flag", False) is True

--- a/tests/test_editor_panel.py
+++ b/tests/test_editor_panel.py
@@ -8,7 +8,6 @@ from app.core.labels import Label
 
 def _make_panel():
     wx = pytest.importorskip("wx")
-    _app = wx.App()
     frame = wx.Frame(None)
     from app.ui.editor_panel import EditorPanel
     return EditorPanel(frame)
@@ -29,7 +28,7 @@ def _base_data():
     }
 
 
-def test_editor_save_and_delete(tmp_path):
+def test_editor_save_and_delete(tmp_path, wx_app):
     panel = _make_panel()
     panel.new_requirement()
     panel.fields["id"].SetValue("1")
@@ -67,7 +66,7 @@ def test_editor_save_and_delete(tmp_path):
     assert not path.exists()
 
 
-def test_editor_clone(tmp_path):
+def test_editor_clone(tmp_path, wx_app):
     from app.core import store
 
     orig_path = store.save(tmp_path, _base_data())
@@ -84,7 +83,7 @@ def test_editor_clone(tmp_path):
     assert data["title"] == orig_data["title"]
 
 
-def test_get_data_requires_valid_id():
+def test_get_data_requires_valid_id(wx_app):
     panel = _make_panel()
     panel.new_requirement()
     with pytest.raises(ValueError):
@@ -100,7 +99,7 @@ def test_get_data_requires_valid_id():
     assert data.id == 10
 
 
-def test_enum_localization_roundtrip():
+def test_enum_localization_roundtrip(wx_app):
     wx = pytest.importorskip("wx")
     from app.ui import locale
 
@@ -140,7 +139,7 @@ def test_enum_localization_roundtrip():
     assert data.verification == Verification.DEMONSTRATION
 
 
-def test_labels_selection_and_update():
+def test_labels_selection_and_update(wx_app):
     panel = _make_panel()
     panel.update_labels_list([Label("ui", "#ff0000"), Label("backend", "#00ff00")])
     panel.new_requirement()
@@ -155,7 +154,7 @@ def test_labels_selection_and_update():
     assert panel.extra["labels"] == []
 
 
-def test_loading_requirement_without_labels_clears_display():
+def test_loading_requirement_without_labels_clears_display(wx_app):
     panel = _make_panel()
     panel.update_labels_list([Label("ui", "#ff0000")])
     panel.load({"id": 1, "labels": ["ui"]})

--- a/tests/test_editor_panel_gui.py
+++ b/tests/test_editor_panel_gui.py
@@ -7,13 +7,12 @@ from app.core.labels import Label
 
 def _make_panel():
     wx = pytest.importorskip("wx")
-    _app = wx.App()
     frame = wx.Frame(None)
     from app.ui.editor_panel import EditorPanel
     return EditorPanel(frame)
 
 
-def test_editor_new_requirement_resets(tmp_path):
+def test_editor_new_requirement_resets(tmp_path, wx_app):
     panel = _make_panel()
     data = {
         "id": 1,
@@ -47,7 +46,7 @@ def test_editor_new_requirement_resets(tmp_path):
     assert defaults.units is None
 
 
-def test_editor_add_attachment_included():
+def test_editor_add_attachment_included(wx_app):
     panel = _make_panel()
     panel.new_requirement()
     panel.add_attachment("file.txt", "note")
@@ -56,7 +55,7 @@ def test_editor_add_attachment_included():
     assert [asdict(a) for a in data.attachments] == [{"path": "file.txt", "note": "note"}]
 
 
-def test_id_field_highlight_on_duplicate(tmp_path):
+def test_id_field_highlight_on_duplicate(tmp_path, wx_app):
     wx = pytest.importorskip("wx")
     from app.core import store
 
@@ -88,7 +87,7 @@ def test_id_field_highlight_on_duplicate(tmp_path):
     assert panel.fields["id"].GetBackgroundColour() == default
 
 
-def test_editor_load_populates_fields(tmp_path):
+def test_editor_load_populates_fields(tmp_path, wx_app):
     panel = _make_panel()
     data = {
         "id": 1,
@@ -135,7 +134,7 @@ def test_editor_load_populates_fields(tmp_path):
     assert panel.mtime == 42.0
 
 
-def test_editor_clone_resets_path_and_mtime(tmp_path):
+def test_editor_clone_resets_path_and_mtime(tmp_path, wx_app):
     panel = _make_panel()
     panel.load({"id": 1}, path=tmp_path / "old.json", mtime=1.0)
     panel.clone(2)
@@ -144,7 +143,7 @@ def test_editor_clone_resets_path_and_mtime(tmp_path):
     assert panel.mtime is None
 
 
-def test_editor_save_and_delete_roundtrip(tmp_path):
+def test_editor_save_and_delete_roundtrip(tmp_path, wx_app):
     import json
 
     panel = _make_panel()
@@ -166,7 +165,7 @@ def test_editor_save_and_delete_roundtrip(tmp_path):
     assert panel.mtime is None
     assert not saved_path.exists()
 
-def test_editor_toggle_derived_link_updates_data(tmp_path):
+def test_editor_toggle_derived_link_updates_data(tmp_path, wx_app):
     panel = _make_panel()
     data = {
         "id": 2,
@@ -179,7 +178,7 @@ def test_editor_toggle_derived_link_updates_data(tmp_path):
     assert result.derived_from[0].suspect is True
 
 
-def test_editor_loads_links(tmp_path):
+def test_editor_loads_links(tmp_path, wx_app):
     panel = _make_panel()
     data = {
         "id": 5,
@@ -196,7 +195,7 @@ def test_editor_loads_links(tmp_path):
     assert result.links.relates and result.links.relates[0].source_id == 3
 
 
-def test_multiline_fields_resize_dynamically():
+def test_multiline_fields_resize_dynamically(wx_app):
     panel = _make_panel()
     wx = pytest.importorskip("wx")
     panel.new_requirement()
@@ -216,7 +215,7 @@ def test_multiline_fields_resize_dynamically():
     assert shrunk < grown
     assert shrunk >= line_h * 2
 
-def test_rationale_autosizes_without_affecting_statement():
+def test_rationale_autosizes_without_affecting_statement(wx_app):
     panel = _make_panel()
     wx = pytest.importorskip("wx")
     panel.new_requirement()

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -1,14 +1,13 @@
 import pytest
 
 
-def test_gui_imports():
+def test_gui_imports(wx_app):
     wx = pytest.importorskip("wx")
     from app.main import main
     from app.ui.main_frame import MainFrame
     from app.ui.list_panel import ListPanel
     from app.ui.editor_panel import EditorPanel
 
-    app = wx.App()
     frame = MainFrame(None)
     list_panel = ListPanel(frame)
     editor_panel = EditorPanel(frame)

--- a/tests/test_labels_dialog.py
+++ b/tests/test_labels_dialog.py
@@ -6,9 +6,8 @@ import pytest
 from app.core.labels import Label
 
 
-def test_labels_dialog_changes_color():
+def test_labels_dialog_changes_color(wx_app):
     wx = pytest.importorskip("wx")
-    app = wx.App()
     from app.ui.labels_dialog import LabelsDialog
 
     dlg = LabelsDialog(None, [Label("ui", "#ff0000")])
@@ -27,12 +26,10 @@ def test_labels_dialog_changes_color():
     img = dlg.list.GetImageList(wx.IMAGE_LIST_SMALL).GetBitmap(img_idx).ConvertToImage()
     assert (img.GetRed(0, 0), img.GetGreen(0, 0), img.GetBlue(0, 0)) == (0, 255, 0)
     dlg.Destroy()
-    app.Destroy()
 
 
-def test_labels_dialog_displays_color_rect():
+def test_labels_dialog_displays_color_rect(wx_app):
     wx = pytest.importorskip("wx")
-    app = wx.App()
     from app.ui.labels_dialog import LabelsDialog
 
     dlg = LabelsDialog(None, [Label("ui", "#ff0000")])
@@ -41,12 +38,10 @@ def test_labels_dialog_displays_color_rect():
     img = dlg.list.GetImageList(wx.IMAGE_LIST_SMALL).GetBitmap(img_idx).ConvertToImage()
     assert (img.GetRed(0, 0), img.GetGreen(0, 0), img.GetBlue(0, 0)) == (255, 0, 0)
     dlg.Destroy()
-    app.Destroy()
 
 
-def test_labels_dialog_adds_presets():
+def test_labels_dialog_adds_presets(wx_app):
     wx = pytest.importorskip("wx")
-    app = wx.App()
     from app.ui.labels_dialog import LabelsDialog
     from app.core.labels import PRESET_SETS
 
@@ -58,12 +53,10 @@ def test_labels_dialog_adds_presets():
     dlg._on_add_preset_set("basic")
     assert len(dlg.get_labels()) == len(PRESET_SETS["basic"])
     dlg.Destroy()
-    app.Destroy()
 
 
-def test_labels_dialog_deletes_selected():
+def test_labels_dialog_deletes_selected(wx_app):
     wx = pytest.importorskip("wx")
-    app = wx.App()
     from app.ui.labels_dialog import LabelsDialog
 
     dlg = LabelsDialog(None, [Label("a", "#111111"), Label("b", "#222222"), Label("c", "#333333")])
@@ -73,24 +66,20 @@ def test_labels_dialog_deletes_selected():
     names = [l.name for l in dlg.get_labels()]
     assert names == ["b"]
     dlg.Destroy()
-    app.Destroy()
 
 
-def test_labels_dialog_clear_all():
+def test_labels_dialog_clear_all(wx_app):
     wx = pytest.importorskip("wx")
-    app = wx.App()
     from app.ui.labels_dialog import LabelsDialog
 
     dlg = LabelsDialog(None, [Label("a", "#111111")])
     dlg._on_clear_all(None)
     assert dlg.get_labels() == []
     dlg.Destroy()
-    app.Destroy()
 
 
-def test_labels_dialog_renames_selected(monkeypatch):
+def test_labels_dialog_renames_selected(monkeypatch, wx_app):
     wx = pytest.importorskip("wx")
-    app = wx.App()
     from app.ui.labels_dialog import LabelsDialog
 
     dlg = LabelsDialog(None, [Label("old", "#111111")])
@@ -113,7 +102,6 @@ def test_labels_dialog_renames_selected(monkeypatch):
     dlg._on_rename_selected(None)
     assert dlg.get_labels()[0].name == "new"
     dlg.Destroy()
-    app.Destroy()
 
 
 def _prepare_frame(monkeypatch, tmp_path):
@@ -135,7 +123,6 @@ def _prepare_frame(monkeypatch, tmp_path):
     save(tmp_path, data)
 
     wx = pytest.importorskip("wx")
-    app = wx.App()
 
     class DummyDirDialog:
         def __init__(self, parent, message):
@@ -161,11 +148,11 @@ def _prepare_frame(monkeypatch, tmp_path):
     evt = wx.CommandEvent(wx.EVT_MENU.typeId, wx.ID_OPEN)
     frame.ProcessEvent(evt)
 
-    return wx, app, frame, main_frame
+    return wx, frame, main_frame
 
 
-def test_main_frame_manage_labels_saves(monkeypatch, tmp_path):
-    wx, app, frame, main_frame_mod = _prepare_frame(monkeypatch, tmp_path)
+def test_main_frame_manage_labels_saves(monkeypatch, tmp_path, wx_app):
+    wx, frame, main_frame_mod = _prepare_frame(monkeypatch, tmp_path)
 
     class DummyLabelsDialog:
         def __init__(self, parent, labels):
@@ -201,11 +188,10 @@ def test_main_frame_manage_labels_saves(monkeypatch, tmp_path):
     assert ("panel", ["ui"]) in captured
 
     frame.Destroy()
-    app.Destroy()
 
 
-def test_main_frame_manage_labels_deletes_used(monkeypatch, tmp_path):
-    wx, app, frame, main_frame_mod = _prepare_frame(monkeypatch, tmp_path)
+def test_main_frame_manage_labels_deletes_used(monkeypatch, tmp_path, wx_app):
+    wx, frame, main_frame_mod = _prepare_frame(monkeypatch, tmp_path)
 
     class DummyLabelsDialog:
         def __init__(self, parent, labels):
@@ -241,4 +227,3 @@ def test_main_frame_manage_labels_deletes_used(monkeypatch, tmp_path):
     assert req.labels == []
 
     frame.Destroy()
-    app.Destroy()

--- a/tests/test_labels_sync.py
+++ b/tests/test_labels_sync.py
@@ -20,9 +20,8 @@ def _create_requirement(directory):
     store.save(directory, data)
 
 
-def test_sync_labels_preserves_unused(monkeypatch, tmp_path):
+def test_sync_labels_preserves_unused(monkeypatch, tmp_path, wx_app):
     wx = pytest.importorskip("wx")
-    app = wx.App()
     store.save_labels(tmp_path, PRESET_SETS["basic"])
     _create_requirement(tmp_path)
     from app.ui.main_frame import MainFrame
@@ -30,4 +29,3 @@ def test_sync_labels_preserves_unused(monkeypatch, tmp_path):
     frame._load_directory(tmp_path)
     assert {l.name for l in frame.labels} == {l.name for l in PRESET_SETS["basic"]}
     frame.Destroy()
-    app.Destroy()

--- a/tests/test_language_switch.py
+++ b/tests/test_language_switch.py
@@ -3,9 +3,8 @@ import importlib
 import pytest
 
 
-def test_switch_to_russian_updates_ui(monkeypatch):
+def test_switch_to_russian_updates_ui(monkeypatch, wx_app):
     wx = pytest.importorskip("wx")
-    app = wx.App()
     import app.ui.main_frame as main_frame
     importlib.reload(main_frame)
 
@@ -53,4 +52,3 @@ def test_switch_to_russian_updates_ui(monkeypatch):
     from app import i18n
     # restore default language for subsequent tests
     i18n.install(main_mod.APP_NAME, main_mod.LOCALE_DIR, ["en"])
-    app.Destroy()

--- a/tests/test_list_panel_gui.py
+++ b/tests/test_list_panel_gui.py
@@ -26,9 +26,8 @@ def _req(id: int, title: str, **kwargs) -> Requirement:
     return Requirement(**base)
 
 
-def test_list_panel_real_widgets():
+def test_list_panel_real_widgets(wx_app):
     wx = pytest.importorskip("wx")
-    app = wx.App()
     import app.ui.list_panel as list_panel
     importlib.reload(list_panel)
     frame = wx.Frame(None)
@@ -50,12 +49,10 @@ def test_list_panel_real_widgets():
     assert panel.list.IsShown()
 
     frame.Destroy()
-    app.Destroy()
 
 
-def test_list_panel_context_menu_calls_handlers(monkeypatch):
+def test_list_panel_context_menu_calls_handlers(monkeypatch, wx_app):
     wx = pytest.importorskip("wx")
-    app = wx.App()
     import app.ui.list_panel as list_panel
     importlib.reload(list_panel)
     frame = wx.Frame(None)
@@ -94,12 +91,10 @@ def test_list_panel_context_menu_calls_handlers(monkeypatch):
     assert reqs[0].version == "2"
 
     frame.Destroy()
-    app.Destroy()
 
 
-def test_list_panel_context_menu_via_event(monkeypatch):
+def test_list_panel_context_menu_via_event(monkeypatch, wx_app):
     wx = pytest.importorskip("wx")
-    app = wx.App()
     import app.ui.list_panel as list_panel
     importlib.reload(list_panel)
     frame = wx.Frame(None)
@@ -111,7 +106,7 @@ def test_list_panel_context_menu_via_event(monkeypatch):
     frame.GetSizer().Add(panel, 1, wx.EXPAND)
     frame.Layout()
     frame.Show()
-    app.Yield()
+    wx_app.Yield()
 
     called: dict[str, tuple[int, int | None]] = {}
 
@@ -129,12 +124,10 @@ def test_list_panel_context_menu_via_event(monkeypatch):
 
     assert called.get("args") == (0, None)
     frame.Destroy()
-    app.Destroy()
 
 
-def test_bulk_edit_updates_selected_items(monkeypatch):
+def test_bulk_edit_updates_selected_items(monkeypatch, wx_app):
     wx = pytest.importorskip("wx")
-    app = wx.App()
     import app.ui.list_panel as list_panel
     importlib.reload(list_panel)
     frame = wx.Frame(None)
@@ -158,12 +151,10 @@ def test_bulk_edit_updates_selected_items(monkeypatch):
     assert [r.version for r in reqs] == ["2", "2"]
     assert [r.type for r in reqs] == [RequirementType.CONSTRAINT, RequirementType.CONSTRAINT]
     frame.Destroy()
-    app.Destroy()
 
 
-def test_recalc_derived_map_updates_count():
+def test_recalc_derived_map_updates_count(wx_app):
     wx = pytest.importorskip("wx")
-    app = wx.App()
     import app.ui.list_panel as list_panel
     importlib.reload(list_panel)
     frame = wx.Frame(None)
@@ -178,4 +169,3 @@ def test_recalc_derived_map_updates_count():
     panel.recalc_derived_map([req1, req2])
     assert panel.list.GetItem(0, 1).GetText() == "0"
     frame.Destroy()
-    app.Destroy()

--- a/tests/test_main_frame_gui_size.py
+++ b/tests/test_main_frame_gui_size.py
@@ -4,7 +4,7 @@ from app.core.store import save
 from app.ui import main_frame
 
 
-def test_main_frame_editor_multiline_fields_have_size(tmp_path, monkeypatch):
+def test_main_frame_editor_multiline_fields_have_size(tmp_path, monkeypatch, wx_app):
     wx = pytest.importorskip("wx")
     data = {
         "id": 1,
@@ -39,16 +39,14 @@ def test_main_frame_editor_multiline_fields_have_size(tmp_path, monkeypatch):
 
     monkeypatch.setattr(wx, "DirDialog", DummyDirDialog)
 
-    app = wx.App()
     frame = main_frame.MainFrame(None)
     evt = wx.CommandEvent(wx.EVT_MENU.typeId, wx.ID_OPEN)
     frame.ProcessEvent(evt)
     frame.Show()
     frame.panel.list.Select(0)
-    app.Yield()
+    wx_app.Yield()
 
     for name in ["statement", "acceptance", "conditions", "trace_up", "trace_down", "source"]:
         assert frame.editor.fields[name].GetSize().GetHeight() > 0
 
     frame.Destroy()
-    app.Destroy()

--- a/tests/test_main_frame_llm_integration.py
+++ b/tests/test_main_frame_llm_integration.py
@@ -12,12 +12,11 @@ import app.ui.command_dialog as cmd
 
 
 
-def test_main_frame_creates_requirement_via_llm(tmp_path: Path, monkeypatch) -> None:
+def test_main_frame_creates_requirement_via_llm(tmp_path: Path, monkeypatch, wx_app) -> None:
     wx = pytest.importorskip("wx")
     port = 8155
     stop_server()
     start_server(port=port, base_path=str(tmp_path))
-    app = wx.App()
     try:
         _wait_until_ready(port)
         settings = settings_from_env(tmp_path)
@@ -61,5 +60,4 @@ def test_main_frame_creates_requirement_via_llm(tmp_path: Path, monkeypatch) -> 
         finally:
             frame.Destroy()
     finally:
-        app.Destroy()
         stop_server()

--- a/tests/test_recent_dirs.py
+++ b/tests/test_recent_dirs.py
@@ -1,9 +1,8 @@
 import importlib
 import pytest
 
-def test_recent_dirs_history(tmp_path):
+def test_recent_dirs_history(tmp_path, wx_app):
     wx = pytest.importorskip("wx")
-    app = wx.App()
     import app.ui.list_panel as list_panel
     import app.ui.main_frame as main_frame
     importlib.reload(list_panel)
@@ -23,4 +22,3 @@ def test_recent_dirs_history(tmp_path):
     assert items == frame.recent_dirs
 
     frame.Destroy()
-    app.Destroy()

--- a/tests/test_settings_dialog.py
+++ b/tests/test_settings_dialog.py
@@ -11,9 +11,8 @@ def test_available_translations_contains_locales():
     assert {"en", "ru"}.issubset(codes)
 
 
-def test_settings_dialog_returns_language():
+def test_settings_dialog_returns_language(wx_app):
     wx = pytest.importorskip("wx")
-    _app = wx.App()
     from app.ui.settings_dialog import SettingsDialog
 
     dlg = SettingsDialog(
@@ -49,9 +48,8 @@ def test_settings_dialog_returns_language():
     dlg.Destroy()
 
 
-def test_mcp_start_stop_server(monkeypatch):
+def test_mcp_start_stop_server(monkeypatch, wx_app):
     wx = pytest.importorskip("wx")
-    _app = wx.App()
     from app.ui.settings_dialog import SettingsDialog
     import app.ui.settings_dialog as sd
     from app.mcp.controller import MCPStatus
@@ -117,9 +115,8 @@ def test_mcp_start_stop_server(monkeypatch):
     dlg.Destroy()
 
 
-def test_mcp_check_status(monkeypatch):
+def test_mcp_check_status(monkeypatch, wx_app):
     wx = pytest.importorskip("wx")
-    _app = wx.App()
     from app.ui.settings_dialog import SettingsDialog
     import app.ui.settings_dialog as sd
     from app.mcp.controller import MCPStatus
@@ -174,9 +171,8 @@ def test_mcp_check_status(monkeypatch):
     dlg.Destroy()
 
 
-def test_llm_agent_checks(monkeypatch):
+def test_llm_agent_checks(monkeypatch, wx_app):
     wx = pytest.importorskip("wx")
-    _app = wx.App()
     from app.ui.settings_dialog import SettingsDialog
     import app.ui.settings_dialog as sd
 


### PR DESCRIPTION
## Summary
- provide session-scoped `wx_app` fixture for GUI tests
- rely on shared fixture instead of creating `wx.App` in each test

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c579ca659c83209c44a37436be6b6a