### PR TITLE
Introduce HelpStaticBox wrapper for cleaner layout

### DIFF
--- a/app/locale/en/LC_MESSAGES/CookaReq.po
+++ b/app/locale/en/LC_MESSAGES/CookaReq.po
@@ -467,6 +467,21 @@ msgstr "Update requirement?"
 msgid "Verifies"
 msgstr "Verifies"
 
+msgid "IDs of requirements this one verifies"
+msgstr "IDs of requirements this one verifies"
+
+msgid "IDs of related requirements"
+msgstr "IDs of related requirements"
+
+msgid "IDs of source requirements"
+msgstr "IDs of source requirements"
+
+msgid "Requirement ID"
+msgstr "Requirement ID"
+
+msgid "ID"
+msgstr "ID"
+
 msgid "check only LLM"
 msgstr "check only LLM"
 

--- a/app/locale/ru/LC_MESSAGES/CookaReq.po
+++ b/app/locale/ru/LC_MESSAGES/CookaReq.po
@@ -470,6 +470,21 @@ msgstr "Обновить требование?"
 msgid "Verifies"
 msgstr "Проверяет"
 
+msgid "IDs of requirements this one verifies"
+msgstr "ID требований, которые проверяет это требование"
+
+msgid "IDs of related requirements"
+msgstr "ID связанных требований"
+
+msgid "IDs of source requirements"
+msgstr "ID исходных требований"
+
+msgid "Requirement ID"
+msgstr "ID требования"
+
+msgid "ID"
+msgstr "ID"
+
 msgid "check only LLM"
 msgstr "проверить только LLM"
 

--- a/app/ui/editor_panel.py
+++ b/app/ui/editor_panel.py
@@ -374,19 +374,27 @@ class EditorPanel(ScrolledPanel):
 
         # verifies section ----------------------------------------------
         ver_sizer = self._create_links_section(
-            _("Verifies"), "verifies", help_key="verifies"
+            _("IDs of requirements this one verifies"),
+            "verifies",
+            help_key="verifies",
         )
         links_grid.Add(ver_sizer, 0, wx.EXPAND | wx.ALL, 5)
 
         # relates section -----------------------------------------------
         rel_sizer = self._create_links_section(
-            _("Relates"), "relates", help_key="relates"
+            _("IDs of related requirements"),
+            "relates",
+            help_key="relates",
         )
         links_grid.Add(rel_sizer, 0, wx.EXPAND | wx.ALL, 5)
 
         # derived from section -------------------------------------------
         df_sizer = self._create_links_section(
-            _("Derived from"), "derived_from", help_key="derived_from", id_name="derived_id", list_name="derived_list"
+            _("IDs of source requirements"),
+            "derived_from",
+            help_key="derived_from",
+            id_name="derived_id",
+            list_name="derived_list",
         )
         links_grid.Add(df_sizer, 0, wx.EXPAND | wx.ALL, 5)
 
@@ -499,6 +507,7 @@ class EditorPanel(ScrolledPanel):
         box = sizer.GetStaticBox()
         row = wx.BoxSizer(wx.HORIZONTAL)
         id_ctrl = wx.TextCtrl(box)
+        id_ctrl.SetHint(_("Requirement ID"))
         row.Add(id_ctrl, 1, wx.EXPAND | wx.RIGHT, 5)
         add_btn = wx.Button(box, label=_("Add"))
         add_btn.Bind(wx.EVT_BUTTON, lambda _evt, a=attr: self._on_add_link_generic(a))
@@ -507,7 +516,11 @@ class EditorPanel(ScrolledPanel):
         remove_btn.Bind(wx.EVT_BUTTON, lambda _evt, a=attr: self._on_remove_link_generic(a))
         row.Add(remove_btn, 0)
         sizer.Add(row, 0, wx.EXPAND | wx.ALL, 5)
-        lst = wx.ListBox(box, choices=[])
+        lst = wx.ListCtrl(box, style=wx.LC_REPORT | wx.LC_SINGLE_SEL)
+        lst.InsertColumn(0, _("ID"))
+        lst.InsertColumn(1, _("Title"))
+        lst.SetColumnWidth(0, wx.LIST_AUTOSIZE_USEHEADER)
+        lst.SetColumnWidth(1, wx.LIST_AUTOSIZE_USEHEADER)
         sizer.Add(lst, 1, wx.EXPAND | wx.ALL, 5)
         # по умолчанию список и кнопка удаления скрыты
         lst.Hide()
