### PR TITLE
feat: improve filters UI

### DIFF
--- a/tests/test_list_panel.py
+++ b/tests/test_list_panel.py
@@ -265,7 +265,12 @@ def test_list_panel_has_filter_and_list(monkeypatch):
 
     sizer = panel.GetSizer()
     children = [child.GetWindow() for child in sizer.GetChildren()]
-    assert children == [panel.filter_btn, panel.list]
+    assert len(children) == 2
+    btn_row = children[0]
+    assert isinstance(btn_row, wx_stub.BoxSizer)
+    inner = [child.GetWindow() for child in btn_row.GetChildren()]
+    assert inner == [panel.filter_btn, panel.reset_btn, panel.filter_summary]
+    assert children[1] is panel.list
 
 
 def test_column_click_sorts(monkeypatch):


### PR DESCRIPTION
## Summary
- localize filter dialog fields and colorize label options
- show active filters and reset button in requirements list
- allow resetting filters from dialog and main panel

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c5cb4133248320941e5f45cbc8e563