### PR TITLE
Add contextual reset filters button

### DIFF
--- a/app/locale/en/LC_MESSAGES/CookaReq.po
+++ b/app/locale/en/LC_MESSAGES/CookaReq.po
@@ -332,6 +332,9 @@ msgstr "File"
 msgid "Filters"
 msgstr "Filters"
 
+msgid "Clear filters"
+msgstr "Clear filters"
+
 msgid "General"
 msgstr "General"
 

--- a/app/locale/ru/LC_MESSAGES/CookaReq.po
+++ b/app/locale/ru/LC_MESSAGES/CookaReq.po
@@ -338,6 +338,9 @@ msgstr "Файл"
 msgid "Filters"
 msgstr "Фильтры"
 
+msgid "Clear filters"
+msgstr "Убрать фильтры"
+
 msgid "General"
 msgstr "Общее"
 

--- a/tests/test_list_panel_gui.py
+++ b/tests/test_list_panel_gui.py
@@ -44,12 +44,31 @@ def test_list_panel_real_widgets(wx_app):
 
     assert panel in frame.GetChildren()
     assert isinstance(panel.filter_btn, wx.Button)
+    assert isinstance(panel.reset_btn, wx.BitmapButton)
     assert isinstance(panel.list, ULC.UltimateListCtrl)
     assert panel.filter_btn.GetParent() is panel
+    assert panel.reset_btn.GetParent() is panel
     assert panel.list.GetParent() is panel
     assert panel.filter_btn.IsShown()
     assert panel.list.IsShown()
+    assert not panel.reset_btn.IsShown()
 
+    frame.Destroy()
+
+
+def test_reset_button_visibility_gui(wx_app):
+    wx = pytest.importorskip("wx")
+    import app.ui.list_panel as list_panel
+    importlib.reload(list_panel)
+    frame = wx.Frame(None)
+    from app.ui.requirement_model import RequirementModel
+    panel = list_panel.ListPanel(frame, model=RequirementModel())
+    panel.set_search_query("T")
+    wx_app.Yield()
+    assert panel.reset_btn.IsShown()
+    panel.reset_filters()
+    wx_app.Yield()
+    assert not panel.reset_btn.IsShown()
     frame.Destroy()
 
 


### PR DESCRIPTION
## Summary
- Hide reset filters button until any filter is active
- Show reset button as a compact cross icon with a localized tooltip
- Cover behavior with unit and GUI tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5cf7509288320bbab62d1b4a25bb5