### PR TITLE
feat: enforce docstrings on public functions

### DIFF
--- a/app/cli/commands.py
+++ b/app/cli/commands.py
@@ -38,6 +38,7 @@ def cmd_list(args: argparse.Namespace, repo: RequirementRepository) -> None:
 
 
 def add_list_arguments(p: argparse.ArgumentParser) -> None:
+    """Configure parser for the ``list`` command."""
     p.add_argument("directory", help=_("requirements directory"))
     p.add_argument("--labels", nargs="*", default=[], help=_("filter by labels"))
     p.add_argument("--query", help=_("text search query"))
@@ -63,6 +64,7 @@ def cmd_add(args: argparse.Namespace, repo: RequirementRepository) -> None:
 
 
 def add_add_arguments(p: argparse.ArgumentParser) -> None:
+    """Configure parser for the ``add`` command."""
     p.add_argument("directory", help=_("requirements directory"))
     p.add_argument("file", help=_("JSON file with requirement"))
     p.add_argument("--modified-at", help=_("explicit modified timestamp"))
@@ -91,6 +93,7 @@ def cmd_edit(args: argparse.Namespace, repo: RequirementRepository) -> None:
 
 
 def add_edit_arguments(p: argparse.ArgumentParser) -> None:
+    """Configure parser for the ``edit`` command."""
     p.add_argument("directory", help=_("requirements directory"))
     p.add_argument("file", help=_("JSON file with updated requirement"))
     p.add_argument("--modified-at", help=_("explicit modified timestamp"))
@@ -108,6 +111,7 @@ def cmd_delete(args: argparse.Namespace, repo: RequirementRepository) -> None:
 
 
 def add_delete_arguments(p: argparse.ArgumentParser) -> None:
+    """Configure parser for the ``delete`` command."""
     p.add_argument("directory", help=_("requirements directory"))
     p.add_argument("id", type=int, help=_("requirement id"))
 
@@ -126,6 +130,7 @@ def cmd_clone(args: argparse.Namespace, repo: RequirementRepository) -> None:
 
 
 def add_clone_arguments(p: argparse.ArgumentParser) -> None:
+    """Configure parser for the ``clone`` command."""
     p.add_argument("directory", help=_("requirements directory"))
     p.add_argument("source_id", type=int, help=_("source requirement id"))
     p.add_argument("new_id", type=int, help=_("new requirement id"))
@@ -140,6 +145,7 @@ def cmd_show(args: argparse.Namespace, repo: RequirementRepository) -> None:
 
 
 def add_show_arguments(p: argparse.ArgumentParser) -> None:
+    """Configure parser for the ``show`` command."""
     p.add_argument("directory", help=_("requirements directory"))
     p.add_argument("id", type=int, help=_("requirement id"))
 
@@ -156,6 +162,7 @@ def cmd_check(args: argparse.Namespace, _repo: RequirementRepository) -> None:
 
 
 def add_check_arguments(p: argparse.ArgumentParser) -> None:
+    """Configure parser for the ``check`` command."""
     p.add_argument("--llm", action="store_true", help=_("check only LLM"))
     p.add_argument("--mcp", action="store_true", help=_("check only MCP"))
 

--- a/app/cli/main.py
+++ b/app/cli/main.py
@@ -25,6 +25,7 @@ set_confirm(auto_confirm)
 
 
 def build_parser() -> argparse.ArgumentParser:
+    """Construct argument parser for CLI commands."""
     parser = argparse.ArgumentParser(description=_("CookaReq CLI"))
     parser.add_argument(
         "--settings",

--- a/build.py
+++ b/build.py
@@ -12,6 +12,7 @@ import PyInstaller.__main__  # type: ignore
 
 
 def main() -> None:
+    """Build project executables using PyInstaller."""
     root = Path(__file__).resolve().parent
     script = root / "app" / "main.py"
     icon = root / "app" / "resources" / "app.ico"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
 dev = ["pytest", "polib", "pydocstyle"]
 
 [tool.pydocstyle]
-select = ["D100", "D101", "D102"]
+select = ["D100", "D101", "D102", "D103"]
 
 [build-system]
 requires = ["setuptools", "wheel"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,6 +31,7 @@ def _auto_confirm():
 
 @pytest.fixture(scope="session")
 def wx_app():
+    """Provide wx.App instance, starting virtual display if needed."""
     display = None
     if os.name != "nt" and not os.environ.get("DISPLAY"):
         try:
@@ -59,6 +60,7 @@ def _get_free_port() -> int:
 
 @pytest.fixture(scope="module")
 def mcp_server():
+    """Run MCP server on a free port for the duration of tests."""
     port = _get_free_port()
     stop_server()
     start_server(port=port, base_path="")
@@ -69,11 +71,13 @@ def mcp_server():
 
 @pytest.hookimpl(tryfirst=True)
 def pytest_sessionstart(session):
+    """Store test session start time for summary reporting."""
     session.config._start_time = time.time()
 
 
 @pytest.hookimpl(trylast=True)
 def pytest_terminal_summary(terminalreporter, exitstatus):
+    """Print concise summary including duration at end of test run."""
     passed = len(terminalreporter.stats.get("passed", []))
     failed = len(terminalreporter.stats.get("failed", []))
     skipped = len(terminalreporter.stats.get("skipped", []))


### PR DESCRIPTION
## Summary
- require pydocstyle D103 in configuration
- document public CLI helpers and test fixtures
- add build script main() docstring

## Testing
- `python3 -m pydocstyle`
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_68c6512b82088320849d20b262d538a9