### PR TITLE
Убрать микросекунды из временных меток

### DIFF
--- a/app/core/model.py
+++ b/app/core/model.py
@@ -5,6 +5,8 @@ from dataclasses import dataclass, field, asdict
 from enum import Enum
 from typing import List, Optional, Any
 
+from ..util.time import normalize_timestamp
+
 
 class RequirementType(str, Enum):
     REQUIREMENT = "requirement"
@@ -141,12 +143,16 @@ def requirement_from_dict(data: dict[str, Any]) -> Requirement:
         trace_up=data.get("trace_up", ""),
         trace_down=data.get("trace_down", ""),
         version=data.get("version", ""),
-        modified_at=data.get("modified_at", ""),
+        modified_at=normalize_timestamp(data.get("modified_at")),
         units=units,
         labels=list(data.get("labels", [])),
         attachments=attachments,
         revision=data.get("revision", 1),
-        approved_at=data.get("approved_at"),
+        approved_at=(
+            normalize_timestamp(data.get("approved_at"))
+            if data.get("approved_at")
+            else None
+        ),
         notes=data.get("notes", ""),
         parent=parent,
         derived_from=derived_from,

--- a/app/core/requirements.py
+++ b/app/core/requirements.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import Iterable, Mapping, Sequence, Tuple
-from datetime import datetime
 
 from .model import Requirement, requirement_from_dict, Status
 from .labels import Label
@@ -23,15 +22,10 @@ from .store import (
     load_labels as store_load_labels,
     save_labels as store_save_labels,
 )
+from ..util.time import local_now_str, normalize_timestamp
 
 # Re-export searchable fields for UI components
 SEARCHABLE_FIELDS = core_search.SEARCHABLE_FIELDS
-
-
-def _current_timestamp() -> str:
-    """Return current time in unified string format."""
-    return datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-
 
 def load_all(directory: str | Path) -> list[Requirement]:
     """Load all requirements from *directory*.
@@ -110,7 +104,9 @@ def save_requirement(
         obj = data
     else:
         obj = requirement_from_dict(dict(data))
-    obj.modified_at = modified_at or _current_timestamp()
+    obj.modified_at = (
+        normalize_timestamp(modified_at) if modified_at else local_now_str()
+    )
     return save(directory, obj, mtime=mtime)
 
 

--- a/app/log.py
+++ b/app/log.py
@@ -2,10 +2,11 @@
 
 from __future__ import annotations
 
-import datetime
 import json
 import logging
 from typing import Any
+
+from .util.time import utc_now_iso
 
 logger = logging.getLogger("cookareq")
 
@@ -22,7 +23,7 @@ class JsonlHandler(logging.Handler):
         if data is None:
             data = {"message": record.getMessage(), "level": record.levelname}
         if "timestamp" not in data:
-            data["timestamp"] = datetime.datetime.now(datetime.UTC).isoformat()
+            data["timestamp"] = utc_now_iso()
         with open(self.filename, "a", encoding="utf-8") as fh:
             json.dump(data, fh, ensure_ascii=False)
             fh.write("\n")

--- a/app/mcp/server.py
+++ b/app/mcp/server.py
@@ -12,7 +12,6 @@ import json
 import logging
 import os
 import threading
-import datetime
 from typing import Mapping, Optional
 
 from fastapi import FastAPI, Request
@@ -21,6 +20,7 @@ import uvicorn
 from mcp.server.fastmcp import FastMCP
 
 from ..log import JsonlHandler, configure_logging, logger
+from ..util.time import utc_now_iso
 from .utils import ErrorCode, mcp_error, sanitize
 from . import tools_read, tools_write
 
@@ -66,7 +66,7 @@ def _log_request(request: Request, status: int) -> None:
     headers = sanitize(dict(request.headers))
     query = sanitize(dict(request.query_params))
     entry = {
-        "timestamp": datetime.datetime.now(datetime.UTC).isoformat(),
+        "timestamp": utc_now_iso(),
         "method": request.method,
         "path": request.url.path,
         "query": query,

--- a/app/mcp/utils.py
+++ b/app/mcp/utils.py
@@ -2,12 +2,12 @@
 
 from __future__ import annotations
 
-import datetime
 from enum import Enum
 from typing import Any, Mapping
 
 from ..log import logger
 from ..telemetry import sanitize
+from ..util.time import utc_now_iso
 
 
 def log_tool(
@@ -36,7 +36,7 @@ def log_tool(
     """
 
     entry = {
-        "timestamp": datetime.datetime.now(datetime.UTC).isoformat(),
+        "timestamp": utc_now_iso(),
         "tool": tool,
         "params": sanitize(params),
     }

--- a/app/util/time.py
+++ b/app/util/time.py
@@ -1,0 +1,29 @@
+"""Time-related helpers for CookaReq."""
+
+from __future__ import annotations
+
+import datetime
+
+
+def utc_now_iso() -> str:
+    """Return current UTC time in ISO format without sub-second precision."""
+    return datetime.datetime.now(datetime.UTC).isoformat(timespec="seconds")
+
+
+def local_now_str() -> str:
+    """Return local time in ``YYYY-MM-DD HH:MM:SS`` format."""
+    return datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+
+
+def normalize_timestamp(value: str | None) -> str:
+    """Normalize ``value`` to second precision while preserving date-only strings."""
+    if not value:
+        return ""
+    if ":" not in value:
+        return value.split(".", 1)[0]
+    try:
+        dt = datetime.datetime.fromisoformat(value)
+    except ValueError:
+        base = value.split(".", 1)[0]
+        return base.replace("T", " ")
+    return dt.strftime("%Y-%m-%d %H:%M:%S")


### PR DESCRIPTION
## Summary
- Добавлен модуль `util.time` с функциями для получения времени без долей секунды и нормализации строк
- Нормализованы поля `modified_at` и `approved_at` при загрузке и сохранении требований
- Логирование и MCP-сервер теперь записывают метки времени с точностью до секунд

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c5a7cc1cb08320bfad2c73836ed7fa