### PR TITLE
Добавлена подпись для консоли ошибок

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -210,7 +210,7 @@ class ConfigManager:
         splitter: wx.SplitterWindow,
         main_splitter: wx.SplitterWindow,
         panel: ListPanelLike,
-        log_console: wx.TextCtrl,
+        log_console: wx.Window,
         log_menu_item: wx.MenuItem | None = None,
     ) -> None:
         """Restore window geometry and splitter positions."""

--- a/app/locale/en/LC_MESSAGES/CookaReq.po
+++ b/app/locale/en/LC_MESSAGES/CookaReq.po
@@ -196,6 +196,9 @@ msgstr "Short title"
 msgid "Show Error Console"
 msgstr "Show Error Console"
 
+msgid "Error Console"
+msgstr "Error Console"
+
 msgid "Source"
 msgstr "Source"
 

--- a/app/locale/ru/LC_MESSAGES/CookaReq.po
+++ b/app/locale/ru/LC_MESSAGES/CookaReq.po
@@ -185,6 +185,9 @@ msgstr "&Файл"
 msgid "Show Error Console"
 msgstr "Показать консоль ошибок"
 
+msgid "Error Console"
+msgstr "Консоль ошибок"
+
 msgid "&View"
 msgstr "&Вид"
 

--- a/app/ui/main_frame.py
+++ b/app/ui/main_frame.py
@@ -126,10 +126,17 @@ class MainFrame(wx.Frame):
         self.splitter.SplitVertically(self.panel, self.editor, 300)
         self.editor.Hide()
 
+        self.log_panel = wx.Panel(self.main_splitter)
+        log_sizer = wx.BoxSizer(wx.VERTICAL)
+        self.log_label = wx.StaticText(self.log_panel, label=_("Error Console"))
         self.log_console = wx.TextCtrl(
-            self.main_splitter,
+            self.log_panel,
             style=wx.TE_MULTILINE | wx.TE_READONLY | wx.TE_DONTWRAP,
         )
+        log_sizer.Add(self.log_label, 0, wx.EXPAND | wx.LEFT | wx.RIGHT | wx.TOP, 5)
+        log_sizer.Add(self.log_console, 1, wx.EXPAND | wx.ALL, 5)
+        self.log_panel.SetSizer(log_sizer)
+
         existing = next((h for h in logger.handlers if isinstance(h, WxLogHandler)), None)
         if existing:
             self.log_handler = existing
@@ -406,13 +413,13 @@ class MainFrame(wx.Frame):
     def on_toggle_log_console(self, event: wx.CommandEvent) -> None:
         if self.navigation.log_menu_item.IsChecked():
             sash = self.config.get_log_sash(self.GetClientSize().height - 150)
-            self.log_console.Show()
-            self.main_splitter.SplitHorizontally(self.splitter, self.log_console, sash)
+            self.log_panel.Show()
+            self.main_splitter.SplitHorizontally(self.splitter, self.log_panel, sash)
         else:
             if self.main_splitter.IsSplit():
                 self.config.set_log_sash(self.main_splitter.GetSashPosition())
-            self.main_splitter.Unsplit(self.log_console)
-            self.log_console.Hide()
+            self.main_splitter.Unsplit(self.log_panel)
+            self.log_panel.Hide()
         self.config.set_log_shown(self.navigation.log_menu_item.IsChecked())
 
     def _load_layout(self) -> None:
@@ -422,7 +429,7 @@ class MainFrame(wx.Frame):
             self.splitter,
             self.main_splitter,
             self.panel,
-            self.log_console,
+            self.log_panel,
             self.log_menu_item,
         )
 

--- a/tests/test_main_frame_gui.py
+++ b/tests/test_main_frame_gui.py
@@ -181,6 +181,22 @@ def test_log_handler_not_duplicated(tmp_path, wx_app):
     # wx_app fixture handles cleanup
 
 
+def test_log_console_shows_label(wx_app):
+    wx = pytest.importorskip("wx")
+    from app.i18n import _
+    import app.ui.main_frame as main_frame
+
+    frame = main_frame.MainFrame(None)
+    frame.navigation.log_menu_item.Check(True)
+    frame.on_toggle_log_console(wx.CommandEvent(wx.EVT_MENU.typeId))
+    wx_app.Yield()
+
+    assert frame.log_label.GetLabel() == _("Error Console")
+    assert frame.log_label.GetPosition().y < frame.log_console.GetPosition().y
+
+    frame.Destroy()
+
+
 def test_main_frame_loads_requirements(monkeypatch, tmp_path, wx_app):
     wx = pytest.importorskip("wx")
     from app.core.store import save


### PR DESCRIPTION
## Summary
- Обернул консоль ошибок в панель со статичным заголовком "Error Console"
- Обновил восстановление и переключение макета для работы с новой панелью
- Добавил локализацию строки и тест, проверяющий отображение подписи

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5b2f167688320add5a221a087a1c4