### PR TITLE
feat: unify field labels and improve translations

### DIFF
--- a/app/locale/en/LC_MESSAGES/CookaReq.po
+++ b/app/locale/en/LC_MESSAGES/CookaReq.po
@@ -323,6 +323,9 @@ msgstr "Derived from"
 msgid "Derived only"
 msgstr "Derived only"
 
+msgid "Derived count"
+msgstr "Derived count"
+
 msgid "File"
 msgstr "File"
 

--- a/app/locale/ru/LC_MESSAGES/CookaReq.po
+++ b/app/locale/ru/LC_MESSAGES/CookaReq.po
@@ -321,13 +321,16 @@ msgid "Derivation Graph"
 msgstr "Граф выводов"
 
 msgid "Derive"
-msgstr "Вывести"
+msgstr "Создать производное"
 
 msgid "Derived from"
 msgstr "Получено из"
 
 msgid "Derived only"
 msgstr "Только производные"
+
+msgid "Derived count"
+msgstr "Количество производных"
 
 msgid "File"
 msgstr "Файл"
@@ -430,7 +433,7 @@ msgid "Run"
 msgstr "Запустить"
 
 msgid "Run Agent Command\tCtrl+K"
-msgstr "Запустить команду агента\tCtrl+K"
+msgstr "Выполнить команду агента\tCtrl+K"
 
 msgid "Select attachment"
 msgstr "Выберите вложение"

--- a/app/ui/editor_panel.py
+++ b/app/ui/editor_panel.py
@@ -49,25 +49,26 @@ class EditorPanel(ScrolledPanel):
         self.directory: Path | None = None
         self.original_id: int | None = None
 
-        labels = {
-            "id": _("Requirement ID (number)"),
-            "title": _("Short title"),
-            "statement": _("Requirement text"),
-            "acceptance": _("Acceptance criteria"),
-            "conditions": _("Conditions"),
-            "trace_up": _("Trace up"),
-            "trace_down": _("Trace down"),
-            "version": _("Requirement version"),
-            "modified_at": _("Modified at"),
-            "owner": _("Owner"),
-            "source": _("Source"),
-            "type": _("Requirement type"),
-            "status": _("Status"),
-            "priority": _("Priority"),
-            "verification": _("Verification method"),
-            "rationale": _("Rationale"),
-            "assumptions": _("Assumptions"),
-        }
+        field_names = [
+            "id",
+            "title",
+            "statement",
+            "acceptance",
+            "conditions",
+            "trace_up",
+            "trace_down",
+            "version",
+            "modified_at",
+            "owner",
+            "source",
+            "type",
+            "status",
+            "priority",
+            "verification",
+            "rationale",
+            "assumptions",
+        ]
+        labels = {name: locale.field_label(name) for name in field_names}
 
         help_texts = {
             "id": _(

--- a/app/ui/list_panel.py
+++ b/app/ui/list_panel.py
@@ -126,7 +126,7 @@ class ListPanel(wx.Panel, ColumnSorterMixin):
         self.list.ClearAll()
         self.list.InsertColumn(0, _("Title"))
         for idx, field in enumerate(self.columns, start=1):
-            self.list.InsertColumn(idx, field)
+            self.list.InsertColumn(idx, locale.field_label(field))
         ColumnSorterMixin.__init__(self, self.list.GetColumnCount())
         try:  # remove mixin's default binding and use our own
             self.list.Unbind(wx.EVT_LIST_COL_CLICK)
@@ -431,7 +431,8 @@ class ListPanel(wx.Panel, ColumnSorterMixin):
         }
         if field in enum_map:
             choices = [locale.code_to_label(field, e.value) for e in enum_map[field]]
-            dlg = wx.SingleChoiceDialog(self, _("Select {field}").format(field=field), _("Edit"), choices)
+            label = locale.field_label(field)
+            dlg = wx.SingleChoiceDialog(self, _("Select {field}").format(field=label), _("Edit"), choices)
             if dlg.ShowModal() == wx.ID_OK:
                 label = dlg.GetStringSelection()
                 code = locale.label_to_code(field, label)
@@ -440,7 +441,8 @@ class ListPanel(wx.Panel, ColumnSorterMixin):
                 value = None
             dlg.Destroy()
             return value
-        dlg = wx.TextEntryDialog(self, _("New value for {field}").format(field=field), _("Edit"))
+        label = locale.field_label(field)
+        dlg = wx.TextEntryDialog(self, _("New value for {field}").format(field=label), _("Edit"))
         if dlg.ShowModal() == wx.ID_OK:
             value = dlg.GetValue()
         else:

--- a/app/ui/locale.py
+++ b/app/ui/locale.py
@@ -27,6 +27,37 @@ EN_LABELS = {
     "verification": VERIFICATION,
 }
 
+# Human-readable labels for requirement fields
+FIELD_LABELS = {
+    "id": _("Requirement ID (number)"),
+    "title": _("Short title"),
+    "statement": _("Requirement text"),
+    "acceptance": _("Acceptance criteria"),
+    "conditions": _("Conditions"),
+    "trace_up": _("Trace up"),
+    "trace_down": _("Trace down"),
+    "version": _("Requirement version"),
+    "modified_at": _("Modified at"),
+    "owner": _("Owner"),
+    "source": _("Source"),
+    "type": _("Requirement type"),
+    "status": _("Status"),
+    "priority": _("Priority"),
+    "verification": _("Verification method"),
+    "rationale": _("Rationale"),
+    "assumptions": _("Assumptions"),
+    "labels": _("Labels"),
+    "derived_count": _("Derived count"),
+}
+
+
+def field_label(name: str) -> str:
+    """Return localized label for requirement field name."""
+    label = FIELD_LABELS.get(name)
+    if label is not None:
+        return label
+    return _(name.replace("_", " ").capitalize())
+
 
 def code_to_label(category: str, code: str) -> str:
     """Return localized label for given code."""

--- a/app/ui/navigation.py
+++ b/app/ui/navigation.py
@@ -6,6 +6,8 @@ from ..i18n import _
 from pathlib import Path
 from typing import Callable, Dict
 
+from . import locale
+
 import wx
 
 from ..config import ConfigManager
@@ -80,7 +82,8 @@ class Navigation:
         columns_menu = wx.Menu()
         self._column_items.clear()
         for field in self.available_fields:
-            item = columns_menu.AppendCheckItem(wx.ID_ANY, field)
+            label = locale.field_label(field)
+            item = columns_menu.AppendCheckItem(wx.ID_ANY, label)
             item.Check(field in self.selected_fields)
             self.frame.Bind(wx.EVT_MENU, self.on_toggle_column, item)
             self._column_items[item.GetId()] = field


### PR DESCRIPTION
## Summary
- centralize requirement field labels and expose `field_label`
- translate column names and agent command strings
- refine Russian wording for deriving requirements

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c5b8c476a483208ddb27b0a98ced88