### PR TITLE
Add module docstrings across project

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,12 @@ Install the package along with development dependencies:
 pip install .[dev]
 ```
 
+Check that every module has a docstring:
+
+```bash
+pydocstyle app tests
+```
+
 ## License
 
 This project is distributed under the [Apache License 2.0](LICENSE).

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,3 @@
+"""Top-level package for the CookaReq application."""
+
+

--- a/app/cli/commands.py
+++ b/app/cli/commands.py
@@ -1,3 +1,5 @@
+"""Command implementations for the CLI interface."""
+
 from __future__ import annotations
 
 import argparse

--- a/app/cli/main.py
+++ b/app/cli/main.py
@@ -1,3 +1,5 @@
+"""Entry point for the command-line interface."""
+
 from __future__ import annotations
 
 import argparse

--- a/app/confirm.py
+++ b/app/confirm.py
@@ -1,3 +1,5 @@
+"""Confirmation callback registry for user interactions."""
+
 from typing import Callable
 
 ConfirmCallback = Callable[[str], bool]

--- a/app/core/repository.py
+++ b/app/core/repository.py
@@ -1,6 +1,6 @@
-from __future__ import annotations
-
 """Requirement repository interface and implementations."""
+
+from __future__ import annotations
 
 from pathlib import Path
 from typing import Mapping, Protocol, Sequence

--- a/app/core/validate.py
+++ b/app/core/validate.py
@@ -1,5 +1,6 @@
-from __future__ import annotations
 """Additional business rules for requirements."""
+
+from __future__ import annotations
 
 from pathlib import Path
 

--- a/app/mcp/__init__.py
+++ b/app/mcp/__init__.py
@@ -1,0 +1,3 @@
+"""MCP server and client utilities package."""
+
+

--- a/app/mcp/client.py
+++ b/app/mcp/client.py
@@ -1,3 +1,5 @@
+"""HTTP client for interacting with the MCP server."""
+
 from __future__ import annotations
 
 import json
@@ -126,4 +128,3 @@ class MCPClient:
         """Backward compatible wrapper for :meth:`call_tool`."""
 
         return self.call_tool(name, arguments)
-

--- a/app/mcp/controller.py
+++ b/app/mcp/controller.py
@@ -1,3 +1,5 @@
+"""Service controller for managing the MCP server."""
+
 from __future__ import annotations
 
 from enum import Enum

--- a/app/settings.py
+++ b/app/settings.py
@@ -1,6 +1,6 @@
-from __future__ import annotations
-
 """Typed application settings with Pydantic validation."""
+
+from __future__ import annotations
 
 from pathlib import Path
 import json

--- a/app/telemetry.py
+++ b/app/telemetry.py
@@ -1,3 +1,5 @@
+"""Structured telemetry logging helpers."""
+
 from __future__ import annotations
 
 import datetime

--- a/app/ui/__init__.py
+++ b/app/ui/__init__.py
@@ -1,0 +1,3 @@
+"""Graphical user interface package."""
+
+

--- a/app/ui/controllers/__init__.py
+++ b/app/ui/controllers/__init__.py
@@ -1,3 +1,5 @@
+"""Controller classes for user interface operations."""
+
 from .requirements import RequirementsController
 from .labels import LabelsController
 

--- a/app/ui/controllers/labels.py
+++ b/app/ui/controllers/labels.py
@@ -1,3 +1,5 @@
+"""Controller for label persistence and synchronization."""
+
 from __future__ import annotations
 
 from pathlib import Path

--- a/app/ui/controllers/requirements.py
+++ b/app/ui/controllers/requirements.py
@@ -1,3 +1,5 @@
+"""Controller handling requirement CRUD operations."""
+
 from __future__ import annotations
 
 from dataclasses import replace

--- a/app/util/__init__.py
+++ b/app/util/__init__.py
@@ -1,0 +1,3 @@
+"""Utility helpers for CookaReq."""
+
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,10 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-dev = ["pytest", "polib"]
+dev = ["pytest", "polib", "pydocstyle"]
+
+[tool.pydocstyle]
+select = ["D100"]
 
 [build-system]
 requires = ["setuptools", "wheel"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,5 @@
+"""Pytest fixtures and shared helpers."""
+
 import os
 import sys
 import time

--- a/tests/llm_utils.py
+++ b/tests/llm_utils.py
@@ -1,3 +1,5 @@
+"""Utilities for LLM-related tests."""
+
 import json
 import os
 from pathlib import Path

--- a/tests/mcp_utils.py
+++ b/tests/mcp_utils.py
@@ -1,3 +1,5 @@
+"""Utilities for MCP-related tests."""
+
 import time
 from http.client import HTTPConnection
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,3 +1,5 @@
+"""Tests for cli."""
+
 from __future__ import annotations
 
 import json

--- a/tests/test_command_dialog.py
+++ b/tests/test_command_dialog.py
@@ -1,3 +1,5 @@
+"""Tests for command dialog."""
+
 import json
 import pytest
 

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -1,3 +1,5 @@
+"""Tests for config manager."""
+
 import pytest
 
 from app.config import ConfigManager

--- a/tests/test_config_manager_proxies.py
+++ b/tests/test_config_manager_proxies.py
@@ -1,3 +1,5 @@
+"""Tests for config manager proxies."""
+
 from app.config import ConfigManager
 
 

--- a/tests/test_confirm.py
+++ b/tests/test_confirm.py
@@ -1,3 +1,5 @@
+"""Tests for confirm."""
+
 import pytest
 
 from app import confirm as confirm_mod

--- a/tests/test_derived_requirements.py
+++ b/tests/test_derived_requirements.py
@@ -1,3 +1,5 @@
+"""Tests for derived requirements."""
+
 from __future__ import annotations
 from pathlib import Path
 

--- a/tests/test_editor_panel.py
+++ b/tests/test_editor_panel.py
@@ -1,3 +1,5 @@
+"""Tests for editor panel."""
+
 import os
 import pytest
 from app.i18n import _
@@ -179,4 +181,3 @@ def test_loading_requirement_without_labels_clears_display(wx_app):
     children = panel.labels_panel.GetChildren()
     assert len(children) == 1
     assert children[0].GetLabel() == _("(none)")
-

--- a/tests/test_editor_panel_gui.py
+++ b/tests/test_editor_panel_gui.py
@@ -1,3 +1,5 @@
+"""Tests for editor panel gui."""
+
 import pytest
 from dataclasses import asdict
 

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -1,3 +1,5 @@
+"""Tests for gui."""
+
 import pytest
 
 

--- a/tests/test_hashing.py
+++ b/tests/test_hashing.py
@@ -1,3 +1,5 @@
+"""Tests for hashing."""
+
 from app.util.hashing import id_to_hash
 
 

--- a/tests/test_health_endpoint.py
+++ b/tests/test_health_endpoint.py
@@ -1,3 +1,5 @@
+"""Tests for health endpoint."""
+
 def test_health_endpoint_returns_ok():
     from app.mcp.server import app
     from fastapi.testclient import TestClient

--- a/tests/test_i18n.py
+++ b/tests/test_i18n.py
@@ -1,3 +1,5 @@
+"""Tests for i18n."""
+
 from app import i18n
 
 

--- a/tests/test_i18n_escape.py
+++ b/tests/test_i18n_escape.py
@@ -1,3 +1,5 @@
+"""Tests for i18n escape."""
+
 from pathlib import Path
 from app import i18n
 

--- a/tests/test_labels.py
+++ b/tests/test_labels.py
@@ -1,3 +1,5 @@
+"""Tests for labels."""
+
 from app.core.labels import Label, add_label, get_label, update_label, delete_label
 from app.core import store
 from pathlib import Path

--- a/tests/test_labels_dialog.py
+++ b/tests/test_labels_dialog.py
@@ -1,3 +1,5 @@
+"""Tests for labels dialog."""
+
 import importlib
 from types import SimpleNamespace
 

--- a/tests/test_labels_sync.py
+++ b/tests/test_labels_sync.py
@@ -1,3 +1,5 @@
+"""Tests for labels sync."""
+
 import pytest
 from app.core import store
 from app.core.labels import PRESET_SETS

--- a/tests/test_language_switch.py
+++ b/tests/test_language_switch.py
@@ -1,3 +1,5 @@
+"""Tests for language switch."""
+
 import importlib
 
 import pytest

--- a/tests/test_list_panel.py
+++ b/tests/test_list_panel.py
@@ -1,3 +1,5 @@
+"""Tests for list panel."""
+
 import sys
 import types
 import importlib
@@ -571,5 +573,3 @@ def test_sort_method_and_callback(monkeypatch):
     panel.sort(1, False)
     assert [r.id for r in panel.model.get_visible()] == [2, 1]
     assert calls[-1] == (1, False)
-
-

--- a/tests/test_list_panel_gui.py
+++ b/tests/test_list_panel_gui.py
@@ -1,3 +1,5 @@
+"""Tests for list panel gui."""
+
 import importlib
 import pytest
 from app.core.model import (

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -1,3 +1,5 @@
+"""Tests for llm client."""
+
 import json
 import logging
 import os

--- a/tests/test_local_agent.py
+++ b/tests/test_local_agent.py
@@ -1,3 +1,5 @@
+"""Tests for local agent."""
+
 import pytest
 
 from app.agent import local_agent as la

--- a/tests/test_locale.py
+++ b/tests/test_locale.py
@@ -1,3 +1,5 @@
+"""Tests for locale."""
+
 import pytest
 from app.i18n import _, install
 

--- a/tests/test_logging_config.py
+++ b/tests/test_logging_config.py
@@ -1,3 +1,5 @@
+"""Tests for logging config."""
+
 import logging
 import pytest
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,3 +1,5 @@
+"""Tests for main."""
+
 import sys
 import types
 import importlib

--- a/tests/test_main_frame_gui.py
+++ b/tests/test_main_frame_gui.py
@@ -1,3 +1,5 @@
+"""Tests for main frame gui."""
+
 import importlib
 import pytest
 import logging

--- a/tests/test_main_frame_gui_size.py
+++ b/tests/test_main_frame_gui_size.py
@@ -1,3 +1,5 @@
+"""Tests for main frame gui size."""
+
 import pytest
 
 from app.core.store import save

--- a/tests/test_main_frame_llm_integration.py
+++ b/tests/test_main_frame_llm_integration.py
@@ -1,3 +1,5 @@
+"""Tests for main frame llm integration."""
+
 import json
 import os
 from pathlib import Path

--- a/tests/test_mcp_auth.py
+++ b/tests/test_mcp_auth.py
@@ -1,3 +1,5 @@
+"""Tests for mcp auth."""
+
 from app.mcp.server import start_server, stop_server
 from tests.mcp_utils import _request, _wait_until_ready
 

--- a/tests/test_mcp_client.py
+++ b/tests/test_mcp_client.py
@@ -1,3 +1,5 @@
+"""Tests for mcp client."""
+
 import json
 import logging
 from pathlib import Path

--- a/tests/test_mcp_controller.py
+++ b/tests/test_mcp_controller.py
@@ -1,3 +1,5 @@
+"""Tests for mcp controller."""
+
 import pytest
 
 def test_controller_check(monkeypatch):

--- a/tests/test_mcp_http_tools.py
+++ b/tests/test_mcp_http_tools.py
@@ -1,3 +1,5 @@
+"""Tests for mcp http tools."""
+
 from __future__ import annotations
 
 import json

--- a/tests/test_mcp_llm_integration.py
+++ b/tests/test_mcp_llm_integration.py
@@ -1,3 +1,5 @@
+"""Tests for mcp llm integration."""
+
 import json
 import logging
 import os

--- a/tests/test_mcp_logging.py
+++ b/tests/test_mcp_logging.py
@@ -1,3 +1,5 @@
+"""Tests for mcp logging."""
+
 import json
 import os
 from tempfile import TemporaryDirectory

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1,3 +1,5 @@
+"""Tests for mcp server."""
+
 import json
 
 from app.mcp.server import start_server, stop_server

--- a/tests/test_mcp_text_commands.py
+++ b/tests/test_mcp_text_commands.py
@@ -1,3 +1,5 @@
+"""Tests for mcp text commands."""
+
 import json
 import logging
 import os
@@ -68,4 +70,3 @@ def test_run_command_error_logs(tmp_path: Path, monkeypatch, mcp_server) -> None
     entries = [json.loads(line) for line in log_file.read_text().splitlines()]
     events = {e.get("event") for e in entries}
     assert {"LLM_REQUEST", "LLM_RESPONSE", "TOOL_CALL", "TOOL_RESULT", "ERROR"} <= events
-

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -1,3 +1,5 @@
+"""Tests for mcp tools."""
+
 from pathlib import Path
 
 from app.core import store

--- a/tests/test_missing_translations.py
+++ b/tests/test_missing_translations.py
@@ -1,3 +1,5 @@
+"""Tests for missing translations."""
+
 import threading
 from app import i18n
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,3 +1,5 @@
+"""Tests for model."""
+
 from app.core.model import (
     Priority,
     Requirement,

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -1,3 +1,5 @@
+"""Tests for paths."""
+
 from pathlib import Path
 
 import pytest

--- a/tests/test_recent_dirs.py
+++ b/tests/test_recent_dirs.py
@@ -1,3 +1,5 @@
+"""Tests for recent dirs."""
+
 import importlib
 import pytest
 

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -1,3 +1,5 @@
+"""Tests for repository."""
+
 from __future__ import annotations
 
 import json

--- a/tests/test_requirement_model.py
+++ b/tests/test_requirement_model.py
@@ -1,3 +1,5 @@
+"""Tests for requirement model."""
+
 import pytest
 from app.ui.requirement_model import RequirementModel
 from app.core.model import Requirement, RequirementType, Status, Priority, Verification

--- a/tests/test_requirement_ops.py
+++ b/tests/test_requirement_ops.py
@@ -1,3 +1,5 @@
+"""Tests for requirement ops."""
+
 import pytest
 from pathlib import Path
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,3 +1,5 @@
+"""Tests for schema."""
+
 import pytest
 
 from app.core.schema import validate

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,3 +1,5 @@
+"""Tests for search."""
+
 from app.core.model import (
     Priority,
     Requirement,
@@ -136,5 +138,3 @@ def test_filter_by_status_function():
     filtered = filter_by_status(reqs, "approved")
     assert [r.id for r in filtered] == [2]
     assert filter_by_status(reqs, None) == reqs
-
-

--- a/tests/test_settings_dialog.py
+++ b/tests/test_settings_dialog.py
@@ -1,3 +1,5 @@
+"""Tests for settings dialog."""
+
 import pytest
 
 

--- a/tests/test_settings_validation.py
+++ b/tests/test_settings_validation.py
@@ -1,3 +1,5 @@
+"""Tests for settings validation."""
+
 from __future__ import annotations
 
 import json
@@ -11,4 +13,3 @@ def test_invalid_settings_raises(tmp_path):
     file.write_text(json.dumps({"mcp": {"port": "not-int"}}))
     with pytest.raises(ValueError):
         load_app_settings(file)
-

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -1,3 +1,5 @@
+"""Tests for store."""
+
 from __future__ import annotations
 
 import json

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -1,3 +1,5 @@
+"""Tests for telemetry."""
+
 import json
 import logging
 from pathlib import Path

--- a/tests/test_tool_logging.py
+++ b/tests/test_tool_logging.py
@@ -1,3 +1,5 @@
+"""Tests for tool logging."""
+
 import json
 from pathlib import Path
 

--- a/tests/test_translation_coverage.py
+++ b/tests/test_translation_coverage.py
@@ -1,3 +1,5 @@
+"""Tests for translation coverage."""
+
 import polib
 from pathlib import Path
 

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -1,3 +1,5 @@
+"""Tests for validate."""
+
 import json
 import pytest
 


### PR DESCRIPTION
## Summary
- add module-level docstrings to CLI modules and utility packages
- document GUI controllers and MCP components
- introduce docstrings for all test modules for clearer purpose
- enforce module docstrings via pydocstyle and document linter usage

## Testing
- `pydocstyle app tests`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c59f2930588320a0e271aa4ad4f80d