@@ -548,6 +561,28 @@ class EditorPanel(ScrolledPanel):
         self.Layout()
         self.FitInside()
 
+    def _autosize_link_columns(self, list_ctrl: wx.ListCtrl) -> None:
+        """Adjust column widths for a two-column link list."""
+        list_ctrl.SetColumnWidth(0, wx.LIST_AUTOSIZE_USEHEADER)
+        list_ctrl.SetColumnWidth(1, wx.LIST_AUTOSIZE)
+
+    def _rebuild_links_list(self, attr: str) -> None:
+        """Repopulate ListCtrl for given link attribute."""
+        _, list_ctrl, links_list = self._link_widgets(attr)
+        list_ctrl.DeleteAllItems()
+        for link in links_list:
+            src_id = link["source_id"]
+            title = ""
+            if self.directory:
+                try:
+                    req = req_ops.get_requirement(self.directory, src_id)
+                    title = req.title or ""
+                except Exception:  # pragma: no cover - lookup errors
+                    pass
+            idx = list_ctrl.InsertItem(list_ctrl.GetItemCount(), str(src_id))
+            list_ctrl.SetItem(idx, 1, title)
+        self._autosize_link_columns(list_ctrl)
+
     # basic operations -------------------------------------------------
     def set_directory(self, directory: str | Path | None) -> None:
         """Set working directory for ID validation."""
@@ -585,11 +620,11 @@ class EditorPanel(ScrolledPanel):
             self.approved_picker.SetValue(wx.DefaultDateTime)
             self.notes_ctrl.ChangeValue("")
             self._refresh_attachments()
-            self.derived_list.Set([])
+            self.derived_list.DeleteAllItems()
             self.derived_id.ChangeValue("")
-            self.verifies_list.Set([])
+            self.verifies_list.DeleteAllItems()
             self.verifies_id.ChangeValue("")
-            self.relates_list.Set([])
+            self.relates_list.DeleteAllItems()
             self.relates_id.ChangeValue("")
             self._refresh_links_visibility("derived_from")
             self._refresh_links_visibility("verifies")
@@ -619,19 +654,16 @@ class EditorPanel(ScrolledPanel):
                 ctrl.ChangeValue(str(data.get(name, "")))
             self.attachments = list(data.get("attachments", []))
             self.derived_from = [dict(link) for link in data.get("derived_from", [])]
-            items = [f"{d['source_id']} (r{d['source_revision']})" for d in self.derived_from]
-            self.derived_list.Set(items)
+            self._rebuild_links_list("derived_from")
             self.derived_id.ChangeValue("")
             self._refresh_links_visibility("derived_from")
             links = data.get("links", {})
             self.verifies = [dict(l) for l in links.get("verifies", [])]
-            items = [f"{d['source_id']} (r{d['source_revision']})" for d in self.verifies]
-            self.verifies_list.Set(items)
+            self._rebuild_links_list("verifies")
             self.verifies_id.ChangeValue("")
             self._refresh_links_visibility("verifies")
             self.relates = [dict(l) for l in links.get("relates", [])]
-            items = [f"{d['source_id']} (r{d['source_revision']})" for d in self.relates]
-            self.relates_list.Set(items)
+            self._rebuild_links_list("relates")
             self.relates_id.ChangeValue("")
             self._refresh_links_visibility("relates")
             self.parent = dict(data.get("parent", {})) or None
@@ -680,11 +712,11 @@ class EditorPanel(ScrolledPanel):
             self.mtime = None
             self.original_id = None
             self.derived_from = []
-            self.derived_list.Set([])
+            self.derived_list.DeleteAllItems()
             self.verifies = []
-            self.verifies_list.Set([])
+            self.verifies_list.DeleteAllItems()
             self.relates = []
-            self.relates_list.Set([])
+            self.relates_list.DeleteAllItems()
             self._refresh_links_visibility("derived_from")
             self._refresh_links_visibility("verifies")
             self._refresh_links_visibility("relates")
