### PR TITLE
refactor: use relative imports

### DIFF
--- a/app/agent/local_agent.py
+++ b/app/agent/local_agent.py
@@ -4,12 +4,12 @@ from __future__ import annotations
 
 from typing import Any, Callable
 
-from app.llm.client import LLMClient
-from app.mcp.client import MCPClient
-from app.mcp.utils import ErrorCode, mcp_error
-from app.settings import AppSettings
-from app.telemetry import log_event
-from app.confirm import confirm as default_confirm
+from ..llm.client import LLMClient
+from ..mcp.client import MCPClient
+from ..mcp.utils import ErrorCode, mcp_error
+from ..settings import AppSettings
+from ..telemetry import log_event
+from ..confirm import confirm as default_confirm
 
 
 class LocalAgent:

--- a/app/cli.py
+++ b/app/cli.py
@@ -5,8 +5,8 @@ import os
 import sys
 import atexit
 from pathlib import Path
-from app import i18n
-from app.i18n import _
+from . import i18n
+from .i18n import _
 
 import argparse
 import json

--- a/app/config.py
+++ b/app/config.py
@@ -7,7 +7,7 @@ from typing import Protocol
 
 import wx
 
-from app.settings import LLMSettings, MCPSettings, AppSettings, UISettings
+from .settings import LLMSettings, MCPSettings, AppSettings, UISettings
 
 
 class ListPanelLike(Protocol):

--- a/app/confirm.py
+++ b/app/confirm.py
@@ -22,7 +22,7 @@ def confirm(message: str) -> bool:
 def wx_confirm(message: str) -> bool:
     """GUI confirmation dialog using wxWidgets."""
     import wx  # type: ignore
