### PR TITLE
Streamline requirement fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,6 @@ Each requirement is stored in its own `<id>.json` file and contains the followin
 - `conditions` *(str)* — conditions
 - `trace_up` *(str)* and `trace_down` *(str)* — traceability links
 - `version` *(str)* and `modified_at` *(str)* — version and date of modification
-- `units` *(object, optional)* — {`quantity`, `nominal`, `tolerance`}
 - `labels` *(list[str])* — custom labels
 - `attachments` *(list[obj])* — attachments `{path, note}`
 - `revision` *(int)* — revision number (starting at 1)

--- a/app/core/model.py
+++ b/app/core/model.py
@@ -36,13 +36,6 @@ class Verification(str, Enum):
 
 
 @dataclass
-class Units:
-    quantity: str
-    nominal: float
-    tolerance: Optional[float] = None
-
-
-@dataclass
 class Attachment:
     path: str
     note: str = ""
@@ -67,8 +60,6 @@ class DerivationInfo:
 
     rationale: str
     assumptions: List[str]
-    method: str
-    margin: str
 
 
 @dataclass
@@ -96,7 +87,6 @@ class Requirement:
     trace_down: str = ""
     version: str = ""
     modified_at: str = ""
-    units: Optional[Units] = None
     labels: List[str] = field(default_factory=list)
     attachments: List[Attachment] = field(default_factory=list)
     revision: int = 1
@@ -111,12 +101,10 @@ class Requirement:
 def requirement_from_dict(data: dict[str, Any]) -> Requirement:
     """Create :class:`Requirement` instance from a plain ``dict``.
 
-    Nested ``attachments``, ``units`` and derivation structures are converted
+    Nested ``attachments`` and derivation structures are converted
     into their respective dataclasses. Missing optional fields fall back to
     sensible defaults.
     """
-    units_data = data.get("units")
-    units = Units(**units_data) if units_data else None
     attachments = [Attachment(**a) for a in data.get("attachments", [])]
     parent_data = data.get("parent")
     parent = RequirementLink(**parent_data) if parent_data else None
@@ -144,7 +132,6 @@ def requirement_from_dict(data: dict[str, Any]) -> Requirement:
         trace_down=data.get("trace_down", ""),
         version=data.get("version", ""),
         modified_at=normalize_timestamp(data.get("modified_at")),
-        units=units,
         labels=list(data.get("labels", [])),
         attachments=attachments,
         revision=data.get("revision", 1),