@@ -868,14 +900,18 @@ class EditorPanel(ScrolledPanel):
             wx.MessageBox(_("ID must be a number"), _("Error"), style=wx.ICON_ERROR)
             return
         revision = 1
+        title = ""
         if self.directory:
             try:
                 req = req_ops.get_requirement(self.directory, src_id)
                 revision = req.revision or 1
-            except Exception:
+                title = req.title or ""
+            except Exception:  # pragma: no cover - lookup errors
                 pass
         links_list.append({"source_id": src_id, "source_revision": revision, "suspect": False})
-        list_ctrl.Append(f"{src_id} (r{revision})")
+        idx = list_ctrl.InsertItem(list_ctrl.GetItemCount(), str(src_id))
+        list_ctrl.SetItem(idx, 1, title)
+        self._autosize_link_columns(list_ctrl)
         id_ctrl.ChangeValue("")
         self._refresh_links_visibility(attr)
 
@@ -888,7 +924,10 @@ class EditorPanel(ScrolledPanel):
         )
         if idx != -1:
             del links_list[idx]
-            list_ctrl.Delete(idx)
+            if hasattr(list_ctrl, "DeleteItem"):
+                list_ctrl.DeleteItem(idx)
+            else:
+                list_ctrl.Delete(idx)
         self._refresh_links_visibility(attr)
 
     def _on_add_link(self, _event: wx.CommandEvent) -> None:

--- a/app/ui/editor_panel.py
+++ b/app/ui/editor_panel.py
@@ -521,6 +521,10 @@ class EditorPanel(ScrolledPanel):
         lst.InsertColumn(1, _("Title"))
         lst.SetColumnWidth(0, wx.LIST_AUTOSIZE_USEHEADER)
         lst.SetColumnWidth(1, wx.LIST_AUTOSIZE_USEHEADER)
+        lst.Bind(
+            wx.EVT_SIZE,
+            lambda evt, lc=lst: (evt.Skip(), self._autosize_link_columns(lc)),
+        )
         sizer.Add(lst, 1, wx.EXPAND | wx.ALL, 5)
         # по умолчанию список и кнопка удаления скрыты
         lst.Hide()
@@ -560,11 +564,18 @@ class EditorPanel(ScrolledPanel):
         box.Layout()
         self.Layout()
         self.FitInside()
+        if visible:
+            self._autosize_link_columns(list_ctrl)
 
     def _autosize_link_columns(self, list_ctrl: wx.ListCtrl) -> None:
         """Adjust column widths for a two-column link list."""
         list_ctrl.SetColumnWidth(0, wx.LIST_AUTOSIZE_USEHEADER)
-        list_ctrl.SetColumnWidth(1, wx.LIST_AUTOSIZE)
+        total = list_ctrl.GetClientSize().width
+        id_width = list_ctrl.GetColumnWidth(0)
+        if total > id_width:
+            list_ctrl.SetColumnWidth(1, total - id_width)
+        else:
+            list_ctrl.SetColumnWidth(1, wx.LIST_AUTOSIZE)
 
     def _rebuild_links_list(self, attr: str) -> None:
         """Repopulate ListCtrl for given link attribute."""
@@ -581,7 +592,6 @@ class EditorPanel(ScrolledPanel):
                     pass
             idx = list_ctrl.InsertItem(list_ctrl.GetItemCount(), str(src_id))
             list_ctrl.SetItem(idx, 1, title)
-        self._autosize_link_columns(list_ctrl)
 
     # basic operations -------------------------------------------------
     def set_directory(self, directory: str | Path | None) -> None:
@@ -911,7 +921,6 @@ class EditorPanel(ScrolledPanel):
         links_list.append({"source_id": src_id, "source_revision": revision, "suspect": False})
         idx = list_ctrl.InsertItem(list_ctrl.GetItemCount(), str(src_id))
         list_ctrl.SetItem(idx, 1, title)
-        self._autosize_link_columns(list_ctrl)
         id_ctrl.ChangeValue("")
         self._refresh_links_visibility(attr)
 

