### PR TITLE
Improve MCP check feedback and documentation

### DIFF
--- a/app/locale/en/LC_MESSAGES/CookaReq.po
+++ b/app/locale/en/LC_MESSAGES/CookaReq.po
@@ -479,8 +479,8 @@ msgstr "not running"
 msgid "running"
 msgstr "running"
 
-msgid "MCP is a local server providing tools for requirement management."
-msgstr "MCP is a local server providing tools for requirement management."
+msgid "MCP is a local server providing tools for requirement management used by agents and the LLM."
+msgstr "MCP is a local server providing tools for requirement management used by agents and the LLM."
 
 msgid "path to JSON/TOML settings"
 msgstr "path to JSON/TOML settings"

--- a/app/locale/ru/LC_MESSAGES/CookaReq.po
+++ b/app/locale/ru/LC_MESSAGES/CookaReq.po
@@ -482,8 +482,8 @@ msgstr "не запущен"
 msgid "running"
 msgstr "запущен"
 
-msgid "MCP is a local server providing tools for requirement management."
-msgstr "MCP — локальный сервер, который предоставляет инструменты для управления требованиями."
+msgid "MCP is a local server providing tools for requirement management used by agents and the LLM."
+msgstr "MCP — локальный сервер, предоставляющий инструменты для управления требованиями, которые используют агенты и LLM."
 
 msgid "path to JSON/TOML settings"
 msgstr "путь к настройкам JSON/TOML"

--- a/app/ui/settings_dialog.py
+++ b/app/ui/settings_dialog.py
@@ -134,7 +134,7 @@ class SettingsDialog(wx.Dialog):
         help_txt = wx.StaticText(
             mcp,
             label=_(
-                "MCP is a local server providing tools for requirement management."
+                "MCP is a local server providing tools for requirement management used by agents and the LLM."
             ),
         )
         help_txt.Wrap(300)
@@ -238,8 +238,15 @@ class SettingsDialog(wx.Dialog):
         running = status != MCPStatus.NOT_RUNNING
         self._start.Enable(not running)
         self._stop.Enable(running)
-        label = _("running") if running else _("not running")
+        label_map = {
+            MCPStatus.READY: _("ready"),
+            MCPStatus.ERROR: _("error"),
+            MCPStatus.NOT_RUNNING: _("not running"),
+        }
+        label = label_map[status]
         self._status.SetLabel(f"{_('Status')}: {label}")
+        self.Layout()
+        wx.MessageBox(f"{_('Status')}: {label}", _("Check MCP"))
 
     # ------------------------------------------------------------------
     def get_values(self) -> tuple[

--- a/tests/test_settings_dialog.py
+++ b/tests/test_settings_dialog.py
@@ -145,6 +145,8 @@ def test_mcp_check_status(monkeypatch, wx_app):
 
     dummy = DummyMCP()
     monkeypatch.setattr("app.ui.settings_dialog.MCPController", lambda: dummy)
+    messages: list[tuple[str, str]] = []
+    monkeypatch.setattr("wx.MessageBox", lambda msg, caption, *a, **k: messages.append((msg, caption)))
 
     dlg = SettingsDialog(
         None,
@@ -164,11 +166,12 @@ def test_mcp_check_status(monkeypatch, wx_app):
 
     dummy.state = MCPStatus.READY
     dlg._on_check(wx.CommandEvent())
-    assert dlg._status.GetLabel() == f"{sd._('Status')}: {sd._('running')}"
+    assert dlg._status.GetLabel() == f"{sd._('Status')}: {sd._('ready')}"
+    assert messages[-1] == (f"{sd._('Status')}: {sd._('ready')}", sd._("Check MCP"))
 
     dummy.state = MCPStatus.ERROR
     dlg._on_check(wx.CommandEvent())
-    assert dlg._status.GetLabel() == f"{sd._('Status')}: {sd._('running')}"
+    assert dlg._status.GetLabel() == f"{sd._('Status')}: {sd._('error')}"
 
     dummy.state = MCPStatus.NOT_RUNNING
     dlg._on_check(wx.CommandEvent())


### PR DESCRIPTION
## Summary
- show detailed MCP status and popup on Check MCP
- mention agents and LLM in MCP tooltip
- cover new behavior in settings dialog tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c5d40cca488320bada546d409e70c1