--- a/app/core/schema.py
+++ b/app/core/schema.py
@@ -38,15 +38,6 @@ SCHEMA: dict[str, Any] = {
         "trace_down": {"type": "string"},
         "version": {"type": "string"},
         "modified_at": {"type": "string"},
-        "units": {
-            "type": "object",
-            "properties": {
-                "quantity": {"type": "string"},
-                "nominal": {"type": "number"},
-                "tolerance": {"type": ["number", "null"]},
-            },
-            "required": ["quantity", "nominal"],
-        },
         "labels": {"type": "array", "items": {"type": "string"}},
         "attachments": {
             "type": "array",
@@ -112,12 +103,10 @@ SCHEMA: dict[str, Any] = {
         },
         "derivation": {
             "type": "object",
-            "required": ["rationale", "assumptions", "method", "margin"],
+            "required": ["rationale", "assumptions"],
             "properties": {
                 "rationale": {"type": "string"},
                 "assumptions": {"type": "array", "items": {"type": "string"}},
-                "method": {"type": "string"},
-                "margin": {"type": "string"},
             },
         },
         "revision": {"type": "integer", "minimum": 1},

--- a/app/locale/en/LC_MESSAGES/CookaReq.po
+++ b/app/locale/en/LC_MESSAGES/CookaReq.po
@@ -275,9 +275,6 @@ msgstr "Agent Command"
 msgid "Any field contains"
 msgstr "Any field contains"
 
-msgid "Applied margin."
-msgstr "Applied margin."
-
 msgid "Approved at"
 msgstr "Approved at"
 
@@ -313,9 +310,6 @@ msgstr "Delete requirement?"
 
 msgid "Derivation Graph"
 msgstr "Derivation Graph"
-
-msgid "Derivation method."
-msgstr "Derivation method."
 
 msgid "Derive"
 msgstr "Derive"
@@ -368,14 +362,10 @@ msgstr "MCP"
 msgid "Manage Labels"
 msgstr "Manage Labels"
 
-msgid "Margin"
-msgstr "Margin"
 
 msgid "Match any labels"
 msgstr "Match any labels"
 
-msgid "Method"
-msgstr "Method"
 
 msgid "Name"
 msgstr "Name"
@@ -392,11 +382,6 @@ msgstr "No derivation links found."
 msgid "No requirements loaded"
 msgstr "No requirements loaded"
 
-msgid "Nominal"
-msgstr "Nominal"
-
-msgid "Nominal must be a number"
-msgstr "Nominal must be a number"
 
 msgid "Note"
 msgstr "Note"
@@ -413,8 +398,6 @@ msgstr "Path"
 msgid "Port"
 msgstr "Port"
 
-msgid "Quantity"
-msgstr "Quantity"
 
 msgid "Rationale"
 msgstr "Rationale"
@@ -467,17 +450,7 @@ msgstr "Suspect only"
 msgid "Token"
 msgstr "Token"
 
-msgid "Tolerance"
-msgstr "Tolerance"
 
-msgid "Tolerance must be a number"
-msgstr "Tolerance must be a number"
-
-msgid "Units"
-msgstr "Units"
-
-msgid "Units require quantity and nominal"
-msgstr "Units require quantity and nominal"
 
 msgid "Update requirement?"
 msgstr "Update requirement?"
@@ -676,21 +649,6 @@ msgstr ""
 "ensure the requirement remains valid."
 
 msgid ""
-"Technique used to derive the requirement, for example decomposition, "
-"modeling or stakeholder interviews. Knowing the derivation method helps "
-"reviewers assess validity and reproduce the reasoning if needed. It "
-"documents the path from source to requirement."
-msgstr ""
-"Technique used to derive the requirement, for example decomposition, "
-"modeling or stakeholder interviews. Knowing the derivation method helps "
-"reviewers assess validity and reproduce the reasoning if needed. It "
-"documents the path from source to requirement."
-
-msgid ""
-"Safety or performance margin applied during derivation. Record extra "
-"capacity or tolerance added to cover uncertainties. Tracking margins keeps "
 "risk decisions transparent and supports future recalculations."
 msgstr ""
-"Safety or performance margin applied during derivation. Record extra "
-"capacity or tolerance added to cover uncertainties. Tracking margins keeps "
 "risk decisions transparent and supports future recalculations."

--- a/app/locale/ru/LC_MESSAGES/CookaReq.po
+++ b/app/locale/ru/LC_MESSAGES/CookaReq.po
@@ -281,9 +281,6 @@ msgstr "Команда агента"
 msgid "Any field contains"
 msgstr "Любое поле содержит"
 
-msgid "Applied margin."
-msgstr "Применённый запас."
-
 msgid "Approved at"
 msgstr "Утверждено"
 
@@ -319,9 +316,6 @@ msgstr "Удалить требование?"
 
 msgid "Derivation Graph"
 msgstr "Граф выводов"
-
-msgid "Derivation method."
-msgstr "Метод вывода."
 
 msgid "Derive"
 msgstr "Вывести"
@@ -374,14 +368,8 @@ msgstr "MCP"
 msgid "Manage Labels"
 msgstr "Управление метками"
 
-msgid "Margin"
-msgstr "Запас"
-
 msgid "Match any labels"
 msgstr "Совпадает с любой меткой"
-
-msgid "Method"
-msgstr "Метод"
 
 msgid "Name"
 msgstr "Имя"
@@ -398,11 +386,6 @@ msgstr "Связи вывода не найдены."
 msgid "No requirements loaded"
 msgstr "Требования не загружены"
 
-msgid "Nominal"
-msgstr "Номинал"
-
-msgid "Nominal must be a number"
-msgstr "Номинал должен быть числом"
 
 msgid "Note"
 msgstr "Примечание"
@@ -418,9 +401,6 @@ msgstr "Путь"
 
 msgid "Port"
 msgstr "Порт"
-
-msgid "Quantity"
-msgstr "Количество"
 
 msgid "Rationale"
 msgstr "Обоснование"
@@ -473,17 +453,7 @@ msgstr "Только подозрительные"
 msgid "Token"
 msgstr "Токен"
 
-msgid "Tolerance"
-msgstr "Допуск"
 
-msgid "Tolerance must be a number"
-msgstr "Допуск должен быть числом"
-
-msgid "Units"
-msgstr "Единицы"
-
-msgid "Units require quantity and nominal"
-msgstr "Для единиц требуются количество и номинал"
 
 msgid "Update requirement?"
 msgstr "Обновить требование?"
@@ -688,24 +658,10 @@ msgstr ""
 "риски и проясняет контекст, который может измениться. Периодически "
 "пересматривайте их, чтобы требование оставалось актуальным."
 
-msgid ""
-"Technique used to derive the requirement, for example decomposition, "
-"modeling or stakeholder interviews. Knowing the derivation method helps "
-"reviewers assess validity and reproduce the reasoning if needed. It "
-"documents the path from source to requirement."
-msgstr ""
-"Методика, с помощью которой получено требование: декомпозиция, "
-"моделирование, интервью с заинтересованными сторонами и т.п. Знание метода "
-"помогает рецензентам оценить обоснованность и при необходимости "
-"воспроизвести ход рассуждений. Это документирует путь от источника к "
-"требованию."
 
 msgid ""
-"Safety or performance margin applied during derivation. Record extra "
-"capacity or tolerance added to cover uncertainties. Tracking margins keeps "
 "risk decisions transparent and supports future recalculations."
 msgstr ""
-"Запас прочности или производительности, заложенный при выводе требования. "
 "Укажите дополнительный ресурс или допуск, который покрывает "
 "неопределённости. Фиксация запасов делает решения по рискам прозрачными и "
 "помогает при последующих пересчётах."

--- a/app/ui/list_panel.py
+++ b/app/ui/list_panel.py
@@ -304,16 +304,6 @@ class ListPanel(wx.Panel, ColumnSorterMixin):
                     value = ", ".join(getattr(a, "path", "") for a in getattr(req, "attachments", []))
                     self.list.SetStringItem(index, col, value)
                     continue
-                if field == "units":
-                    u = getattr(req, "units", None)
-                    if u:
-                        value = f"{u.quantity} {u.nominal}"
-                        if getattr(u, "tolerance", None) is not None:
-                            value += f" ±{u.tolerance}"
-                    else:
-                        value = ""
-                    self.list.SetStringItem(index, col, value)
-                    continue
                 value = getattr(req, field, "")
                 if isinstance(value, Enum):
                     value = locale.code_to_label(field, value.value)

--- a/tests/test_derived_requirements.py
+++ b/tests/test_derived_requirements.py
@@ -31,8 +31,6 @@ def test_store_roundtrip_derived_fields(tmp_path: Path) -> None:
     derived["derivation"] = {
         "rationale": "calc",
         "assumptions": ["a1", "a2"],
-        "method": "m",
-        "margin": "10%",
     }
 
     save(tmp_path, src)
@@ -44,7 +42,6 @@ def test_store_roundtrip_derived_fields(tmp_path: Path) -> None:
     assert req.derived_from[0].source_id == 1
     assert req.derived_from[0].suspect is False
     assert req.derivation is not None
-    assert req.derivation.method == "m"
     assert req.derivation.assumptions == ["a1", "a2"]
 
 

--- a/tests/test_editor_panel.py
+++ b/tests/test_editor_panel.py
@@ -39,9 +39,6 @@ def test_editor_save_and_delete(tmp_path, wx_app):
     panel.fields["owner"].SetValue("owner")
     panel.fields["source"].SetValue("src")
     panel.fields["acceptance"].SetValue("Acc")
-    panel.units_fields["quantity"].SetValue("kg")
-    panel.units_fields["nominal"].SetValue("1.0")
-    panel.units_fields["tolerance"].SetValue("0.1")
     wx = pytest.importorskip("wx")
     dt = wx.DateTime()
     dt.ParseISODate("2025-01-01")
@@ -60,7 +57,6 @@ def test_editor_save_and_delete(tmp_path, wx_app):
     data, _ = store.load(path)
     assert data["id"] == 1
     assert data["attachments"][0]["path"] == f"attachments{os.sep}{att.name}"
-    assert data["units"] == {"quantity": "kg", "nominal": 1.0, "tolerance": 0.1}
     assert data["approved_at"] == "2025-01-01"
     assert data["notes"] == "Note"
 

--- a/tests/test_editor_panel_gui.py
+++ b/tests/test_editor_panel_gui.py
@@ -21,7 +21,6 @@ def test_editor_new_requirement_resets(tmp_path, wx_app):
         "title": "T",
         "statement": "S",
         "attachments": [{"path": "a.txt", "note": "n"}],
-        "units": {"quantity": "kg", "nominal": 1.0, "tolerance": 0.1},
         "labels": ["L1"],
         "revision": 5,
         "approved_at": "2025-01-01",
@@ -31,7 +30,6 @@ def test_editor_new_requirement_resets(tmp_path, wx_app):
     panel.new_requirement()
 
     assert all(ctrl.GetValue() == "" for ctrl in panel.fields.values())
-    assert all(ctrl.GetValue() == "" for ctrl in panel.units_fields.values())
     panel.fields["id"].SetValue("1")
     defaults = panel.get_data()
     assert defaults.type == RequirementType.REQUIREMENT
@@ -45,7 +43,6 @@ def test_editor_new_requirement_resets(tmp_path, wx_app):
     assert defaults.revision == 1
     assert defaults.approved_at is None
     assert defaults.notes == ""
-    assert defaults.units is None
 
 
 def test_editor_add_attachment_included(wx_app):
@@ -107,7 +104,6 @@ def test_editor_load_populates_fields(tmp_path, wx_app):
         "revision": 2,
         "approved_at": "2025-01-02",
         "notes": "Note",
-        "units": {"quantity": "kg", "nominal": 2.0, "tolerance": 0.5},
     }
     path = tmp_path / "req.json"
     panel.update_labels_list([Label("L", "#000000")])
@@ -129,9 +125,6 @@ def test_editor_load_populates_fields(tmp_path, wx_app):
     assert result.revision == data["revision"]
     assert result.approved_at == data["approved_at"]
     assert result.notes == data["notes"]
-    assert result.units.quantity == "kg"
-    assert result.units.nominal == 2.0
-    assert result.units.tolerance == 0.5
     assert panel.current_path == path
     assert panel.mtime == 42.0
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -26,7 +26,6 @@ def test_requirement_defaults():
     assert req.revision == 1
     assert req.labels == []
     assert req.attachments == []
-    assert req.units is None
     assert req.approved_at is None
     assert req.notes == ""
     assert req.conditions == ""
@@ -55,14 +54,11 @@ def test_requirement_derivation_conversion():
         "derivation": {
             "rationale": "r",
             "assumptions": ["a1", "a2"],
-            "method": "m",
-            "margin": "10%",
         },
     }
     req = requirement_from_dict(data)
     assert req.derived_from[0].source_id == 2
     assert req.derived_from[0].suspect is True