--- a/app/ui/editor_panel.py
+++ b/app/ui/editor_panel.py
@@ -183,8 +183,7 @@ class EditorPanel(ScrolledPanel):
             ),
             "verifies": _(
                 "Links to requirements that this one verifies or tests. "
-                "Use it to show downward traceability towards implementation or validation artifacts. "
-                "Mark suspect links when changes might invalidate verification."
+                "Use it to show downward traceability towards implementation or validation artifacts."
             ),
             "relates": _(
                 "Associations with requirements touching the same topic. "
@@ -193,8 +192,7 @@ class EditorPanel(ScrolledPanel):
             ),
             "derived_from": _(
                 "Source requirements from which this one was derived. "
-                "Capturing derivation clarifies reasoning and lets teams propagate changes upstream. "
-                "Keep suspect flag to signal when the parent requirement has changed."
+                "Capturing derivation clarifies reasoning and lets teams propagate changes upstream."
             ),
         }
 
@@ -509,8 +507,7 @@ class EditorPanel(ScrolledPanel):
         remove_btn.Bind(wx.EVT_BUTTON, lambda _evt, a=attr: self._on_remove_link_generic(a))
         row.Add(remove_btn, 0)
         sizer.Add(row, 0, wx.EXPAND | wx.ALL, 5)
-        lst = wx.CheckListBox(box, choices=[])
-        lst.Bind(wx.EVT_CHECKLISTBOX, lambda _evt, a=attr: self._toggle_links(a))
+        lst = wx.ListBox(box, choices=[])
         sizer.Add(lst, 1, wx.EXPAND | wx.ALL, 5)
         # по умолчанию список и кнопка удаления скрыты
         lst.Hide()
@@ -624,23 +621,17 @@ class EditorPanel(ScrolledPanel):
             self.derived_from = [dict(link) for link in data.get("derived_from", [])]
             items = [f"{d['source_id']} (r{d['source_revision']})" for d in self.derived_from]
             self.derived_list.Set(items)
-            for i, link in enumerate(self.derived_from):
-                self.derived_list.Check(i, link.get("suspect", False))
             self.derived_id.ChangeValue("")
             self._refresh_links_visibility("derived_from")
             links = data.get("links", {})
             self.verifies = [dict(l) for l in links.get("verifies", [])]
             items = [f"{d['source_id']} (r{d['source_revision']})" for d in self.verifies]
             self.verifies_list.Set(items)
-            for i, link in enumerate(self.verifies):
-                self.verifies_list.Check(i, link.get("suspect", False))
             self.verifies_id.ChangeValue("")
             self._refresh_links_visibility("verifies")
             self.relates = [dict(l) for l in links.get("relates", [])]
             items = [f"{d['source_id']} (r{d['source_revision']})" for d in self.relates]
             self.relates_list.Set(items)
-            for i, link in enumerate(self.relates):
-                self.relates_list.Check(i, link.get("suspect", False))
             self.relates_id.ChangeValue("")
             self._refresh_links_visibility("relates")
             self.parent = dict(data.get("parent", {})) or None
@@ -890,22 +881,18 @@ class EditorPanel(ScrolledPanel):
 
     def _on_remove_link_generic(self, attr: str) -> None:
         _, list_ctrl, links_list = self._link_widgets(attr)
-        idx = list_ctrl.GetFirstSelected() if hasattr(list_ctrl, "GetFirstSelected") else getattr(list_ctrl, "GetSelection", lambda: -1)()
+        idx = (
+            list_ctrl.GetFirstSelected()
+            if hasattr(list_ctrl, "GetFirstSelected")
+            else getattr(list_ctrl, "GetSelection", lambda: -1)()
+        )
         if idx != -1:
             del links_list[idx]
             list_ctrl.Delete(idx)
         self._refresh_links_visibility(attr)
 
-    def _toggle_links(self, attr: str) -> None:
-        _, list_ctrl, links_list = self._link_widgets(attr)
-        for i, link in enumerate(links_list):
-            link["suspect"] = list_ctrl.IsChecked(i)
-
     def _on_add_link(self, _event: wx.CommandEvent) -> None:
         self._on_add_link_generic("derived_from")
