### PR TITLE
Replace deprecated SetStringItem usage in list panel

### DIFF
--- a/app/ui/list_panel.py
+++ b/app/ui/list_panel.py
@@ -166,7 +166,7 @@ class ListPanel(wx.Panel, ColumnSorterMixin):
 
     def _set_label_image(self, index: int, col: int, labels: list[str]) -> None:
         if not labels:
-            self.list.SetStringItem(index, col, "")
+            self.list.SetItem(index, col, "")
             return
         key = tuple(labels)
         img_id = self._label_images.get(key)
@@ -175,7 +175,7 @@ class ListPanel(wx.Panel, ColumnSorterMixin):
             self._ensure_image_list_size(bmp.GetWidth(), bmp.GetHeight())
             img_id = self._image_list.Add(bmp)
             self._label_images[key] = img_id
-        self.list.SetStringItem(index, col, "")
+        self.list.SetItem(index, col, "")
         if hasattr(self.list, "SetItemColumnImage"):
             try:
                 self.list.SetItemColumnImage(index, col, img_id)
@@ -191,7 +191,7 @@ class ListPanel(wx.Panel, ColumnSorterMixin):
             except Exception:
                 pass
         else:  # pragma: no cover - stub fallback
-            self.list.SetStringItem(index, col, ", ".join(labels))
+            self.list.SetItem(index, col, ", ".join(labels))
 
     def _setup_columns(self) -> None:
         """Configure list control columns based on selected fields."""
@@ -426,7 +426,7 @@ class ListPanel(wx.Panel, ColumnSorterMixin):
                             suspect_row = True
                         texts.append(txt)
                     value = ", ".join(texts)
-                    self.list.SetStringItem(index, col, value)
+                    self.list.SetItem(index, col, value)
                     continue
                 if field in {"verifies", "relates"}:
                     links = getattr(getattr(req, "links", None), field, [])
@@ -438,7 +438,7 @@ class ListPanel(wx.Panel, ColumnSorterMixin):
                             suspect_row = True
                         texts.append(txt)
                     value = ", ".join(texts)
-                    self.list.SetStringItem(index, col, value)
+                    self.list.SetItem(index, col, value)
                     continue
                 if field == "parent":
                     link = getattr(req, "parent", None)
@@ -448,15 +448,15 @@ class ListPanel(wx.Panel, ColumnSorterMixin):
                         if getattr(link, "suspect", False):
                             value = f"!{value}"
                             suspect_row = True
-                    self.list.SetStringItem(index, col, value)
+                    self.list.SetItem(index, col, value)
                     continue
                 if field == "derived_count":
                     count = len(self.derived_map.get(req.id, []))
-                    self.list.SetStringItem(index, col, str(count))
+                    self.list.SetItem(index, col, str(count))
                     continue
                 if field == "attachments":
                     value = ", ".join(getattr(a, "path", "") for a in getattr(req, "attachments", []))
-                    self.list.SetStringItem(index, col, value)
+                    self.list.SetItem(index, col, value)
                     continue
                 value = getattr(req, field, "")
                 if isinstance(value, Enum):
@@ -464,7 +464,7 @@ class ListPanel(wx.Panel, ColumnSorterMixin):
                 if field == "labels" and isinstance(value, list):
                     self._set_label_image(index, col, value)
                     continue
-                self.list.SetStringItem(index, col, str(value))
+                self.list.SetItem(index, col, str(value))
             if suspect_row and hasattr(self.list, "SetItemTextColour"):
                 try:
                     colour = getattr(wx, "RED", None) or wx.Colour(255, 0, 0)
@@ -618,4 +618,4 @@ class ListPanel(wx.Panel, ColumnSorterMixin):
             setattr(req, field, value)
             self.model.update(req)
             display = value.value if isinstance(value, Enum) else value
-            self.list.SetStringItem(idx, column, str(display))
+            self.list.SetItem(idx, column, str(display))

--- a/tests/test_list_panel.py
+++ b/tests/test_list_panel.py
@@ -141,8 +141,9 @@ def _build_wx_stub():
             self._items.insert(index, text)
             self._data.insert(index, 0)
             return index
-        def SetStringItem(self, index, col, text):
+        def SetItem(self, index, col, text):
             pass
+        SetStringItem = SetItem
         def SetItemData(self, index, data):
             self._data[index] = data
         def GetItemData(self, index):
@@ -512,7 +513,7 @@ def test_labels_column_renders_badges(monkeypatch):
 
     texts: list[tuple[int, int, str]] = []
     images: list[tuple[int, int, int]] = []
-    panel.list.SetStringItem = lambda idx, col, text: texts.append((idx, col, text))
+    panel.list.SetItem = lambda idx, col, text: texts.append((idx, col, text))
     panel.list.SetItemColumnImage = lambda idx, col, img: images.append((idx, col, img))
     dummy = types.SimpleNamespace(GetWidth=lambda: 10, GetHeight=lambda: 10)
     calls: list[list[str]] = []


### PR DESCRIPTION
## Summary
- Replace deprecated `SetStringItem` with `SetItem` in the requirements list panel to silence wxPyDeprecationWarning.
- Update test stubs to support `SetItem` and adjust tests accordingly.

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c6540eebc88320a2c648c024b21ada