-    assert req.derivation.margin == "10%"
     roundtrip = requirement_to_dict(req)
     assert roundtrip["derived_from"][0]["source_revision"] == 3
     assert roundtrip["derivation"]["assumptions"] == ["a1", "a2"]

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -24,7 +24,6 @@ def sample(req_id: int = 1) -> dict:
         "source": "spec",
         "verification": "analysis",
         "revision": 1,
-        "units": {"quantity": "kg", "nominal": 1.0, "tolerance": 0.1},
         "attachments": [{"path": "a.txt", "note": "n"}],
         "approved_at": "2025-01-01",
         "notes": "note",

--- a/tests/test_requirement_ops.py
+++ b/tests/test_requirement_ops.py
@@ -25,7 +25,6 @@ def _base_req(req_id: int) -> dict:
         "priority": "medium",
         "source": "spec",
         "verification": "analysis",
-        "units": {"quantity": "kg", "nominal": 1.0, "tolerance": 0.1},
         "attachments": [{"path": "a.txt", "note": "n"}],
         "approved_at": "2025-01-01",
         "notes": "note",
@@ -45,7 +44,6 @@ def test_create_patch_delete(tmp_path: Path):
     data, _ = load(path)
     assert data["title"] == "New"
     assert data["revision"] == 2
-    assert data["units"] == {"quantity": "kg", "nominal": 1.0, "tolerance": 0.1}
     assert data["attachments"] == [{"path": "a.txt", "note": "n"}]
     assert data["approved_at"] == "2025-01-01"
     assert data["notes"] == "note"

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -46,8 +46,6 @@ def test_derived_from_and_derivation_valid():
     data["derivation"] = {
         "rationale": "r",
         "assumptions": ["a"],
-        "method": "m",
-        "margin": "10%",
     }
     validate(data)
 
