### PR TITLE
feat: improve MCP controls

### DIFF
--- a/app/locale/en/LC_MESSAGES/CookaReq.po
+++ b/app/locale/en/LC_MESSAGES/CookaReq.po
@@ -473,6 +473,12 @@ msgstr "check only MCP"
 msgid "not running"
 msgstr "not running"
 
+msgid "running"
+msgstr "running"
+
+msgid "MCP is a local server providing tools for requirement management."
+msgstr "MCP is a local server providing tools for requirement management."
+
 msgid "path to JSON/TOML settings"
 msgstr "path to JSON/TOML settings"
 

--- a/app/locale/ru/LC_MESSAGES/CookaReq.po
+++ b/app/locale/ru/LC_MESSAGES/CookaReq.po
@@ -140,7 +140,7 @@ msgid "Requirement type"
 msgstr "Тип требования"
 
 msgid "Status"
-msgstr "Текущий статус"
+msgstr "Статус"
 
 msgid "Priority"
 msgstr "Приоритет исполнения"
@@ -475,6 +475,12 @@ msgstr "проверить только MCP"
 
 msgid "not running"
 msgstr "не запущен"
+
+msgid "running"
+msgstr "запущен"
+
+msgid "MCP is a local server providing tools for requirement management."
+msgstr "MCP — локальный сервер, который предоставляет инструменты для управления требованиями."
 
 msgid "path to JSON/TOML settings"
 msgstr "путь к настройкам JSON/TOML"

--- a/tests/test_settings_dialog.py
+++ b/tests/test_settings_dialog.py
@@ -94,25 +94,29 @@ def test_mcp_start_stop_server(monkeypatch, wx_app):
         token="",
     )
 
-    import app.ui.settings_dialog as sd
+    assert dlg._start.IsEnabled()
+    assert not dlg._stop.IsEnabled()
+    assert dlg._status.GetLabel() == f"{sd._('Status')}: {sd._('not running')}"
 
-    assert dlg._start_stop.GetLabel() == sd._("Start MCP")
-
-    dlg._on_start_stop(wx.CommandEvent())
+    dlg._on_start(wx.CommandEvent())
     assert fake.calls[0][0] == "start"
     settings = fake.calls[0][1]
-    assert (settings.host, settings.port, settings.base_path, settings.require_token, settings.token) == (
-        "localhost",
-        8123,
-        "/tmp",
-        False,
-        "",
-    )
-    assert dlg._start_stop.GetLabel() == sd._("Stop MCP")
+    assert (
+        settings.host,
+        settings.port,
+        settings.base_path,
+        settings.require_token,
+        settings.token,
+    ) == ("localhost", 8123, "/tmp", False, "")
+    assert not dlg._start.IsEnabled()
+    assert dlg._stop.IsEnabled()
+    assert dlg._status.GetLabel() == f"{sd._('Status')}: {sd._('running')}"
 
-    dlg._on_start_stop(wx.CommandEvent())
+    dlg._on_stop(wx.CommandEvent())
     assert fake.calls[-1] == ("stop",)
-    assert dlg._start_stop.GetLabel() == sd._("Start MCP")
+    assert dlg._start.IsEnabled()
+    assert not dlg._stop.IsEnabled()
+    assert dlg._status.GetLabel() == f"{sd._('Status')}: {sd._('not running')}"
 
     dlg.Destroy()
 
@@ -160,15 +164,15 @@ def test_mcp_check_status(monkeypatch, wx_app):
 
     dummy.state = MCPStatus.READY
     dlg._on_check(wx.CommandEvent())
-    assert dlg._status.GetLabel() == sd._("ready")
+    assert dlg._status.GetLabel() == f"{sd._('Status')}: {sd._('running')}"
 
     dummy.state = MCPStatus.ERROR
     dlg._on_check(wx.CommandEvent())
-    assert dlg._status.GetLabel() == sd._("error")
+    assert dlg._status.GetLabel() == f"{sd._('Status')}: {sd._('running')}"
 
     dummy.state = MCPStatus.NOT_RUNNING
     dlg._on_check(wx.CommandEvent())
-    assert dlg._status.GetLabel() == sd._("not running")
+    assert dlg._status.GetLabel() == f"{sd._('Status')}: {sd._('not running')}"
 
     dlg.Destroy()
 


### PR DESCRIPTION
## Summary
- show Start/Stop MCP buttons simultaneously and display current status
- add short MCP description and update translations
- adjust settings dialog tests for new controls

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5b9b370288320a7e9242550804e41