### PR TITLE
fix: resolve merge conflicts

### DIFF
--- a/app/ui/list_panel.py
+++ b/app/ui/list_panel.py
@@ -403,7 +403,6 @@ class ListPanel(wx.Panel, ColumnSorterMixin):
         self.list.DeleteAllItems()
         for req in items:
             title = getattr(req, "title", "")
-<<< codex/fix-labels-display-in-requirements-list-grgjfv
             index = self.list.InsertItem(self.list.GetItemCount(), title, -1)
             # Windows ListCtrl may still assign image 0; clear explicitly
             if hasattr(self.list, "SetItemImage"):
@@ -411,9 +410,6 @@ class ListPanel(wx.Panel, ColumnSorterMixin):
                     self.list.SetItemImage(index, -1)
                 except Exception:
                     pass
-=====
-            index = self.list.InsertItem(self.list.GetItemCount(), title)
->>>>> main
             req_id = getattr(req, "id", 0)
             try:
                 self.list.SetItemData(index, int(req_id))

--- a/tests/test_list_panel.py
+++ b/tests/test_list_panel.py
@@ -194,25 +194,16 @@ def _build_wx_stub():
             return len(self._items)
         def GetColumnCount(self):
             return len(self._cols)
-<<<<< codex/fix-labels-display-in-requirements-list-grgjfv
         def InsertItem(self, index, text, image=-1):
-====
-        def InsertItem(self, index, text):
->>>>> main
             self._items.insert(index, text)
             self._data.insert(index, 0)
             self._item_images.insert(index, image)
             return index
         InsertStringItem = InsertItem
-<<<<< codex/fix-labels-display-in-requirements-list-grgjfv
         def SetItem(self, index, col, text, image=-1):
             if col == 0:
                 self._items[index] = text
             self._cells[(index, col)] = text
-=====
-        def SetItem(self, index, col, text):
-            pass
->>>>> main
         SetStringItem = SetItem
         def SetItemData(self, index, data):
             self._data[index] = data


### PR DESCRIPTION
## Summary
- remove leftover conflict markers from ListPanel refresh routine
- adjust mock ListCtrl in tests to align with image-aware insertion API

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c67c57283c8320ae683425873f5578