### PR TITLE
fix: restore column drag behavior and locale fallback

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -31,7 +31,12 @@ def init_locale(language: str | None = None) -> wx.Locale:
     else:
         locale = wx.Locale(wx.LANGUAGE_DEFAULT)
     locale.AddCatalog(APP_NAME)
-    codes = [language] if language else [locale.GetName().split("_")[0]]
+    code = language
+    if not code and hasattr(locale, "GetName"):
+        name = locale.GetName()
+        if name:
+            code = name.split("_")[0]
+    codes = [code] if code else []
     i18n.install(APP_NAME, LOCALE_DIR, codes)
     return locale
 

--- a/app/ui/list_panel.py
+++ b/app/ui/list_panel.py
@@ -175,21 +175,13 @@ class ListPanel(wx.Panel):
         self.list.ClearColumns()
         self.list.AppendTextColumn(_("Title"), 0)
         for idx, field in enumerate(self.columns, start=1):
-
+            label = locale.field_label(field)
             if field == "labels":
                 self.renderer = LabelBadgeRenderer(self)
-                col = dv.DataViewColumn(_("Labels"), self.renderer, idx)
+                col = dv.DataViewColumn(label, self.renderer, idx)
                 self.list.AppendColumn(col)
             else:
-                self.list.AppendTextColumn(field, idx)
-
-            self.list.InsertColumn(idx, locale.field_label(field))
-        ColumnSorterMixin.__init__(self, self.list.GetColumnCount())
-        try:  # remove mixin's default binding and use our own
-            self.list.Unbind(wx.EVT_LIST_COL_CLICK)
-        except Exception:  # pragma: no cover - Unbind may not exist
-            pass
-        self.list.Bind(wx.EVT_LIST_COL_CLICK, self._on_col_click)
+                self.list.AppendTextColumn(label, idx)
 
 
     def load_column_widths(self, config: wx.Config) -> None:


### PR DESCRIPTION
## Summary
- remove leftover ColumnSorterMixin usage to restore column drag and drop
- resolve locale initialization when wx.Locale lacks GetName

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c5c4c3f9708320ab4a9984a74e0fad