-
-    def _on_link_toggle(self, _event: wx.CommandEvent) -> None:
-        self._toggle_links("derived_from")
 
     def _on_set_parent(self, _event: wx.CommandEvent) -> None:
         value = self.parent_id.GetValue().strip()

--- a/app/ui/editor_panel.py
+++ b/app/ui/editor_panel.py
@@ -549,6 +549,7 @@ class EditorPanel(ScrolledPanel):
         box = list_ctrl.GetParent()
         box.Layout()
         self.Layout()
+        self.FitInside()
 
     # basic operations -------------------------------------------------
     def set_directory(self, directory: str | Path | None) -> None:
@@ -842,6 +843,7 @@ class EditorPanel(ScrolledPanel):
             btn_sizer.Show(self.remove_attachment_btn, visible)
             btn_sizer.Layout()
         self.Layout()
+        self.FitInside()
 
     def _on_add_attachment(self, _event: wx.CommandEvent) -> None:
         dlg = wx.FileDialog(self, _("Select attachment"), style=wx.FD_OPEN | wx.FD_FILE_MUST_EXIST)
@@ -872,6 +874,7 @@ class EditorPanel(ScrolledPanel):
         try:
             src_id = int(value)
         except ValueError:
+            wx.MessageBox(_("ID must be a number"), _("Error"), style=wx.ICON_ERROR)
             return
         revision = 1
         if self.directory:

--- a/app/ui/editor_panel.py
+++ b/app/ui/editor_panel.py
@@ -25,7 +25,7 @@ from ..core.model import (
 )
 from . import locale
 from .label_selection_dialog import LabelSelectionDialog
-from .helpers import create_help_static_box
+from .helpers import HelpStaticBox
 
 
 class EditorPanel(ScrolledPanel):
@@ -281,9 +281,10 @@ class EditorPanel(ScrolledPanel):
         sizer.Add(grid, 0, wx.EXPAND | wx.ALL, 5)
 
         # attachments section --------------------------------------------
