### PR TITLE
Add help popups for settings fields

### DIFF
--- a/app/ui/editor_panel.py
+++ b/app/ui/editor_panel.py
@@ -25,7 +25,7 @@ from ..core.model import (
 )
 from . import locale
 from .label_selection_dialog import LabelSelectionDialog
-from .helpers import HelpStaticBox
+from .helpers import HelpStaticBox, make_help_button, show_help
 
 
 class EditorPanel(ScrolledPanel):
@@ -211,7 +211,7 @@ class EditorPanel(ScrolledPanel):
             ("source", True),
         ]:
             label = wx.StaticText(self, label=labels[name])
-            help_btn = self._make_help_button(self._help_texts[name])
+            help_btn = make_help_button(self, self._help_texts[name])
             row = wx.BoxSizer(wx.HORIZONTAL)
             row.Add(label, 0, wx.ALIGN_CENTER_VERTICAL)
             row.Add(help_btn, 0, wx.ALIGN_CENTER_VERTICAL | wx.LEFT, 5)
@@ -232,7 +232,7 @@ class EditorPanel(ScrolledPanel):
         def add_text_field(name: str) -> None:
             container = wx.BoxSizer(wx.VERTICAL)
             label = wx.StaticText(self, label=labels[name])
-            help_btn = self._make_help_button(self._help_texts[name])
+            help_btn = make_help_button(self, self._help_texts[name])
             row = wx.BoxSizer(wx.HORIZONTAL)
             row.Add(label, 0, wx.ALIGN_CENTER_VERTICAL)
             row.Add(help_btn, 0, wx.ALIGN_CENTER_VERTICAL | wx.LEFT, 5)
@@ -248,7 +248,7 @@ class EditorPanel(ScrolledPanel):
             codes = getattr(locale, name.upper()).keys()
             choices = [locale.code_to_label(name, code) for code in codes]
             choice = wx.Choice(self, choices=choices)
-            help_btn = self._make_help_button(self._help_texts[name])
+            help_btn = make_help_button(self, self._help_texts[name])
             row = wx.BoxSizer(wx.HORIZONTAL)
             row.Add(label, 0, wx.ALIGN_CENTER_VERTICAL)
             row.Add(choice, 1, wx.ALIGN_CENTER_VERTICAL | wx.LEFT, 5)
@@ -280,7 +280,7 @@ class EditorPanel(ScrolledPanel):
 
         # attachments section --------------------------------------------
         a_sizer = HelpStaticBox(
-            self, _("Attachments"), self._help_texts["attachments"], self._show_help
+            self, _("Attachments"), self._help_texts["attachments"], lambda msg: show_help(self, msg)
         )
         a_box = a_sizer.GetStaticBox()
         self.attachments_list = wx.ListCtrl(
@@ -303,7 +303,7 @@ class EditorPanel(ScrolledPanel):
         container = wx.BoxSizer(wx.VERTICAL)
         row = wx.BoxSizer(wx.HORIZONTAL)
         label = wx.StaticText(self, label=_("Approved at"))
-        help_btn = self._make_help_button(self._help_texts["approved_at"])
+        help_btn = make_help_button(self, self._help_texts["approved_at"])
         row.Add(label, 0, wx.ALIGN_CENTER_VERTICAL)
         row.Add(help_btn, 0, wx.ALIGN_CENTER_VERTICAL | wx.LEFT, 5)
         container.Add(row, 0, wx.ALL, 5)
@@ -316,7 +316,7 @@ class EditorPanel(ScrolledPanel):
         container = wx.BoxSizer(wx.VERTICAL)
         row = wx.BoxSizer(wx.HORIZONTAL)
         label = wx.StaticText(self, label=_("Notes"))
-        help_btn = self._make_help_button(self._help_texts["notes"])
+        help_btn = make_help_button(self, self._help_texts["notes"])
         row.Add(label, 0, wx.ALIGN_CENTER_VERTICAL)
         row.Add(help_btn, 0, wx.ALIGN_CENTER_VERTICAL | wx.LEFT, 5)
         container.Add(row, 0, wx.ALL, 5)
@@ -334,7 +334,7 @@ class EditorPanel(ScrolledPanel):
 
         # labels section -------------------------------------------------
         box_sizer = HelpStaticBox(
-            self, _("Labels"), self._help_texts["labels"], self._show_help
+            self, _("Labels"), self._help_texts["labels"], lambda msg: show_help(self, msg)
         )
         box = box_sizer.GetStaticBox()
         row = wx.BoxSizer(wx.HORIZONTAL)
@@ -355,7 +355,7 @@ class EditorPanel(ScrolledPanel):
 
         # parent section -------------------------------------------------
         pr_sizer = HelpStaticBox(
-            self, _("Parent"), self._help_texts["parent"], self._show_help
+            self, _("Parent"), self._help_texts["parent"], lambda msg: show_help(self, msg)
         )
         pr_box = pr_sizer.GetStaticBox()
         row = wx.BoxSizer(wx.HORIZONTAL)
@@ -411,7 +411,7 @@ class EditorPanel(ScrolledPanel):
             ("assumptions", True),
         ]:
             label = wx.StaticText(deriv_box, label=labels[name])
