### PR TITLE
feat: add label repository and storage

### DIFF
--- a/app/core/label_repository.py
+++ b/app/core/label_repository.py
@@ -1,0 +1,28 @@
+"""Label repository interface and implementations."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Protocol
+
+from .labels import Label
+from . import label_store
+
+
+class LabelRepository(Protocol):
+    """Abstract persistence operations for labels."""
+
+    def load(self, directory: str | Path) -> list[Label]:
+        """Load labels from *directory*."""
+
+    def save(self, directory: str | Path, labels: list[Label]) -> Path:
+        """Persist *labels* into *directory* and return resulting path."""
+
+
+class FileLabelRepository(LabelRepository):
+    """Filesystem-backed label repository."""
+
+    def load(self, directory: str | Path) -> list[Label]:  # type: ignore[override]
+        return label_store.load_labels(directory)
+
+    def save(self, directory: str | Path, labels: list[Label]) -> Path:  # type: ignore[override]
+        return label_store.save_labels(directory, labels)

--- a/app/core/label_store.py
+++ b/app/core/label_store.py
@@ -1,0 +1,47 @@
+"""JSON file storage for label data."""
+from __future__ import annotations
+
+from dataclasses import asdict
+import json
+from pathlib import Path
+
+from ..log import logger
+
+from .labels import Label
+
+LABELS_FILENAME = "labels.json"
+
+
+def _read_json(path: Path) -> object:
+    """Read JSON from *path* and raise :class:`ValueError` on invalid content."""
+    try:
+        with path.open("r", encoding="utf-8") as fh:
+            return json.load(fh)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"Invalid JSON in {path}: {exc}") from exc
+
+
+def load_labels(directory: str | Path) -> list[Label]:
+    """Load labels from ``directory``.
+
+    Missing files yield an empty list.
+    """
+    path = Path(directory) / LABELS_FILENAME
+    if not path.exists():
+        return []
+    try:
+        data = _read_json(path)
+    except ValueError as exc:
+        logger.warning("%s", exc)
+        return []
+    return [Label(**item) for item in data]
+
+
+def save_labels(directory: str | Path, labels: list[Label]) -> Path:
+    """Persist ``labels`` into ``directory`` and return resulting path."""
+    directory = Path(directory)
+    directory.mkdir(parents=True, exist_ok=True)
+    path = directory / LABELS_FILENAME
+    with path.open("w", encoding="utf-8") as fh:
+        json.dump([asdict(lbl) for lbl in labels], fh, ensure_ascii=False, indent=2, sort_keys=True)
+    return path

--- a/app/core/requirements.py
+++ b/app/core/requirements.py
@@ -19,9 +19,8 @@ from .store import (
     save,
     delete,
     ConflictError,
-    load_labels as store_load_labels,
-    save_labels as store_save_labels,
 )
+from .label_repository import LabelRepository, FileLabelRepository
 from ..util.time import local_now_str, normalize_timestamp
 
 # Re-export searchable fields for UI components
@@ -146,11 +145,17 @@ def search_loaded(
     )
 
 
-def load_labels(directory: str | Path) -> list[Label]:
-    """Load labels from ``directory``."""
-    return store_load_labels(directory)
+def load_labels(
+    directory: str | Path, repo: LabelRepository | None = None
+) -> list[Label]:
+    """Load labels from ``directory`` using ``repo`` if provided."""
+    repo = repo or FileLabelRepository()
+    return repo.load(directory)
 
 
-def save_labels(directory: str | Path, labels: list[Label]):
-    """Persist ``labels`` into ``directory``."""
-    return store_save_labels(directory, labels)
+def save_labels(
+    directory: str | Path, labels: list[Label], repo: LabelRepository | None = None
+):
+    """Persist ``labels`` into ``directory`` using ``repo`` if provided."""
+    repo = repo or FileLabelRepository()
+    return repo.save(directory, labels)

--- a/app/core/store.py
+++ b/app/core/store.py
@@ -1,17 +1,15 @@
 """JSON file storage for requirements."""
 from __future__ import annotations
 
-from dataclasses import asdict, is_dataclass
+from dataclasses import is_dataclass
 import json
 from pathlib import Path
 
 from ..log import logger
 
 from .validate import validate
-from .labels import Label
 from .model import requirement_to_dict
-
-LABELS_FILENAME = "labels.json"
+from .label_store import LABELS_FILENAME
 
 # in-memory cache of requirement ids per directory
 _ID_CACHE: dict[Path, set[int]] = {}
@@ -193,32 +191,3 @@ def mark_suspects(directory: str | Path, changed_id: int, new_revision: int) -> 
             with fp.open("w", encoding="utf-8") as fh:
                 json.dump(data, fh, ensure_ascii=False, indent=2, sort_keys=True)
 
-
-# ---------------------------------------------------------------------------
-# label storage
-
-
-def load_labels(directory: str | Path) -> list[Label]:
-    """Load labels from ``directory``.
-
-    Missing files yield an empty list.
-    """
-    path = Path(directory) / LABELS_FILENAME
-    if not path.exists():
-        return []
-    try:
-        data = _read_json(path)
-    except ValueError as exc:
-        logger.warning("%s", exc)
-        return []
-    return [Label(**item) for item in data]
-
-
-def save_labels(directory: str | Path, labels: list[Label]) -> Path:
-    """Persist ``labels`` into ``directory`` and return resulting path."""
-    directory = Path(directory)
-    directory.mkdir(parents=True, exist_ok=True)
-    path = directory / LABELS_FILENAME
-    with path.open("w", encoding="utf-8") as fh:
-        json.dump([asdict(lbl) for lbl in labels], fh, ensure_ascii=False, indent=2, sort_keys=True)
-    return path

--- a/app/ui/main_frame.py
+++ b/app/ui/main_frame.py
@@ -28,6 +28,7 @@ from .navigation import Navigation
 from .command_dialog import CommandDialog
 from .controllers import RequirementsController, LabelsController
 from ..core.repository import FileRequirementRepository
+from ..core.label_repository import FileLabelRepository
 
 
 class WxLogHandler(logging.Handler):
@@ -334,7 +335,10 @@ class MainFrame(wx.Frame):
         self.req_controller = RequirementsController(
             self.config, self.model, path, repo
         )
-        self.labels_controller = LabelsController(self.config, self.model, path)
+        lbl_repo = FileLabelRepository()
+        self.labels_controller = LabelsController(
+            self.config, self.model, path, lbl_repo
+        )
         self.labels_controller.load_labels()
         derived_map = self.req_controller.load_directory()
         self.navigation.update_recent_menu()

--- a/tests/test_labels.py
+++ b/tests/test_labels.py
@@ -1,7 +1,8 @@
 """Tests for labels."""
 
 from app.core.labels import Label, add_label, get_label, update_label, delete_label
-from app.core import store
+from app.core import label_store
+from app.core.label_repository import FileLabelRepository
 from pathlib import Path
 
 
@@ -18,6 +19,14 @@ def test_label_crud_operations(tmp_path: Path) -> None:
 
 def test_store_load_save_labels(tmp_path: Path) -> None:
     labels = [Label("ui", "#ff0000"), Label("backend", "#00ff00")]
-    store.save_labels(tmp_path, labels)
-    loaded = store.load_labels(tmp_path)
+    label_store.save_labels(tmp_path, labels)
+    loaded = label_store.load_labels(tmp_path)
+    assert loaded == labels
+
+
+def test_file_label_repository_roundtrip(tmp_path: Path) -> None:
+    repo = FileLabelRepository()
+    labels = [Label("ui", "#ff0000"), Label("backend", "#00ff00")]
+    repo.save(tmp_path, labels)
+    loaded = repo.load(tmp_path)
     assert loaded == labels

--- a/tests/test_labels_dialog.py
+++ b/tests/test_labels_dialog.py
@@ -182,9 +182,9 @@ def test_main_frame_manage_labels_saves(monkeypatch, tmp_path, wx_app):
     evt = wx.CommandEvent(wx.EVT_MENU.typeId, frame.manage_labels_id)
     frame.ProcessEvent(evt)
 
-    from app.core import store
+    from app.core import label_store
 
-    labels = store.load_labels(tmp_path)
+    labels = label_store.load_labels(tmp_path)
     assert labels[0].color == "#123456"
     assert ("editor", ["ui"]) in captured
     assert ("panel", ["ui"]) in captured

--- a/tests/test_labels_sync.py
+++ b/tests/test_labels_sync.py
@@ -1,7 +1,7 @@
 """Tests for labels sync."""
 
 import pytest
-from app.core import store
+from app.core import store, label_store
 from app.core.labels import PRESET_SETS
 
 
@@ -24,7 +24,7 @@ def _create_requirement(directory):
 
 def test_sync_labels_preserves_unused(monkeypatch, tmp_path, wx_app):
     wx = pytest.importorskip("wx")
-    store.save_labels(tmp_path, PRESET_SETS["basic"])
+    label_store.save_labels(tmp_path, PRESET_SETS["basic"])
     _create_requirement(tmp_path)
     from app.ui.main_frame import MainFrame
     frame = MainFrame(None)


### PR DESCRIPTION
## Summary
- add filesystem-backed label storage module
- define LabelRepository and FileLabelRepository
- inject label repositories into controllers and services

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c5aaafda148320b9ae71dccc0dc66b