-    from app.i18n import _
+    from .i18n import _
 
     return (
         wx.MessageBox(

--- a/app/core/store.py
+++ b/app/core/store.py
@@ -5,7 +5,7 @@ from dataclasses import asdict, is_dataclass
 import json
 from pathlib import Path
 
-from app.log import logger
+from ..log import logger
 
 from .validate import validate
 from .labels import Label

--- a/app/llm/client.py
+++ b/app/llm/client.py
@@ -10,8 +10,8 @@ from typing import Any, Tuple, Mapping
 # подменять ``openai.OpenAI`` до первого использования и тем самым избежать
 # реальных сетевых запросов.
 
-from app.telemetry import log_event
-from app.settings import LLMSettings
+from ..telemetry import log_event
+from ..settings import LLMSettings
 from .spec import SYSTEM_PROMPT, TOOLS
 
 

--- a/app/mcp/client.py
+++ b/app/mcp/client.py
@@ -6,10 +6,10 @@ import time
 from http.client import HTTPConnection
 from typing import Any, Mapping, Callable
 
-from app.i18n import _
-from app.telemetry import log_event
-from app.mcp.utils import ErrorCode, mcp_error, sanitize
-from app.settings import MCPSettings
+from ..i18n import _
+from ..telemetry import log_event
+from .utils import ErrorCode, mcp_error, sanitize
+from ..settings import MCPSettings
 
 
 class MCPClient:

--- a/app/mcp/controller.py
+++ b/app/mcp/controller.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 from enum import Enum
 from http.client import HTTPConnection
 
-from app.mcp.server import start_server, stop_server, is_running as server_is_running
-from app.settings import MCPSettings
+from .server import start_server, stop_server, is_running as server_is_running
+from ..settings import MCPSettings
 
 
 class MCPStatus(str, Enum):

--- a/app/mcp/server.py
+++ b/app/mcp/server.py
@@ -20,9 +20,9 @@ from fastapi.responses import JSONResponse
 import uvicorn
 from mcp.server.fastmcp import FastMCP
 
-from app.log import JsonlHandler, configure_logging, logger
-from app.mcp.utils import ErrorCode, mcp_error, sanitize
-from app.mcp import tools_read, tools_write
+from ..log import JsonlHandler, configure_logging, logger
+from .utils import ErrorCode, mcp_error, sanitize
+from . import tools_read, tools_write
 
 # Dedicated logger for MCP request logging so global handlers remain untouched
 request_logger = logger.getChild("mcp.requests")

--- a/app/mcp/tools_read.py
+++ b/app/mcp/tools_read.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Sequence
 
-from app.core import requirements as req_ops
-from app.core.model import Requirement, requirement_to_dict
-from app.mcp.utils import ErrorCode, log_tool, mcp_error
+from ..core import requirements as req_ops
+from ..core.model import Requirement, requirement_to_dict
+from .utils import ErrorCode, log_tool, mcp_error
 
 
 def _paginate(requirements: Sequence[Requirement], page: int, per_page: int) -> dict:

--- a/app/mcp/tools_write.py
+++ b/app/mcp/tools_write.py
@@ -6,11 +6,11 @@ from typing import Any, Mapping
 
 import jsonpatch
 import jsonschema
-from app.core.schema import SCHEMA
-from app.core.model import requirement_from_dict, requirement_to_dict
-from app.core.store import ConflictError
-from app.core import requirements as req_ops
-from app.mcp.utils import ErrorCode, log_tool, mcp_error
+from ..core.schema import SCHEMA
+from ..core.model import requirement_from_dict, requirement_to_dict
+from ..core.store import ConflictError
+from ..core import requirements as req_ops
+from .utils import ErrorCode, log_tool, mcp_error
 
 # Fields that must not be modified directly through patching
 UNPATCHABLE_FIELDS = {"id", "revision", "derived_from", "parent", "links"}

--- a/app/mcp/utils.py
+++ b/app/mcp/utils.py
@@ -6,8 +6,8 @@ import datetime
 from enum import Enum
 from typing import Any, Mapping
 
-from app.log import logger
-from app.telemetry import sanitize
+from ..log import logger
+from ..telemetry import sanitize
 
 
 def log_tool(

--- a/app/telemetry.py
+++ b/app/telemetry.py
@@ -5,7 +5,7 @@ import json
 import time
 from typing import Any, Mapping
 
-from app.log import logger
+from .log import logger
 
 # Keys that should be redacted when logging
 SENSITIVE_KEYS = {

--- a/app/ui/command_dialog.py
+++ b/app/ui/command_dialog.py
@@ -5,11 +5,11 @@ from __future__ import annotations
 import json
 from dataclasses import dataclass, asdict
 from pathlib import Path
-from app.i18n import _
+from ..i18n import _
 
 import wx
 
-from app.agent import LocalAgent
+from ..agent import LocalAgent
 
 
 @dataclass

--- a/app/ui/controllers/labels.py
+++ b/app/ui/controllers/labels.py
@@ -3,10 +3,10 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Dict, List
 
-from app.config import ConfigManager
-from app.core import requirements as req_ops
-from app.core.labels import Label
-from app.log import logger
+from ...config import ConfigManager
+from ...core import requirements as req_ops
+from ...core.labels import Label
+from ...log import logger
 
 
 class LabelsController:

--- a/app/ui/controllers/requirements.py
+++ b/app/ui/controllers/requirements.py
@@ -4,12 +4,12 @@ from dataclasses import replace
 from pathlib import Path
 from typing import Dict
 
-from app.i18n import _
+from ...i18n import _
 
-from app.config import ConfigManager
-from app.core.model import Requirement
-from app.core.repository import RequirementRepository, FileRequirementRepository
-from app.log import logger
+from ...config import ConfigManager
+from ...core.model import Requirement
+from ...core.repository import RequirementRepository, FileRequirementRepository
+from ...log import logger
 
 
 class RequirementsController:

--- a/app/ui/derivation_graph.py
+++ b/app/ui/derivation_graph.py
@@ -7,13 +7,13 @@ packages are missing, a friendly message is shown instead of the graph.
 
 from __future__ import annotations
 
-from app.i18n import _
+from ..i18n import _
 import io
 from typing import Sequence
 
 import wx
 
-from app.core.model import Requirement
+from ..core.model import Requirement
 
 
 class DerivationGraphFrame(wx.Frame):

--- a/app/ui/editor_panel.py
+++ b/app/ui/editor_panel.py
@@ -5,16 +5,16 @@ from pathlib import Path
 from typing import Any, Callable
 from contextlib import contextmanager
 
-from app.i18n import _
+from ..i18n import _
 
 import wx
 import wx.adv
 from wx.lib.dialogs import ScrolledMessageDialog
 from wx.lib.scrolledpanel import ScrolledPanel
 
-from app.core import requirements as req_ops
-from app.core.labels import Label
-from app.core.model import (
+from ..core import requirements as req_ops
+from ..core.labels import Label
+from ..core.model import (
     Requirement,
     RequirementType,
     Status,

--- a/app/ui/filter_dialog.py
+++ b/app/ui/filter_dialog.py
@@ -1,13 +1,13 @@
 """Dialog for configuring requirement filters."""
 from __future__ import annotations
 
-from app.i18n import _
+from ..i18n import _
 from typing import Dict
 
 import wx
 
-from app.core import requirements as req_ops
-from app.core.model import Status
+from ..core import requirements as req_ops
+from ..core.model import Status
 from . import locale
 
 

--- a/app/ui/label_selection_dialog.py
+++ b/app/ui/label_selection_dialog.py
@@ -1,10 +1,10 @@
 """Dialog for selecting labels with color icons."""
-from app.i18n import _
+from ..i18n import _
 
 import wx
 from wx.lib.mixins.listctrl import CheckListCtrlMixin
 
-from app.core.labels import Label
+from ..core.labels import Label
 
 
 class _CheckListCtrl(wx.ListCtrl, CheckListCtrlMixin):

--- a/app/ui/labels_dialog.py
+++ b/app/ui/labels_dialog.py
@@ -1,12 +1,12 @@
 """Dialog for managing label colors."""
 
-from app.i18n import _
-from app.confirm import confirm
+from ..i18n import _
+from ..confirm import confirm
 
 import wx
 
-from app.core.labels import Label, PRESET_SETS, PRESET_SET_TITLES
-from app.config import ConfigManager
+from ..core.labels import Label, PRESET_SETS, PRESET_SET_TITLES
+from ..config import ConfigManager
 
 
 class LabelsDialog(wx.Dialog):

--- a/app/ui/list_panel.py
+++ b/app/ui/list_panel.py
@@ -1,6 +1,6 @@
 """Panel displaying requirements list and simple filters."""
 
-from app.i18n import _
+from ..i18n import _
 
 import wx
 from wx.lib.agw import ultimatelistctrl as ULC
@@ -9,8 +9,8 @@ from wx.lib.mixins.listctrl import ColumnSorterMixin
 from typing import Callable, List, Sequence, TYPE_CHECKING
 from enum import Enum
 
-from app.core.model import Priority, RequirementType, Status, Verification, Requirement
-from app.core.labels import Label
+from ..core.model import Priority, RequirementType, Status, Verification, Requirement
+from ..core.labels import Label
 from .requirement_model import RequirementModel
 from .filter_dialog import FilterDialog
 from . import locale

--- a/app/ui/locale.py
+++ b/app/ui/locale.py
@@ -1,9 +1,9 @@
 """Localization helpers for enumerated fields using gettext."""
 
-from app.i18n import _
+from ..i18n import _
 from enum import Enum
 
-from app.core.model import RequirementType, Status, Priority, Verification
+from ..core.model import RequirementType, Status, Priority, Verification
 
 
 def _enum_label(e: Enum) -> str:

--- a/app/ui/main_frame.py
+++ b/app/ui/main_frame.py
@@ -1,6 +1,6 @@
 """Main application window."""
 
-from app.i18n import _
+from ..i18n import _
 
 import logging
 from importlib import resources
@@ -9,16 +9,16 @@ from dataclasses import fields, replace
 
 import wx
 
-from app.log import logger
+from ..log import logger
 
-from app.config import ConfigManager
-from app.core import requirements as req_ops
-from app.core.model import Requirement, DerivationLink
-from app.core.labels import Label
-from app.mcp.controller import MCPController
-from app.settings import AppSettings, LLMSettings, MCPSettings
-from app.agent import LocalAgent
-from app.confirm import confirm
+from ..config import ConfigManager
+from ..core import requirements as req_ops
+from ..core.model import Requirement, DerivationLink
+from ..core.labels import Label
+from ..mcp.controller import MCPController
+from ..settings import AppSettings, LLMSettings, MCPSettings
+from ..agent import LocalAgent
+from ..confirm import confirm
 from .list_panel import ListPanel
 from .editor_panel import EditorPanel
 from .settings_dialog import SettingsDialog
@@ -27,7 +27,7 @@ from .labels_dialog import LabelsDialog
 from .navigation import Navigation
 from .command_dialog import CommandDialog
 from .controllers import RequirementsController, LabelsController
-from app.core.repository import FileRequirementRepository
+from ..core.repository import FileRequirementRepository
 
 
 class WxLogHandler(logging.Handler):
@@ -240,7 +240,7 @@ class MainFrame(wx.Frame):
 
     def _apply_language(self) -> None:
         """Reinitialize locale and rebuild UI after language change."""
-        from app.main import init_locale
+        from ..main import init_locale
 
         app = wx.GetApp()
         app.locale = init_locale(self.language)

--- a/app/ui/navigation.py
+++ b/app/ui/navigation.py
@@ -2,13 +2,13 @@
 
 from __future__ import annotations
 
-from app.i18n import _
+from ..i18n import _
 from pathlib import Path
 from typing import Callable, Dict
 
 import wx
 
-from app.config import ConfigManager
+from ..config import ConfigManager
 
 
 class Navigation:

--- a/app/ui/requirement_model.py
+++ b/app/ui/requirement_model.py
@@ -5,8 +5,8 @@ from typing import List, Sequence
 from enum import Enum
 from dataclasses import asdict, is_dataclass
 
-from app.core import requirements as req_ops
-from app.core.model import Requirement
+from ..core import requirements as req_ops
+from ..core.model import Requirement
 
 
 class RequirementModel:

--- a/app/ui/settings_dialog.py
+++ b/app/ui/settings_dialog.py
@@ -1,14 +1,14 @@
 """Dialog for application settings with MCP controls."""
 
-from app.i18n import _
+from ..i18n import _
 from importlib import resources
 
 import wx
 
-from app.llm.client import LLMClient
-from app.mcp.client import MCPClient
-from app.mcp.controller import MCPController, MCPStatus
-from app.settings import LLMSettings, MCPSettings
+from ..llm.client import LLMClient
+from ..mcp.client import MCPClient
+from ..mcp.controller import MCPController, MCPStatus
+from ..settings import LLMSettings, MCPSettings
 
 
 def available_translations() -> list[tuple[str, str]]:


### PR DESCRIPTION
## Summary
- use relative imports inside app package to avoid absolute `from app` references
- adjust CLI to import i18n relatively

## Testing
- `rg "from app" -n app`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5981f3f48832080d6487b1e19db54