### PR TITLE
feat(cli): add status filter to list command

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ python3 -m app.cli <command> [arguments]
 
 Available commands:
 
-- `list <dir>` — print the list of requirements; supports `--labels`, `--query`, and `--fields` for filtering
+- `list <dir>` — print the list of requirements; supports `--labels`, `--query`, `--fields`, and `--status` for filtering
 - `add <dir> <file>` — add a requirement from a JSON file
 - `edit <dir> <file>` — update an existing requirement with data from a file
 - `delete <dir> <id>` — remove a requirement by id

--- a/app/cli.py
+++ b/app/cli.py
@@ -28,7 +28,11 @@ set_confirm(auto_confirm)
 def cmd_list(args: argparse.Namespace, repo: RequirementRepository) -> None:
     """List requirements in directory, optionally filtered."""
     reqs = repo.search(
-        args.directory, labels=args.labels, query=args.query, fields=args.fields
+        args.directory,
+        labels=args.labels,
+        query=args.query,
+        fields=args.fields,
+        status=args.status,
     )
     for r in reqs:
         print(f"{r.id}: {r.title}")
@@ -117,6 +121,7 @@ def build_parser() -> argparse.ArgumentParser:
     p_list.add_argument("--labels", nargs="*", default=[], help=_("filter by labels"))
     p_list.add_argument("--query", help=_("text search query"))
     p_list.add_argument("--fields", nargs="*", help=_("fields for text search"))
+    p_list.add_argument("--status", help=_("filter by status"))
     p_list.set_defaults(func=cmd_list)
 
     p_add = sub.add_parser("add", help=_("add requirement from JSON file"))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 from app.core.store import save
 from app.settings import AppSettings
+from app.cli import main
 
 
 def sample() -> dict:
@@ -33,6 +34,17 @@ def test_cli_list(tmp_path, capsys):
     run_cli(["list", str(tmp_path)])
     captured = capsys.readouterr().out
     assert "1" in captured
+
+
+def test_cli_list_status_filter(tmp_path, capsys):
+    data1 = sample()
+    data2 = sample() | {"id": 2, "status": "approved"}
+    save(tmp_path, data1)
+    save(tmp_path, data2)
+    run_cli(["list", str(tmp_path), "--status", "approved"])
+    captured = capsys.readouterr().out
+    assert "2" in captured
+    assert "1" not in captured
 
 
 def test_cli_show(tmp_path, capsys):


### PR DESCRIPTION
## Summary
- allow `app.cli list` to filter requirements by status
- test CLI status filtering
- document new `--status` option

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c58bcd848c83209cb5393fbc782394