### PR TITLE
Improve CLI requirement validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ Available commands:
 - `edit <dir> <file>` — update an existing requirement with data from a file
 - `show <dir> <id>` — display the full contents of a requirement as JSON
 
+The `add` and `edit` commands validate the input file before saving. If the
+JSON is malformed or does not match the requirement schema, an error message is
+printed and no changes are written to disk.
+
 ## MCP Integration
 
 The application exposes a Model Context Protocol (MCP) server for interaction with LLM agents.

--- a/app/cli.py
+++ b/app/cli.py
@@ -35,22 +35,40 @@ def cmd_list(args: argparse.Namespace, repo: RequirementRepository) -> None:
 
 def cmd_add(args: argparse.Namespace, repo: RequirementRepository) -> None:
     """Add requirement from JSON file to directory."""
-    with open(args.file, "r", encoding="utf-8") as fh:
-        data = json.load(fh)
-    path = repo.save(args.directory, data)
+    try:
+        with open(args.file, "r", encoding="utf-8") as fh:
+            data = json.load(fh)
+    except json.JSONDecodeError as exc:
+        print(_("Invalid JSON file: {error}").format(error=exc))
+        return
+    try:
+        obj = model.requirement_from_dict(data)
+    except ValueError as exc:
+        print(_("Invalid requirement data: {error}").format(error=exc))
+        return
+    path = repo.save(args.directory, obj)
     print(path)
 
 
 def cmd_edit(args: argparse.Namespace, repo: RequirementRepository) -> None:
     """Edit existing requirement using data from JSON file."""
-    with open(args.file, "r", encoding="utf-8") as fh:
-        data = json.load(fh)
+    try:
+        with open(args.file, "r", encoding="utf-8") as fh:
+            data = json.load(fh)
+    except json.JSONDecodeError as exc:
+        print(_("Invalid JSON file: {error}").format(error=exc))
+        return
+    try:
+        obj = model.requirement_from_dict(data)
+    except ValueError as exc:
+        print(_("Invalid requirement data: {error}").format(error=exc))
+        return
     mtime = None
     try:
-        _, mtime = repo.load(args.directory, data["id"])
+        mtime = repo.load(args.directory, obj.id)[1]
     except FileNotFoundError:
         pass
-    path = repo.save(args.directory, data, mtime=mtime)
+    path = repo.save(args.directory, obj, mtime=mtime)
     print(path)
 
 


### PR DESCRIPTION
## Summary
- handle JSON decoding errors and schema validation in `cmd_add` and `cmd_edit`
- document input validation in README
- add CLI tests for invalid JSON and invalid requirement data

## Testing
- `pytest` *(failed: tests/test_llm_client.py::test_check_llm, tests/test_main_frame_llm_integration.py::test_main_frame_creates_requirement_via_llm, tests/test_mcp_llm_integration.py::test_create_and_delete_requirement_via_llm, tests/test_mcp_text_commands.py::test_run_command_list_logs, tests/test_mcp_text_commands.py::test_run_command_error_logs)*

------
https://chatgpt.com/codex/tasks/task_e_68c587f9661083208be48a2579828956