@@ -63,8 +61,6 @@ def test_derivation_missing_field():
     data = make_valid()
     data["derivation"] = {
         "rationale": "r",
-        "assumptions": ["a"],
-        "method": "m",
     }
     with pytest.raises(ValueError):
         validate(data)

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -13,7 +13,6 @@ from app.core.model import (
     Requirement,
     RequirementType,
     Status,
-    Units,
     Verification,
 )
 from app.core.store import (
@@ -38,7 +37,6 @@ def sample(req_id: int = 1) -> dict:
         "source": "spec",
         "verification": "analysis",
         "revision": 1,
-        "units": {"quantity": "kg", "nominal": 1.0, "tolerance": 0.1},
         "attachments": [{"path": "a.txt", "note": "n"}],
         "approved_at": "2025-01-01",
         "notes": "note",
@@ -90,7 +88,6 @@ def test_save_accepts_dataclass(tmp_path: Path):
         source="spec",
         verification=Verification.ANALYSIS,
         acceptance="",
-        units=Units(quantity="kg", nominal=1.0),
     )
     path = save(tmp_path, req)
     loaded, _ = load(path)


### PR DESCRIPTION
## Summary
- Drop unit and derivation method/margin fields from core model and schema
- Simplify editor and list panels to omit removed fields
- Update docs, translations, and tests accordingly

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5aa4dd62883209a4bd6a79e91b454