### PR TITLE
Remove toolbar and use menu for navigation

### DIFF
--- a/app/ui/main_frame.py
+++ b/app/ui/main_frame.py
@@ -253,7 +253,7 @@ class MainFrame(wx.Frame):
         app = wx.GetApp()
         app.locale = init_locale(self.language)
 
-        # Rebuild menus and toolbar with new translations
+        # Rebuild menus with new translations
         self.navigation.rebuild(self.selected_fields)
         self._recent_menu = self.navigation.recent_menu
         self._recent_menu_item = self.navigation.recent_menu_item

--- a/app/ui/navigation.py
+++ b/app/ui/navigation.py
@@ -1,4 +1,4 @@
-"""Menu bar and toolbar handling for the main frame."""
+"""Menu bar handling for the main frame."""
 
 from __future__ import annotations
 
@@ -12,7 +12,7 @@ from ..config import ConfigManager
 
 
 class Navigation:
-    """Encapsulate menu bar and toolbar construction."""
+    """Encapsulate menu bar construction."""
 
     def __init__(
         self,
@@ -47,7 +47,6 @@ class Navigation:
         self._recent_items: Dict[int, Path] = {}
         self._column_items: Dict[int, str] = {}
         self.menu_bar = wx.MenuBar()
-        self.toolbar: wx.ToolBar | None = None
         self.log_menu_item: wx.MenuItem | None = None
         self.recent_menu = wx.Menu()
         self.recent_menu_item: wx.MenuItem | None = None
@@ -57,18 +56,19 @@ class Navigation:
     # ------------------------------------------------------------------
     def _build(self) -> None:
         self._create_menu()
-        self._create_toolbar()
 
     def _create_menu(self) -> None:
         menu_bar = wx.MenuBar()
         file_menu = wx.Menu()
         open_item = file_menu.Append(wx.ID_OPEN, _("&Open Folder\tCtrl+O"))
+        new_item = file_menu.Append(wx.ID_NEW, _("&New Requirement\tCtrl+N"))
         self.recent_menu = wx.Menu()
         self.recent_menu_item = file_menu.AppendSubMenu(self.recent_menu, _("Open &Recent"))
         settings_item = file_menu.Append(wx.ID_PREFERENCES, _("Settings"))
         labels_item = file_menu.Append(wx.ID_ANY, _("Manage Labels"))
         exit_item = file_menu.Append(wx.ID_EXIT, _("E&xit"))
         self.frame.Bind(wx.EVT_MENU, self.on_open_folder, open_item)
+        self.frame.Bind(wx.EVT_MENU, self.on_new_requirement, new_item)
         self.frame.Bind(wx.EVT_MENU, self.on_open_settings, settings_item)
         self.frame.Bind(wx.EVT_MENU, self.on_manage_labels, labels_item)
         self.frame.Bind(wx.EVT_MENU, lambda evt: self.frame.Close(), exit_item)
@@ -99,15 +99,6 @@ class Navigation:
         self.menu_bar = menu_bar
         self.frame.SetMenuBar(self.menu_bar)
 
-    def _create_toolbar(self) -> None:
-        toolbar = self.frame.CreateToolBar()
-        open_tool = toolbar.AddTool(wx.ID_OPEN, _("Open"), wx.ArtProvider.GetBitmap(wx.ART_FOLDER_OPEN))
-        new_tool = toolbar.AddTool(wx.ID_NEW, _("New"), wx.ArtProvider.GetBitmap(wx.ART_NEW))
-        self.frame.Bind(wx.EVT_TOOL, self.on_open_folder, open_tool)
-        self.frame.Bind(wx.EVT_TOOL, self.on_new_requirement, new_tool)
-        toolbar.Realize()
-        self.toolbar = toolbar
-
     def _rebuild_recent_menu(self) -> None:
         for item in list(self.recent_menu.GetMenuItems()):
             self.recent_menu.Delete(item)
@@ -122,11 +113,9 @@ class Navigation:
     # ------------------------------------------------------------------
     # public API
     def rebuild(self, selected_fields: list[str]) -> None:
-        """Rebuild menu and toolbar, typically after language change."""
+        """Rebuild menu, typically after language change."""
         self.selected_fields = selected_fields
         self.frame.SetMenuBar(None)
-        if self.toolbar is not None:
-            self.toolbar.Destroy()
         self._build()
 
     def update_recent_menu(self) -> None:

--- a/tests/test_main_frame_gui.py
+++ b/tests/test_main_frame_gui.py
@@ -39,45 +39,6 @@ def test_main_frame_open_folder(monkeypatch, tmp_path, wx_app):
 
     frame.Destroy()
 
-
-def test_main_frame_open_folder_toolbar(monkeypatch, tmp_path, wx_app):
-    wx = pytest.importorskip("wx")
-
-    called = {}
-
-    class DummyDirDialog:
-        def __init__(self, parent, message):
-            called["init"] = True
-
-        def ShowModal(self):
-            called["show"] = True
-            return wx.ID_OK
-
-        def GetPath(self):
-            return str(tmp_path)
-
-        def Destroy(self):
-            called["destroy"] = True
-
-    monkeypatch.setattr(wx, "DirDialog", DummyDirDialog)
-
-    import app.ui.list_panel as list_panel
-    import app.ui.main_frame as main_frame
-    importlib.reload(list_panel)
-    importlib.reload(main_frame)
-
-    frame = main_frame.MainFrame(None)
-
-    # emulate toolbar event
-    evt = wx.CommandEvent(wx.EVT_TOOL.typeId, wx.ID_OPEN)
-    frame.ProcessEvent(evt)
-
-    assert called == {"init": True, "show": True, "destroy": True}
-    assert isinstance(frame.panel, list_panel.ListPanel)
-
-    frame.Destroy()
-
-
 def test_main_frame_run_command_menu(monkeypatch, wx_app):
     wx = pytest.importorskip("wx")
 
@@ -368,11 +329,11 @@ def test_main_frame_clone_requirement_creates_copy(monkeypatch, tmp_path, wx_app
     frame.Destroy()
 
 
-def test_main_frame_new_requirement_button(monkeypatch, tmp_path, wx_app):
+def test_main_frame_new_requirement_menu(monkeypatch, tmp_path, wx_app):
     wx, frame = _prepare_frame(monkeypatch, tmp_path)
 
-    # emulate toolbar event for new requirement
-    evt = wx.CommandEvent(wx.EVT_TOOL.typeId, wx.ID_NEW)
+    # emulate menu event for new requirement
+    evt = wx.CommandEvent(wx.EVT_MENU.typeId, wx.ID_NEW)
     frame.ProcessEvent(evt)
 
     assert frame.editor.IsShown()


### PR DESCRIPTION
## Summary
- Drop the toolbar from the GUI
- Add "New Requirement" action to the File menu
- Adjust tests for menu-based workflow

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c5b4bd324c8320ac17e531256d6b86