### PR TITLE
feat: add delete command to CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Available commands:
 - `list <dir>` — print the list of requirements; supports `--labels`, `--query`, and `--fields` for filtering
 - `add <dir> <file>` — add a requirement from a JSON file
 - `edit <dir> <file>` — update an existing requirement with data from a file
+- `delete <dir> <id>` — remove a requirement by id
 - `show <dir> <id>` — display the full contents of a requirement as JSON
 
 ## MCP Integration

--- a/app/cli.py
+++ b/app/cli.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import os
+import sys
 import atexit
 from pathlib import Path
 from app import i18n
@@ -54,6 +55,18 @@ def cmd_edit(args: argparse.Namespace, repo: RequirementRepository) -> None:
     print(path)
 
 
+def cmd_delete(args: argparse.Namespace, repo: RequirementRepository) -> None:
+    """Delete requirement with *id* from *directory*."""
+    try:
+        # Ensure requirement exists to report errors for invalid ids
+        repo.get(args.directory, args.id)
+    except FileNotFoundError:
+        print(f"requirement {args.id} not found", file=sys.stderr)
+        return
+    repo.delete(args.directory, args.id)
+    print("deleted")
+
+
 def cmd_show(args: argparse.Namespace, repo: RequirementRepository) -> None:
     """Show detailed JSON for requirement with *id*."""
     req = repo.get(args.directory, args.id)
@@ -97,6 +110,11 @@ def build_parser() -> argparse.ArgumentParser:
     p_edit.add_argument("directory", help=_("requirements directory"))
     p_edit.add_argument("file", help=_("JSON file with updated requirement"))
     p_edit.set_defaults(func=cmd_edit)
+
+    p_delete = sub.add_parser("delete", help=_("delete requirement"))
+    p_delete.add_argument("directory", help=_("requirements directory"))
+    p_delete.add_argument("id", type=int, help=_("requirement id"))
+    p_delete.set_defaults(func=cmd_delete)
 
     p_show = sub.add_parser("show", help=_("show requirement details"))
     p_show.add_argument("directory", help=_("requirements directory"))

--- a/app/llm/client.py
+++ b/app/llm/client.py
@@ -6,7 +6,9 @@ import json
 import time
 from typing import Any, Tuple, Mapping
 
-from openai import OpenAI
+# ``OpenAI`` импортируется динамически в конструкторе, чтобы тесты могли
+# подменять ``openai.OpenAI`` до первого использования и тем самым избежать
+# реальных сетевых запросов.
 
 from app.telemetry import log_event
 from app.settings import LLMSettings
@@ -17,8 +19,10 @@ class LLMClient:
     """High-level client for LLM operations."""
 
     def __init__(self, settings: LLMSettings) -> None:
+        import openai
+
         self.settings = settings
-        self._client = OpenAI(
+        self._client = openai.OpenAI(
             base_url=self.settings.api_base or None,
             api_key=self.settings.api_key or None,
             timeout=self.settings.timeout,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -56,6 +56,24 @@ def test_cli_edit(tmp_path, capsys):
     assert loaded["title"] == "New title"
 
 
+def test_cli_delete(tmp_path, capsys):
+    data = sample()
+    save(tmp_path, data)
+    main(["delete", str(tmp_path), "1"])
+    captured = capsys.readouterr()
+    assert "deleted" in captured.out
+    assert not (tmp_path / "1.json").exists()
+
+
+def test_cli_delete_invalid_id(tmp_path, capsys):
+    data = sample()
+    save(tmp_path, data)
+    main(["delete", str(tmp_path), "2"])
+    captured = capsys.readouterr()
+    assert "not found" in captured.err
+    assert (tmp_path / "1.json").exists()
+
+
 def test_cli_settings_flag(tmp_path, monkeypatch, capsys):
     req_dir = tmp_path / "reqs"
     req_dir.mkdir()


### PR DESCRIPTION
## Summary
- add CLI handler `delete` to remove a requirement by id
- document the new command in README
- cover delete flow and invalid ids in tests
- defer OpenAI import in `LLMClient` so tests can mock it and avoid real network calls

## Testing
- `python3 -m pytest tests/test_cli.py -q`
- `python3 -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c587e8f3248320b86aaf95b3ffe303