-        a_box, a_sizer = create_help_static_box(
+        a_sizer = HelpStaticBox(
             self, _("Attachments"), self._help_texts["attachments"], self._show_help
         )
+        a_box = a_sizer.GetStaticBox()
         self.attachments_list = wx.ListCtrl(
             a_box, style=wx.LC_REPORT | wx.BORDER_SUNKEN | wx.LC_SINGLE_SEL
         )
@@ -334,9 +335,10 @@ class EditorPanel(ScrolledPanel):
         links_grid.AddGrowableRow(2, 1)
 
         # labels section -------------------------------------------------
-        box, box_sizer = create_help_static_box(
+        box_sizer = HelpStaticBox(
             self, _("Labels"), self._help_texts["labels"], self._show_help
         )
+        box = box_sizer.GetStaticBox()
         row = wx.BoxSizer(wx.HORIZONTAL)
         self.labels_panel = wx.Panel(box)
         self.labels_panel.SetSizer(wx.BoxSizer(wx.HORIZONTAL))
@@ -354,9 +356,10 @@ class EditorPanel(ScrolledPanel):
         self.parent: dict[str, Any] | None = None
 
         # parent section -------------------------------------------------
-        pr_box, pr_sizer = create_help_static_box(
+        pr_sizer = HelpStaticBox(
             self, _("Parent"), self._help_texts["parent"], self._show_help
         )
+        pr_box = pr_sizer.GetStaticBox()
         row = wx.BoxSizer(wx.HORIZONTAL)
         self.parent_id = wx.TextCtrl(pr_box, size=(120, -1))
         row.Add(self.parent_id, 0, wx.RIGHT, 5)
@@ -492,9 +495,10 @@ class EditorPanel(ScrolledPanel):
         id_name: str | None = None,
         list_name: str | None = None,
     ) -> wx.StaticBoxSizer:
-        box, sizer = create_help_static_box(
+        sizer = HelpStaticBox(
             self, label, self._help_texts[help_key], self._show_help
         )
+        box = sizer.GetStaticBox()
         row = wx.BoxSizer(wx.HORIZONTAL)
         id_ctrl = wx.TextCtrl(box)
         row.Add(id_ctrl, 1, wx.EXPAND | wx.RIGHT, 5)

--- a/app/ui/helpers.py
+++ b/app/ui/helpers.py
@@ -32,6 +32,14 @@ class HelpStaticBox(wx.StaticBoxSizer):
         self._btn.Bind(wx.EVT_BUTTON, lambda _evt: on_help(help_text))
         self._has_header = False
 
+    def _wrap_first(self, item: wx.Window | wx.Sizer, flag: int) -> wx.Sizer:
+        """Wrap the first item with the help button row."""
+        self._has_header = True
+        row = wx.BoxSizer(wx.HORIZONTAL)
+        row.Add(item, 1, flag & ~wx.ALL, 0)
+        row.Add(self._btn, 0, wx.LEFT | wx.ALIGN_CENTER_VERTICAL, self._border)
+        return row
+
     def Add(
         self,
         item: wx.Window | wx.Sizer,
@@ -47,9 +55,39 @@ class HelpStaticBox(wx.StaticBoxSizer):
         unchanged.
         """
         if not self._has_header:
-            self._has_header = True
-            row = wx.BoxSizer(wx.HORIZONTAL)
-            row.Add(item, 1, flag & ~wx.ALL, 0)
-            row.Add(self._btn, 0, wx.LEFT | wx.ALIGN_CENTER_VERTICAL, self._border)
+            row = self._wrap_first(item, flag)
             return super().Add(row, proportion, flag, border, userData)
         return super().Add(item, proportion, flag, border, userData)
+
+    def Prepend(
+        self,
+        item: wx.Window | wx.Sizer,
+        proportion: int = 0,
+        flag: int = 0,
+        border: int = 0,
+        userData: object | None = None,
+    ) -> wx.SizerItem:
+        """Prepend an item, keeping the help button on the first row."""
+        if not self._has_header:
+            row = self._wrap_first(item, flag)
+            return super().Prepend(row, proportion, flag, border, userData)
+        return super().Insert(1, item, proportion, flag, border, userData)
+
+    def Insert(
+        self,
+        index: int,
+        item: wx.Window | wx.Sizer,
+        proportion: int = 0,
+        flag: int = 0,
+        border: int = 0,
+        userData: object | None = None,
+    ) -> wx.SizerItem:
+        """Insert an item at the given position.
+
+        Indexing is performed as if the help row did not exist, so callers can
+        treat this sizer like a regular ``StaticBoxSizer``.
+        """
+        if not self._has_header:
+            row = self._wrap_first(item, flag)
+            return super().Insert(index, row, proportion, flag, border, userData)
+        return super().Insert(index + 1, item, proportion, flag, border, userData)

--- a/app/ui/helpers.py
+++ b/app/ui/helpers.py
@@ -6,54 +6,50 @@ from typing import Callable
 import wx
 
 
-def create_help_static_box(
-    parent: wx.Window,
-    label: str,
-    help_text: str,
-    on_help: Callable[[str], None],
-    *,
-    orient: int = wx.VERTICAL,
-    border: int = 5,
-) -> tuple[wx.StaticBox, wx.StaticBoxSizer]:
-    """Create a ``wx.StaticBox`` with a question button that shows a hint.
+class HelpStaticBox(wx.StaticBoxSizer):
+    """A ``wx.StaticBoxSizer`` with a built-in help button.
 
-    The button is anchored in the top‑right corner of the box so it does not
-    consume additional layout space. ``on_help`` is called with ``help_text``
-    when the button is pressed.
-
-    Parameters
-    ----------
-    parent: wx.Window
-        Parent widget for the static box.
-    label: str
-        Title of the static box.
-    help_text: str
-        Message to display when the help button is clicked.
-    on_help: Callable[[str], None]
-        Callback invoked when the help button is pressed; typically shows a
-        dialog with the hint text.
-    orient: int, optional
-        Orientation for ``wx.StaticBoxSizer``; ``wx.VERTICAL`` by default.
-    border: int, optional
-        Distance from the box edge to the help button; default is ``5``.
-
-    Returns
-    -------
-    Tuple[wx.StaticBox, wx.StaticBoxSizer]
-        The created static box and its sizer.
+    The button is appended to the first row inside the static box so it sits on
+    the same line as the first added control. This avoids manual coordinate
+    calculations and relies on sizer layout for positioning.
     """
-    box = wx.StaticBox(parent, label=label)
-    sizer = wx.StaticBoxSizer(box, orient)
-    btn = wx.Button(box, label="?", style=wx.BU_EXACTFIT)
-    btn.Bind(wx.EVT_BUTTON, lambda _evt: on_help(help_text))
 
-    def _reposition(_evt: wx.Event | None = None) -> None:
-        """Place the help button in the box's top-right corner."""
-        w, _ = box.GetClientSize()
-        bw, _ = btn.GetSize()
-        btn.SetPosition((w - bw - border, border))
+    def __init__(
+        self,
+        parent: wx.Window,
+        label: str,
+        help_text: str,
+        on_help: Callable[[str], None],
+        *,
+        orient: int = wx.VERTICAL,
+        border: int = 5,
+    ) -> None:
+        box = wx.StaticBox(parent, label=label)
+        super().__init__(box, orient)
 
-    box.Bind(wx.EVT_SIZE, _reposition)
-    wx.CallAfter(_reposition)
+        self._border = border
+        self._btn = wx.Button(box, label="?", style=wx.BU_EXACTFIT)
+        self._btn.Bind(wx.EVT_BUTTON, lambda _evt: on_help(help_text))
+        self._has_header = False
 
-    return box, sizer
+    def Add(
+        self,
+        item: wx.Window | wx.Sizer,
+        proportion: int = 0,
+        flag: int = 0,
+        border: int = 0,
+        userData: object | None = None,
+    ) -> wx.SizerItem:
+        """Add an item to the sizer.
+
+        The first added item is wrapped into a horizontal row alongside the
+        help button. Subsequent items are forwarded to ``wx.StaticBoxSizer``
+        unchanged.
+        """
+        if not self._has_header:
+            self._has_header = True
+            row = wx.BoxSizer(wx.HORIZONTAL)
+            row.Add(item, 1, flag & ~wx.ALL, 0)
+            row.Add(self._btn, 0, wx.LEFT | wx.ALIGN_CENTER_VERTICAL, self._border)
+            return super().Add(row, proportion, flag, border, userData)
+        return super().Add(item, proportion, flag, border, userData)

--- a/tests/test_editor_panel_gui.py
+++ b/tests/test_editor_panel_gui.py
@@ -160,19 +160,6 @@ def test_editor_save_and_delete_roundtrip(tmp_path, wx_app):
     assert panel.mtime is None
     assert not saved_path.exists()
 
-def test_editor_toggle_derived_link_updates_data(tmp_path, wx_app):
-    panel = _make_panel()
-    data = {
-        "id": 2,
-        "derived_from": [{"source_id": 1, "source_revision": 1, "suspect": False}],
-    }
-    panel.load(data, path=tmp_path / "req.json", mtime=0.0)
-    panel.derived_list.Check(0, True)
-    panel._on_link_toggle(None)
-    result = panel.get_data()
-    assert result.derived_from[0].suspect is True
-
-
 def test_editor_loads_links(tmp_path, wx_app):
     panel = _make_panel()
     data = {

--- a/tests/test_help_static_box.py
+++ b/tests/test_help_static_box.py
@@ -1,0 +1,36 @@
+import wx
+
+from app.ui.helpers import HelpStaticBox
+
+
+def _noop(msg: str) -> None:  # pragma: no cover - placeholder callback
+    pass
+
+
+def test_help_static_box_handles_prepend_and_insert(wx_app):
+    frame = wx.Frame(None)
+    panel = wx.Panel(frame)
+    sizer = HelpStaticBox(panel, "lbl", "help", _noop)
+
+    first = wx.TextCtrl(panel)
+    sizer.Prepend(first)
+    assert sizer.GetItemCount() == 1
+    row = sizer.GetItem(0).GetSizer()
+    assert row.GetItem(0).GetWindow() is first
+    assert isinstance(row.GetItem(1).GetWindow(), wx.Button)
+
+    second = wx.TextCtrl(panel)
+    sizer.Prepend(second)
+    assert sizer.GetItemCount() == 2
+    assert sizer.GetItem(1).GetWindow() is second
+
+    third = wx.TextCtrl(panel)
+    sizer.Insert(0, third)
+    assert sizer.GetItem(1).GetWindow() is third
+
+    fourth = wx.TextCtrl(panel)
+    sizer.Insert(1, fourth)
+    assert sizer.GetItem(2).GetWindow() is fourth
+    assert sizer.GetItem(3).GetWindow() is second
+    assert sizer.GetItemCount() == 4
+    frame.Destroy()

--- a/tests/test_link_column_width.py
+++ b/tests/test_link_column_width.py
@@ -1,0 +1,39 @@
+import wx
+from app.ui.editor_panel import EditorPanel
+from app.core.model import Requirement, RequirementType, Status, Priority, Verification
+from app.core import requirements as req_ops
+
+
+def test_title_column_expands_to_available_width(wx_app, monkeypatch):
+    frame = wx.Frame(None)
+    panel = EditorPanel(frame)
+    panel.set_directory('dummy')
+
+    req = Requirement(
+        id=1,
+        title="T",
+        statement="",
+        type=RequirementType.REQUIREMENT,
+        status=Status.DRAFT,
+        owner="",
+        priority=Priority.MEDIUM,
+        source="",
+        verification=Verification.ANALYSIS,
+    )
+    monkeypatch.setattr(req_ops, 'get_requirement', lambda d, i: req)
+
+    frame.SetClientSize((400, 300))
+    frame.Show()
+    wx.GetApp().Yield()
+
+    panel.derived_id.SetValue('1')
+    panel._on_add_link_generic('derived_from')
+
+    panel.derived_list.SendSizeEvent()
+    wx.GetApp().Yield()
+
+    total = panel.derived_list.GetClientSize().width
+    id_width = panel.derived_list.GetColumnWidth(0)
+    title_width = panel.derived_list.GetColumnWidth(1)
+    assert title_width >= total - id_width - 2
+    frame.Destroy()

--- a/tests/test_link_titles.py
+++ b/tests/test_link_titles.py
@@ -1,0 +1,30 @@
+import wx
+from app.ui.editor_panel import EditorPanel
+from app.core.model import Requirement, RequirementType, Status, Priority, Verification
+from app.core import requirements as req_ops
+
+
+def test_added_link_shows_id_and_title(wx_app, monkeypatch):
+    frame = wx.Frame(None)
+    panel = EditorPanel(frame)
+    panel.set_directory('dummy')
+
+    req = Requirement(
+        id=123,
+        title="Sample",
+        statement="",
+        type=RequirementType.REQUIREMENT,
+        status=Status.DRAFT,
+        owner="",
+        priority=Priority.MEDIUM,
+        source="",
+        verification=Verification.ANALYSIS,
+    )
+    monkeypatch.setattr(req_ops, 'get_requirement', lambda d, i: req)
+
+    panel.derived_id.SetValue('123')
+    panel._on_add_link_generic('derived_from')
+
+    assert panel.derived_list.GetItemText(0, 0) == '123'
+    assert panel.derived_list.GetItemText(0, 1) == 'Sample'
+    frame.Destroy()

--- a/tests/test_links_visibility.py
+++ b/tests/test_links_visibility.py
@@ -1,0 +1,21 @@
+import wx
+from app.ui.editor_panel import EditorPanel
+
+
+def test_links_list_becomes_visible(wx_app, monkeypatch):
+    frame = wx.Frame(None)
+    panel = EditorPanel(frame)
+    assert not panel.derived_list.IsShown()
+
+    called = {}
+
+    def fake_fitinside():
+        called['called'] = True
+
+    monkeypatch.setattr(panel, "FitInside", fake_fitinside)
+    panel.derived_id.SetValue('123')
+    panel._on_add_link_generic('derived_from')
+
+    assert panel.derived_list.IsShown()
+    assert called.get('called')
+    frame.Destroy()


### PR DESCRIPTION
## Summary
- Replace helper function with `HelpStaticBox` class that injects a question button into the first row
- Update editor panel to use `HelpStaticBox` instead of manual positioning

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c65807ce8483209037ac579b4c2a25