### PR TITLE
Revert requirements list to ListCtrl

### DIFF
--- a/tests/test_list_panel_gui.py
+++ b/tests/test_list_panel_gui.py
@@ -40,12 +40,10 @@ def test_list_panel_real_widgets(wx_app):
     frame.GetSizer().Add(panel, 1, wx.EXPAND)
     frame.Layout()
 
-    from wx.lib.agw import ultimatelistctrl as ULC
-
     assert panel in frame.GetChildren()
     assert isinstance(panel.filter_btn, wx.Button)
     assert isinstance(panel.reset_btn, wx.BitmapButton)
-    assert isinstance(panel.list, ULC.UltimateListCtrl)
+    assert isinstance(panel.list, wx.ListCtrl)
     assert panel.filter_btn.GetParent() is panel
     assert panel.reset_btn.GetParent() is panel
     assert panel.list.GetParent() is panel


### PR DESCRIPTION
## Summary
- revert requirement list widget to `wx.ListCtrl` with native column dragging
- render colored label badges inside `ListCtrl` using cached bitmaps
- update list panel tests for badge rendering and label color lookup

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5d0ebe0608320a0303595bc667838