### PR TITLE
Improve MCP health check feedback

### DIFF
--- a/app/ui/settings_dialog.py
+++ b/app/ui/settings_dialog.py
@@ -234,7 +234,8 @@ class SettingsDialog(wx.Dialog):
         self._tools_status.SetLabel(label)
 
     def _on_check(self, event: wx.Event) -> None:  # pragma: no cover - GUI event
-        status = self._mcp.check(self._current_settings())
+        result = self._mcp.check(self._current_settings())
+        status = result.status
         running = status != MCPStatus.NOT_RUNNING
         self._start.Enable(not running)
         self._stop.Enable(running)
@@ -246,7 +247,10 @@ class SettingsDialog(wx.Dialog):
         label = label_map[status]
         self._status.SetLabel(f"{_('Status')}: {label}")
         self.Layout()
-        wx.MessageBox(f"{_('Status')}: {label}", _("Check MCP"))
+        wx.MessageBox(
+            f"{_('Status')}: {label}\n{result.message}",
+            _("Check MCP"),
+        )
 
     # ------------------------------------------------------------------
     def get_values(self) -> tuple[

--- a/tests/test_settings_dialog.py
+++ b/tests/test_settings_dialog.py
@@ -54,7 +54,7 @@ def test_mcp_start_stop_server(monkeypatch, wx_app):
     wx = pytest.importorskip("wx")
     from app.ui.settings_dialog import SettingsDialog
     import app.ui.settings_dialog as sd
-    from app.mcp.controller import MCPStatus
+    from app.mcp.controller import MCPStatus, MCPCheckResult
 
     class FakeMCP:
         def __init__(self) -> None:
@@ -73,7 +73,7 @@ def test_mcp_start_stop_server(monkeypatch, wx_app):
             self.running = False
 
         def check(self, settings):
-            return MCPStatus.NOT_RUNNING
+            return MCPCheckResult(MCPStatus.NOT_RUNNING, "")
 
     fake = FakeMCP()
     monkeypatch.setattr("app.ui.settings_dialog.MCPController", lambda: fake)
@@ -125,7 +125,7 @@ def test_mcp_check_status(monkeypatch, wx_app):
     wx = pytest.importorskip("wx")
     from app.ui.settings_dialog import SettingsDialog
     import app.ui.settings_dialog as sd
-    from app.mcp.controller import MCPStatus
+    from app.mcp.controller import MCPStatus, MCPCheckResult
 
     class DummyMCP:
         def __init__(self):
@@ -141,7 +141,7 @@ def test_mcp_check_status(monkeypatch, wx_app):
             pass
 
         def check(self, settings):
-            return self.state
+            return MCPCheckResult(self.state, f"{self.state.value}")
 
     dummy = DummyMCP()
     monkeypatch.setattr("app.ui.settings_dialog.MCPController", lambda: dummy)
@@ -167,7 +167,9 @@ def test_mcp_check_status(monkeypatch, wx_app):
     dummy.state = MCPStatus.READY
     dlg._on_check(wx.CommandEvent())
     assert dlg._status.GetLabel() == f"{sd._('Status')}: {sd._('ready')}"
-    assert messages[-1] == (f"{sd._('Status')}: {sd._('ready')}", sd._("Check MCP"))
+    msg, caption = messages[-1]
+    assert msg.startswith(f"{sd._('Status')}: {sd._('ready')}")
+    assert caption == sd._("Check MCP")
 
     dummy.state = MCPStatus.ERROR
     dlg._on_check(wx.CommandEvent())


### PR DESCRIPTION
## Summary
- Return structured MCPCheckResult containing status and explanation from MCPController
- Show detailed MCP check information in settings dialog popup
- Update tests for new MCP check results

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5da975b4483209c666d23eebf5caf