### PR TITLE
Fix label column badge placement in list panel

### DIFF
--- a/app/ui/list_panel.py
+++ b/app/ui/list_panel.py
@@ -176,7 +176,12 @@ class ListPanel(wx.Panel, ColumnSorterMixin):
             img_id = self._image_list.Add(bmp)
             self._label_images[key] = img_id
         self.list.SetStringItem(index, col, "")
-        if hasattr(wx, "ListItem"):
+        if hasattr(self.list, "SetItemColumnImage"):
+            try:
+                self.list.SetItemColumnImage(index, col, img_id)
+            except Exception:  # pragma: no cover - platform dependent
+                pass
+        elif hasattr(wx, "ListItem"):
             item = wx.ListItem()
             item.SetId(index)
             item.SetColumn(col)
@@ -186,10 +191,7 @@ class ListPanel(wx.Panel, ColumnSorterMixin):
             except Exception:
                 pass
         else:  # pragma: no cover - stub fallback
-            try:
-                self.list.SetItemColumnImage(index, col, img_id)
-            except Exception:
-                pass
+            self.list.SetStringItem(index, col, ", ".join(labels))
 
     def _setup_columns(self) -> None:
         """Configure list control columns based on selected fields."""

--- a/tests/test_list_panel.py
+++ b/tests/test_list_panel.py
@@ -487,6 +487,14 @@ def test_apply_status_filter(monkeypatch):
 
 def test_labels_column_renders_badges(monkeypatch):
     wx_stub, mixins, ulc = _build_wx_stub()
+    class ListItem:
+        def SetId(self, idx):
+            self.idx = idx
+        def SetColumn(self, col):
+            self.col = col
+        def SetImage(self, img):
+            self.img = img
+    wx_stub.ListItem = ListItem
     agw = types.SimpleNamespace(ultimatelistctrl=ulc)
     monkeypatch.setitem(sys.modules, "wx", wx_stub)
     monkeypatch.setitem(sys.modules, "wx.lib.mixins.listctrl", mixins)


### PR DESCRIPTION
## Summary
- Render labels in their own column by using `SetItemColumnImage` when available
- Fall back to `wx.ListItem` or plain text when column images are unsupported
- Extend tests to cover environments where `wx.ListItem` exists

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6527ca3dc8320a59e697944ccb5ce