-            help_btn = self._make_help_button(self._help_texts[name])
+            help_btn = make_help_button(self, self._help_texts[name])
             row = wx.BoxSizer(wx.HORIZONTAL)
             row.Add(label, 0, wx.ALIGN_CENTER_VERTICAL)
             row.Add(help_btn, 0, wx.ALIGN_CENTER_VERTICAL | wx.LEFT, 5)
@@ -502,7 +502,7 @@ class EditorPanel(ScrolledPanel):
         list_name: str | None = None,
     ) -> wx.StaticBoxSizer:
         sizer = HelpStaticBox(
-            self, label, self._help_texts[help_key], self._show_help
+            self, label, self._help_texts[help_key], lambda msg: show_help(self, msg)
         )
         box = sizer.GetStaticBox()
         row = wx.BoxSizer(wx.HORIZONTAL)
@@ -1052,23 +1052,3 @@ class EditorPanel(ScrolledPanel):
             idx = self.attachments_list.InsertItem(self.attachments_list.GetItemCount(), path)
             self.attachments_list.SetItem(idx, 1, note)
 
-    # helpers ----------------------------------------------------------
-    def _make_help_button(self, message: str, parent: wx.Window | None = None) -> wx.Button:
-        btn = wx.Button(parent or self, label="?", style=wx.BU_EXACTFIT)
-        btn.Bind(wx.EVT_BUTTON, lambda _evt, msg=message: self._show_help(msg))
-        return btn
-
-    def _show_help(self, message: str) -> None:
-        dlg = wx.Dialog(self, title=_("Hint"), style=wx.DEFAULT_DIALOG_STYLE | wx.RESIZE_BORDER)
-        text = wx.TextCtrl(
-            dlg,
-            value=message,
-            style=wx.TE_MULTILINE | wx.TE_READONLY | wx.BORDER_NONE,
-        )
-        sizer = wx.BoxSizer(wx.VERTICAL)
-        sizer.Add(text, 1, wx.EXPAND | wx.ALL, 10)
-        dlg.SetSizerAndFit(sizer)
-        dlg.SetSize((500, 300))
-        wx.CallAfter(dlg.SetFocus)
-        dlg.ShowModal()
-        dlg.Destroy()

--- a/app/ui/filter_dialog.py
+++ b/app/ui/filter_dialog.py
@@ -91,16 +91,16 @@ class FilterDialog(wx.Dialog):
         self.suspect_only.SetValue(values.get("suspect_only", False))
         sizer.Add(self.suspect_only, 0, wx.ALL, 5)
 
-        btns = wx.StdDialogButtonSizer()
-        self.reset_btn = wx.Button(self, wx.ID_RESET, label=_("Reset"))
+        btns = wx.BoxSizer(wx.HORIZONTAL)
+        btns.AddStretchSpacer()
+        self.clear_btn = wx.Button(self, label=_("Clear filters"))
         ok_btn = wx.Button(self, wx.ID_OK)
         cancel_btn = wx.Button(self, wx.ID_CANCEL)
-        btns.AddButton(self.reset_btn)
-        btns.AddButton(ok_btn)
-        btns.AddButton(cancel_btn)
-        btns.Realize()
-        sizer.Add(btns, 0, wx.ALIGN_RIGHT | wx.ALL, 5)
-        self.reset_btn.Bind(wx.EVT_BUTTON, self._on_reset)
+        btns.Add(self.clear_btn, 0, wx.RIGHT, 5)
+        btns.Add(ok_btn, 0, wx.RIGHT, 5)
+        btns.Add(cancel_btn, 0)
+        sizer.Add(btns, 0, wx.EXPAND | wx.ALL, 5)
+        self.clear_btn.Bind(wx.EVT_BUTTON, self._on_clear)
         self.SetSizerAndFit(sizer)
 
     def get_filters(self) -> Dict:
@@ -119,7 +119,7 @@ class FilterDialog(wx.Dialog):
             "field_queries": field_queries,
         }
 
-    def _on_reset(self, _event: wx.Event) -> None:  # pragma: no cover - simple GUI action
+    def _on_clear(self, _event: wx.Event) -> None:
         """Clear all controls to default state."""
         self.any_query.SetValue("")
         for ctrl in self.field_controls.values():

--- a/app/ui/helpers.py
+++ b/app/ui/helpers.py
@@ -5,6 +5,8 @@ from typing import Callable
 
 import wx
 
+from ..i18n import _
+
 
 class HelpStaticBox(wx.StaticBoxSizer):
     """A ``wx.StaticBoxSizer`` with a built-in help button.
@@ -91,3 +93,36 @@ class HelpStaticBox(wx.StaticBoxSizer):
             row = self._wrap_first(item, flag)
             return super().Insert(index, row, proportion, flag, border, userData)
         return super().Insert(index + 1, item, proportion, flag, border, userData)
+
+
+def show_help(parent: wx.Window, message: str, *, title: str | None = None) -> None:
+    """Display a modal dialog with ``message``.
+
+    Parameters
+    ----------
+    parent:
+        Parent window for the dialog.
+    message:
+        Help text to show.
+    title:
+        Optional dialog title; defaults to ``"Hint"``.
+    """
+
+    dlg = wx.Dialog(parent, title=title or _("Hint"), style=wx.DEFAULT_DIALOG_STYLE | wx.RESIZE_BORDER)
+    text = wx.TextCtrl(dlg, value=message, style=wx.TE_MULTILINE | wx.TE_READONLY)
+    sizer = wx.BoxSizer(wx.VERTICAL)
+    sizer.Add(text, 1, wx.ALL | wx.EXPAND, 10)
+    btns = dlg.CreateStdDialogButtonSizer(wx.OK)
+    if btns:
+        sizer.Add(btns, 0, wx.ALL | wx.ALIGN_CENTER, 5)
+    dlg.SetSizerAndFit(sizer)
+    dlg.ShowModal()
+    dlg.Destroy()
+
+
+def make_help_button(parent: wx.Window, message: str) -> wx.Button:
+    """Return a small question-mark button displaying ``message`` when clicked."""
+
+    btn = wx.Button(parent, label="?", style=wx.BU_EXACTFIT)
+    btn.Bind(wx.EVT_BUTTON, lambda _evt: show_help(parent, message))
+    return btn

--- a/app/ui/list_panel.py
+++ b/app/ui/list_panel.py
@@ -408,7 +408,7 @@ class ListPanel(wx.Panel, ColumnSorterMixin):
         self.list.DeleteAllItems()
         for req in items:
             title = getattr(req, "title", "")
-            index = self.list.InsertStringItem(self.list.GetItemCount(), title)
+            index = self.list.InsertItem(self.list.GetItemCount(), title)
             req_id = getattr(req, "id", 0)
             try:
                 self.list.SetItemData(index, int(req_id))

--- a/app/ui/settings_dialog.py
+++ b/app/ui/settings_dialog.py
@@ -5,10 +5,52 @@ from importlib import resources
 
 import wx
 
+from .helpers import make_help_button
 from ..llm.client import LLMClient
 from ..mcp.client import MCPClient
 from ..mcp.controller import MCPController, MCPStatus
 from ..settings import LLMSettings, MCPSettings
+
+LLM_HELP: dict[str, str] = {
+    "api_base": _(
+        "Базовый URL LLM API. Пример: https://api.openai.com/v1\n"
+        "Обязательное поле; определяет, куда отправляются запросы."
+    ),
+    "model": _(
+        "Имя модели LLM. Пример: gpt-4-turbo\n"
+        "Обязательное поле, определяет используемую модель."
+    ),
+    "api_key": _(
+        "Ключ доступа к LLM. Пример: sk-XXXX\n"
+        "Обязателен, если сервис требует авторизации."
+    ),
+    "timeout": _(
+        "Тайм-аут HTTP-запроса в секундах. Пример: 30\n"
+        "Необязательное поле; по умолчанию 60."
+    ),
+}
+
+MCP_HELP: dict[str, str] = {
+    "host": _(
+        "Адрес хоста MCP-сервера. Пример: 127.0.0.1\n"
+        "Обязательное поле; определяет, где запускать сервер."
+    ),
+    "port": _(
+        "Порт MCP-сервера. Пример: 8123\n"
+        "Обязательное поле."
+    ),
+    "base_path": _(
+        "Базовая папка с требованиями. Пример: /tmp/reqs\n"
+        "Обязательное поле; сервер обслуживает файлы из этой директории."
+    ),
+    "require_token": _(
+        "Если включено, сервер требует токен аутентификации."
+    ),
+    "token": _(
+        "Токен доступа для MCP. Пример: secret123\n"
+        "Обязателен, если включено 'Require token'."
+    ),
+}
 
 
 def available_translations() -> list[tuple[str, str]]:
@@ -91,18 +133,22 @@ class SettingsDialog(wx.Dialog):
         base_sz = wx.BoxSizer(wx.HORIZONTAL)
         base_sz.Add(wx.StaticText(llm, label=_("API base")), 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, 5)
         base_sz.Add(self._api_base, 1, wx.ALIGN_CENTER_VERTICAL)
+        base_sz.Add(make_help_button(llm, LLM_HELP["api_base"]), 0, wx.ALIGN_CENTER_VERTICAL | wx.LEFT, 5)
         llm_sizer.Add(base_sz, 0, wx.ALL | wx.EXPAND, 5)
         model_sz = wx.BoxSizer(wx.HORIZONTAL)
         model_sz.Add(wx.StaticText(llm, label=_("Model")), 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, 5)
         model_sz.Add(self._model, 1, wx.ALIGN_CENTER_VERTICAL)
+        model_sz.Add(make_help_button(llm, LLM_HELP["model"]), 0, wx.ALIGN_CENTER_VERTICAL | wx.LEFT, 5)
         llm_sizer.Add(model_sz, 0, wx.ALL | wx.EXPAND, 5)
         key_sz = wx.BoxSizer(wx.HORIZONTAL)
         key_sz.Add(wx.StaticText(llm, label=_("API key")), 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, 5)
         key_sz.Add(self._api_key, 1, wx.ALIGN_CENTER_VERTICAL)
+        key_sz.Add(make_help_button(llm, LLM_HELP["api_key"]), 0, wx.ALIGN_CENTER_VERTICAL | wx.LEFT, 5)
         llm_sizer.Add(key_sz, 0, wx.ALL | wx.EXPAND, 5)
         timeout_sz = wx.BoxSizer(wx.HORIZONTAL)
         timeout_sz.Add(wx.StaticText(llm, label=_("Timeout")), 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, 5)
         timeout_sz.Add(self._timeout, 1, wx.ALIGN_CENTER_VERTICAL)
+        timeout_sz.Add(make_help_button(llm, LLM_HELP["timeout"]), 0, wx.ALIGN_CENTER_VERTICAL | wx.LEFT, 5)
         llm_sizer.Add(timeout_sz, 0, wx.ALL | wx.EXPAND, 5)
         btn_sz = wx.BoxSizer(wx.HORIZONTAL)
         llm_btn_sz = wx.BoxSizer(wx.VERTICAL)
@@ -148,19 +194,26 @@ class SettingsDialog(wx.Dialog):
         host_sz = wx.BoxSizer(wx.HORIZONTAL)
         host_sz.Add(wx.StaticText(mcp, label=_("Host")), 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, 5)
         host_sz.Add(self._host, 1, wx.ALIGN_CENTER_VERTICAL)
+        host_sz.Add(make_help_button(mcp, MCP_HELP["host"]), 0, wx.ALIGN_CENTER_VERTICAL | wx.LEFT, 5)
         mcp_sizer.Add(host_sz, 0, wx.ALL | wx.EXPAND, 5)
         port_sz = wx.BoxSizer(wx.HORIZONTAL)
         port_sz.Add(wx.StaticText(mcp, label=_("Port")), 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, 5)
         port_sz.Add(self._port, 1, wx.ALIGN_CENTER_VERTICAL)
+        port_sz.Add(make_help_button(mcp, MCP_HELP["port"]), 0, wx.ALIGN_CENTER_VERTICAL | wx.LEFT, 5)
         mcp_sizer.Add(port_sz, 0, wx.ALL | wx.EXPAND, 5)
         base_sz = wx.BoxSizer(wx.HORIZONTAL)
         base_sz.Add(wx.StaticText(mcp, label=_("Path")), 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, 5)
         base_sz.Add(self._base_path, 1, wx.ALIGN_CENTER_VERTICAL)
+        base_sz.Add(make_help_button(mcp, MCP_HELP["base_path"]), 0, wx.ALIGN_CENTER_VERTICAL | wx.LEFT, 5)
         mcp_sizer.Add(base_sz, 0, wx.ALL | wx.EXPAND, 5)
-        mcp_sizer.Add(self._require_token, 0, wx.ALL, 5)
+        token_toggle_sz = wx.BoxSizer(wx.HORIZONTAL)
+        token_toggle_sz.Add(self._require_token, 0, wx.ALIGN_CENTER_VERTICAL)
+        token_toggle_sz.Add(make_help_button(mcp, MCP_HELP["require_token"]), 0, wx.ALIGN_CENTER_VERTICAL | wx.LEFT, 5)
+        mcp_sizer.Add(token_toggle_sz, 0, wx.ALL, 5)
         token_sz = wx.BoxSizer(wx.HORIZONTAL)
         token_sz.Add(wx.StaticText(mcp, label=_("Token")), 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, 5)
         token_sz.Add(self._token, 1, wx.ALIGN_CENTER_VERTICAL)
+        token_sz.Add(make_help_button(mcp, MCP_HELP["token"]), 0, wx.ALIGN_CENTER_VERTICAL | wx.LEFT, 5)
         mcp_sizer.Add(token_sz, 0, wx.ALL | wx.EXPAND, 5)
         btn_sz = wx.BoxSizer(wx.HORIZONTAL)
         btn_sz.Add(self._start, 0, wx.RIGHT, 5)

--- a/tests/test_filter_dialog.py
+++ b/tests/test_filter_dialog.py
@@ -1,0 +1,33 @@
+from app.core.labels import Label
+from app.ui.filter_dialog import FilterDialog
+
+
+def _make_dialog(wx_app):
+    labels = [Label("foo", "#000000"), Label("bar", "#ffffff")]
+    values = {
+        "query": "search",
+        "field_queries": {"title": "abc"},
+        "labels": ["foo", "bar"],
+        "match_any": True,
+        "status": "draft",
+        "is_derived": True,
+        "has_derived": True,
+        "suspect_only": True,
+    }
+    return FilterDialog(None, labels=labels, values=values)
+
+
+def test_clear_button_resets_all_filters(wx_app):
+    dlg = _make_dialog(wx_app)
+    dlg._on_clear(None)
+    assert dlg.get_filters() == {
+        "query": "",
+        "labels": [],
+        "match_any": False,
+        "status": None,
+        "is_derived": False,
+        "has_derived": False,
+        "suspect_only": False,
+        "field_queries": {},
+    }
+    dlg.Destroy()

--- a/tests/test_list_panel.py
+++ b/tests/test_list_panel.py
@@ -137,10 +137,11 @@ def _build_wx_stub():
             return len(self._items)
         def GetColumnCount(self):
             return len(self._cols)
-        def InsertStringItem(self, index, text):
+        def InsertItem(self, index, text):
             self._items.insert(index, text)
             self._data.insert(index, 0)
             return index
+        InsertStringItem = InsertItem
         def SetItem(self, index, col, text):
             pass
         SetStringItem = SetItem

--- a/tests/test_settings_dialog.py
+++ b/tests/test_settings_dialog.py
@@ -230,3 +230,46 @@ def test_llm_agent_checks(monkeypatch, wx_app):
     assert dlg._tools_status.GetLabel() == sd._("ok")
 
     dlg.Destroy()
+
+
+def test_settings_help_buttons(monkeypatch, wx_app):
+    wx = pytest.importorskip("wx")
+    from app.ui.settings_dialog import SettingsDialog, LLM_HELP, MCP_HELP
+    from app.ui import helpers
+
+    shown: list[str] = []
+    monkeypatch.setattr(helpers, "show_help", lambda parent, msg: shown.append(msg))
+
+    dlg = SettingsDialog(
+        None,
+        open_last=False,
+        remember_sort=False,
+        language="en",
+        api_base="",
+        model="",
+        api_key="",
+        timeout=10,
+        host="localhost",
+        port=8000,
+        base_path="/tmp",
+        require_token=False,
+        token="",
+    )
+
+    base_btn = next(
+        item.GetWindow()
+        for item in dlg._api_base.GetContainingSizer().GetChildren()
+        if isinstance(item.GetWindow(), wx.Button)
+    )
+    base_btn.GetEventHandler().ProcessEvent(wx.CommandEvent(wx.EVT_BUTTON.typeId))
+    assert shown[-1] == LLM_HELP["api_base"]
+
+    host_btn = next(
+        item.GetWindow()
+        for item in dlg._host.GetContainingSizer().GetChildren()
+        if isinstance(item.GetWindow(), wx.Button)
+    )
+    host_btn.GetEventHandler().ProcessEvent(wx.CommandEvent(wx.EVT_BUTTON.typeId))
+    assert shown[-1] == MCP_HELP["host"]
+
+    dlg.Destroy()


### PR DESCRIPTION
## Summary
- Factor out reusable `show_help` and `make_help_button` helpers
- Attach question-mark help buttons to LLM and MCP settings fields with detailed descriptions
- Cover help button behaviour in tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c659b3bf74832092b0d79065a24c9a