### PR TITLE
Add pytest markers for test categorization

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -4,4 +4,8 @@ xvfb_height = 800
 xvfb_colordepth = 24
 addopts = -q
 markers =
+    unit: unit tests
+    integration: integration tests (MCP/LLM/CLI)
+    gui: tests requiring wx
+    slow: long-running tests
     real_llm: tests that call a real OpenRouter endpoint

--- a/tests/gui/test_app_icon.py
+++ b/tests/gui/test_app_icon.py
@@ -4,6 +4,8 @@ import pytest
 
 from app.ui.main_frame import MainFrame
 
+pytestmark = pytest.mark.gui
+
 
 def test_main_frame_loads_multiple_icon_sizes(wx_app):
     """Main frame should expose all icon sizes for taskbar usage."""

--- a/tests/gui/test_command_dialog.py
+++ b/tests/gui/test_command_dialog.py
@@ -5,6 +5,8 @@ import pytest
 
 from app.agent.local_agent import LocalAgent
 
+pytestmark = [pytest.mark.gui, pytest.mark.integration]
+
 
 def test_command_dialog_shows_result_and_saves_history(tmp_path, wx_app):
     wx = pytest.importorskip("wx")

--- a/tests/gui/test_confirm.py
+++ b/tests/gui/test_confirm.py
@@ -5,6 +5,8 @@ import pytest
 from app import confirm as confirm_mod
 from app.confirm import set_confirm, auto_confirm, wx_confirm
 
+pytestmark = pytest.mark.gui
+
 
 def test_confirm_without_callback_raises(monkeypatch):
     monkeypatch.setattr(confirm_mod, "_callback", None, raising=False)

--- a/tests/gui/test_editor_panel.py
+++ b/tests/gui/test_editor_panel.py
@@ -7,6 +7,8 @@ from app.i18n import _
 from app.core.model import RequirementType, Status, Priority, Verification
 from app.core.labels import Label
 
+pytestmark = pytest.mark.gui
+
 
 def _make_panel():
     wx = pytest.importorskip("wx")

--- a/tests/gui/test_editor_panel_gui.py
+++ b/tests/gui/test_editor_panel_gui.py
@@ -6,6 +6,8 @@ from dataclasses import asdict
 from app.core.model import RequirementType, Status, Priority, Verification
 from app.core.labels import Label
 
+pytestmark = pytest.mark.gui
+
 
 def _make_panel():
     wx = pytest.importorskip("wx")

--- a/tests/gui/test_filter_dialog.py
+++ b/tests/gui/test_filter_dialog.py
@@ -1,5 +1,8 @@
 from app.core.labels import Label
 from app.ui.filter_dialog import FilterDialog
+import pytest
+
+pytestmark = pytest.mark.gui
 
 
 def _make_dialog(wx_app):

--- a/tests/gui/test_gui.py
+++ b/tests/gui/test_gui.py
@@ -2,6 +2,8 @@
 
 import pytest
 
+pytestmark = pytest.mark.gui
+
 
 def test_gui_imports(wx_app):
     wx = pytest.importorskip("wx")

--- a/tests/gui/test_help_static_box.py
+++ b/tests/gui/test_help_static_box.py
@@ -1,6 +1,9 @@
 import wx
 
 from app.ui.helpers import HelpStaticBox
+import pytest
+
+pytestmark = pytest.mark.gui
 
 
 def _noop(msg: str) -> None:  # pragma: no cover - placeholder callback

--- a/tests/gui/test_labels_dialog.py
+++ b/tests/gui/test_labels_dialog.py
@@ -7,6 +7,8 @@ import pytest
 
 from app.core.labels import Label
 
+pytestmark = pytest.mark.gui
+
 
 def test_labels_dialog_changes_color(wx_app):
     wx = pytest.importorskip("wx")

--- a/tests/gui/test_labels_sync.py
+++ b/tests/gui/test_labels_sync.py
@@ -4,6 +4,8 @@ import pytest
 from app.core import store, label_store
 from app.core.labels import PRESET_SETS
 
+pytestmark = pytest.mark.gui
+
 
 def _create_requirement(directory):
     data = {

--- a/tests/gui/test_language_switch.py
+++ b/tests/gui/test_language_switch.py
@@ -4,6 +4,8 @@ import importlib
 
 import pytest
 
+pytestmark = pytest.mark.gui
+
 
 def test_switch_to_russian_updates_ui(monkeypatch, wx_app):
     wx = pytest.importorskip("wx")

--- a/tests/gui/test_link_column_width.py
+++ b/tests/gui/test_link_column_width.py
@@ -2,6 +2,9 @@ import wx
 from app.ui.editor_panel import EditorPanel
 from app.core.model import Requirement, RequirementType, Status, Priority, Verification
 from app.core import requirements as req_ops
+import pytest
+
+pytestmark = pytest.mark.gui
 
 
 def test_title_column_expands_to_available_width(wx_app, monkeypatch):

--- a/tests/gui/test_link_titles.py
+++ b/tests/gui/test_link_titles.py
@@ -2,6 +2,9 @@ import wx
 from app.ui.editor_panel import EditorPanel
 from app.core.model import Requirement, RequirementType, Status, Priority, Verification
 from app.core import requirements as req_ops
+import pytest
+
+pytestmark = pytest.mark.gui
 
 
 def test_added_link_shows_id_and_title(wx_app, monkeypatch):

--- a/tests/gui/test_links_visibility.py
+++ b/tests/gui/test_links_visibility.py
@@ -1,5 +1,8 @@
 import wx
 from app.ui.editor_panel import EditorPanel
+import pytest
+
+pytestmark = pytest.mark.gui
 
 
 def test_links_list_becomes_visible(wx_app, monkeypatch):

--- a/tests/gui/test_list_panel.py
+++ b/tests/gui/test_list_panel.py
@@ -6,6 +6,9 @@ import importlib
 
 from app.core.model import Requirement, RequirementType, Status, Priority, Verification
 from app.core.labels import Label
+import pytest
+
+pytestmark = pytest.mark.gui
 
 
 def _build_wx_stub():

--- a/tests/gui/test_list_panel_gui.py
+++ b/tests/gui/test_list_panel_gui.py
@@ -11,6 +11,8 @@ from app.core.model import (
     DerivationLink,
 )
 
+pytestmark = pytest.mark.gui
+
 
 def _req(id: int, title: str, **kwargs) -> Requirement:
     base = dict(

--- a/tests/gui/test_main.py
+++ b/tests/gui/test_main.py
@@ -3,6 +3,9 @@
 import sys
 import types
 import importlib
+import pytest
+
+pytestmark = pytest.mark.gui
 
 
 def test_main_runs(monkeypatch):

--- a/tests/gui/test_main_frame_gui.py
+++ b/tests/gui/test_main_frame_gui.py
@@ -4,6 +4,8 @@ import importlib
 import pytest
 import logging
 
+pytestmark = pytest.mark.gui
+
 
 def test_main_frame_open_folder(monkeypatch, tmp_path, wx_app):
     wx = pytest.importorskip("wx")

--- a/tests/gui/test_main_frame_gui_size.py
+++ b/tests/gui/test_main_frame_gui_size.py
@@ -5,6 +5,8 @@ import pytest
 from app.core.store import save
 from app.ui import main_frame
 
+pytestmark = pytest.mark.gui
+
 
 def test_main_frame_editor_multiline_fields_have_size(tmp_path, monkeypatch, wx_app):
     wx = pytest.importorskip("wx")

--- a/tests/gui/test_main_frame_llm_integration.py
+++ b/tests/gui/test_main_frame_llm_integration.py
@@ -11,6 +11,8 @@ from tests.llm_utils import make_openai_mock, settings_with_llm
 import app.ui.main_frame as main_frame
 import app.ui.command_dialog as cmd
 
+pytestmark = [pytest.mark.gui, pytest.mark.integration]
+
 def test_main_frame_creates_requirement_via_llm(tmp_path: Path, monkeypatch, wx_app, mcp_server) -> None:
     wx = pytest.importorskip("wx")
     port = mcp_server

--- a/tests/gui/test_recent_dirs.py
+++ b/tests/gui/test_recent_dirs.py
@@ -3,6 +3,8 @@
 import importlib
 import pytest
 
+pytestmark = pytest.mark.gui
+
 def test_recent_dirs_history(tmp_path, wx_app):
     wx = pytest.importorskip("wx")
     import app.ui.list_panel as list_panel

--- a/tests/gui/test_settings_dialog.py
+++ b/tests/gui/test_settings_dialog.py
@@ -2,6 +2,8 @@
 
 import pytest
 
+pytestmark = [pytest.mark.gui, pytest.mark.integration]
+
 
 def test_available_translations_contains_locales():
     wx = pytest.importorskip("wx")

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -10,6 +10,9 @@ from pathlib import Path
 from app.core.store import save
 from app.settings import AppSettings
 from app.cli.main import main
+import pytest
+
+pytestmark = pytest.mark.integration
 
 
 def sample() -> dict:

--- a/tests/integration/test_health_endpoint.py
+++ b/tests/integration/test_health_endpoint.py
@@ -1,4 +1,7 @@
 """Tests for health endpoint."""
+import pytest
+
+pytestmark = pytest.mark.integration
 
 def test_health_endpoint_returns_ok():
     from app.mcp.server import app

--- a/tests/integration/test_llm_client.py
+++ b/tests/integration/test_llm_client.py
@@ -13,6 +13,8 @@ from tests.llm_utils import make_openai_mock, settings_with_llm
 from app.settings import LLMSettings
 from types import SimpleNamespace
 
+pytestmark = pytest.mark.integration
+
 
 def test_missing_api_key_ignores_env(monkeypatch):
     monkeypatch.setenv("OPENAI_API_KEY", "dummy")

--- a/tests/integration/test_llm_openrouter_integration.py
+++ b/tests/integration/test_llm_openrouter_integration.py
@@ -6,6 +6,8 @@ import pytest
 from tests.llm_utils import settings_with_llm
 from app.llm.client import LLMClient
 
+pytestmark = pytest.mark.integration
+
 
 def _load_openrouter_key() -> str | None:
     key = os.getenv("OPEN_ROUTER")

--- a/tests/integration/test_local_agent.py
+++ b/tests/integration/test_local_agent.py
@@ -7,6 +7,8 @@ from app.agent.local_agent import LocalAgent
 from app.settings import AppSettings
 from app.mcp.utils import ErrorCode
 
+pytestmark = pytest.mark.integration
+
 
 class FailingLLM:
     def check_llm(self):

--- a/tests/integration/test_mcp_auth.py
+++ b/tests/integration/test_mcp_auth.py
@@ -2,6 +2,9 @@
 
 from app.mcp.server import start_server, stop_server
 from tests.mcp_utils import _request, _wait_until_ready
+import pytest
+
+pytestmark = pytest.mark.integration
 
 
 def test_authorization_header_rejected_without_valid_token():

--- a/tests/integration/test_mcp_client.py
+++ b/tests/integration/test_mcp_client.py
@@ -10,6 +10,9 @@ from app.mcp.server import JsonlHandler, start_server, stop_server
 from app.settings import MCPSettings
 from tests.llm_utils import settings_with_mcp
 from tests.mcp_utils import _wait_until_ready
+import pytest
+
+pytestmark = pytest.mark.integration
 
 
 def test_check_tools_success(tmp_path: Path) -> None:

--- a/tests/integration/test_mcp_controller.py
+++ b/tests/integration/test_mcp_controller.py
@@ -2,6 +2,8 @@
 
 import pytest
 
+pytestmark = pytest.mark.integration
+
 def test_controller_check(monkeypatch):
     from app.mcp.controller import MCPController, MCPStatus
     from app.settings import MCPSettings

--- a/tests/integration/test_mcp_http_tools.py
+++ b/tests/integration/test_mcp_http_tools.py
@@ -9,6 +9,9 @@ from pathlib import Path
 from app.mcp.server import start_server, stop_server
 from app.core import store
 from tests.mcp_utils import _wait_until_ready
+import pytest
+
+pytestmark = pytest.mark.integration
 
 
 def _sample(req_id: int, title: str, labels: list[str] | None = None) -> dict:

--- a/tests/integration/test_mcp_llm_integration.py
+++ b/tests/integration/test_mcp_llm_integration.py
@@ -8,6 +8,9 @@ from app.log import logger
 from app.agent import LocalAgent
 from app.mcp.server import JsonlHandler, app as mcp_app
 from tests.llm_utils import make_openai_mock, settings_with_mcp
+import pytest
+
+pytestmark = pytest.mark.integration
 
 
 def test_create_and_delete_requirement_via_llm(tmp_path: Path, monkeypatch, mcp_server) -> None:

--- a/tests/integration/test_mcp_logging.py
+++ b/tests/integration/test_mcp_logging.py
@@ -6,6 +6,9 @@ from tempfile import TemporaryDirectory
 
 from app.mcp.server import start_server, stop_server
 from tests.mcp_utils import _request, _wait_until_ready
+import pytest
+
+pytestmark = pytest.mark.integration
 
 
 def test_request_logged_and_token_masked():

--- a/tests/integration/test_mcp_server.py
+++ b/tests/integration/test_mcp_server.py
@@ -4,6 +4,9 @@ import json
 
 from app.mcp.server import start_server, stop_server
 from tests.mcp_utils import _request, _wait_until_ready
+import pytest
+
+pytestmark = pytest.mark.integration
 
 
 def test_background_server_health_endpoint():

--- a/tests/integration/test_mcp_text_commands.py
+++ b/tests/integration/test_mcp_text_commands.py
@@ -8,6 +8,9 @@ from app.log import logger
 from app.agent import LocalAgent
 from app.mcp.server import JsonlHandler, app as mcp_app
 from tests.llm_utils import make_openai_mock, settings_with_mcp
+import pytest
+
+pytestmark = pytest.mark.integration
 
 
 def test_run_command_list_logs(tmp_path: Path, monkeypatch, mcp_server) -> None:

--- a/tests/integration/test_mcp_tools.py
+++ b/tests/integration/test_mcp_tools.py
@@ -5,6 +5,9 @@ from pathlib import Path
 from app.core import store
 from app.mcp.tools_read import list_requirements, get_requirement, search_requirements
 from app.mcp.utils import ErrorCode
+import pytest
+
+pytestmark = pytest.mark.integration
 
 
 def _sample(req_id: int, title: str, status: str, labels: list[str]) -> dict:

--- a/tests/integration/test_tool_logging.py
+++ b/tests/integration/test_tool_logging.py
@@ -9,6 +9,9 @@ from app.log import logger
 from app.mcp.server import JsonlHandler
 from app.mcp.tools_read import list_requirements
 from app.mcp.utils import log_tool
+import pytest
+
+pytestmark = pytest.mark.integration
 
 def test_tool_logging(tmp_path: Path) -> None:
     log_file = tmp_path / "server.jsonl"

--- a/tests/slow/test_pydocstyle.py
+++ b/tests/slow/test_pydocstyle.py
@@ -1,5 +1,8 @@
 import subprocess
 import sys
+import pytest
+
+pytestmark = pytest.mark.slow
 
 def test_pydocstyle_conformance():
     """Ensure docstring conventions are respected."""

--- a/tests/slow/test_translation_coverage.py
+++ b/tests/slow/test_translation_coverage.py
@@ -2,6 +2,9 @@
 
 import polib
 from pathlib import Path
+import pytest
+
+pytestmark = pytest.mark.slow
 
 
 def test_po_files_have_no_missing_translations():

--- a/tests/unit/test_config_manager.py
+++ b/tests/unit/test_config_manager.py
@@ -5,6 +5,8 @@ import pytest
 from app.config import ConfigManager
 from app.settings import LLMSettings, MCPSettings, UISettings, AppSettings
 
+pytestmark = pytest.mark.unit
+
 
 class DummyListPanel:
     def __init__(self):

--- a/tests/unit/test_config_manager_proxies.py
+++ b/tests/unit/test_config_manager_proxies.py
@@ -1,6 +1,9 @@
 """Tests for config manager proxies."""
 
 from app.config import ConfigManager
+import pytest
+
+pytestmark = pytest.mark.unit
 
 
 def test_config_manager_proxy_methods(tmp_path, wx_app):

--- a/tests/unit/test_derived_requirements.py
+++ b/tests/unit/test_derived_requirements.py
@@ -6,6 +6,9 @@ from pathlib import Path
 from app.core.store import save, load, filename_for
 from app.core.model import Requirement, requirement_from_dict
 from app.core.search import search
+import pytest
+
+pytestmark = pytest.mark.unit
 
 
 

--- a/tests/unit/test_hashing.py
+++ b/tests/unit/test_hashing.py
@@ -1,6 +1,9 @@
 """Tests for hashing."""
 
 from app.util.hashing import id_to_hash
+import pytest
+
+pytestmark = pytest.mark.unit
 
 
 def test_id_to_hash_deterministic():

--- a/tests/unit/test_i18n.py
+++ b/tests/unit/test_i18n.py
@@ -1,6 +1,9 @@
 """Tests for i18n."""
 
 from app import i18n
+import pytest
+
+pytestmark = pytest.mark.unit
 
 
 def test_parse_po_multiline_and_unfinished(tmp_path):

--- a/tests/unit/test_i18n_escape.py
+++ b/tests/unit/test_i18n_escape.py
@@ -2,6 +2,9 @@
 
 from pathlib import Path
 from app import i18n
+import pytest
+
+pytestmark = pytest.mark.unit
 
 def test_parse_po_unescape(tmp_path):
     po = tmp_path / "sample.po"

--- a/tests/unit/test_labels.py
+++ b/tests/unit/test_labels.py
@@ -4,6 +4,9 @@ from app.core.labels import Label, add_label, get_label, update_label, delete_la
 from app.core import label_store
 from app.core.label_repository import FileLabelRepository
 from pathlib import Path
+import pytest
+
+pytestmark = pytest.mark.unit
 
 
 def test_label_crud_operations(tmp_path: Path) -> None:

--- a/tests/unit/test_locale.py
+++ b/tests/unit/test_locale.py
@@ -6,6 +6,8 @@ from app.i18n import _, install
 from app.ui import locale
 from app.core import model
 
+pytestmark = pytest.mark.unit
+
 
 def test_round_trip():
     install("CookaReq", "app/locale", ["en"])

--- a/tests/unit/test_logging_config.py
+++ b/tests/unit/test_logging_config.py
@@ -5,6 +5,8 @@ import pytest
 
 from app.log import configure_logging, logger
 
+pytestmark = pytest.mark.unit
+
 
 @pytest.fixture
 def reset_logger() -> None:

--- a/tests/unit/test_missing_translations.py
+++ b/tests/unit/test_missing_translations.py
@@ -2,6 +2,9 @@
 
 import threading
 from app import i18n
+import pytest
+
+pytestmark = pytest.mark.unit
 
 
 def test_flush_missing_writes_unique_msgids(tmp_path):

--- a/tests/unit/test_model.py
+++ b/tests/unit/test_model.py
@@ -9,6 +9,9 @@ from app.core.model import (
     requirement_from_dict,
     requirement_to_dict,
 )
+import pytest
+
+pytestmark = pytest.mark.unit
 
 
 def test_requirement_defaults():

--- a/tests/unit/test_paths.py
+++ b/tests/unit/test_paths.py
@@ -6,6 +6,8 @@ import pytest
 
 from app.util.paths import ensure_relative
 
+pytestmark = pytest.mark.unit
+
 
 def test_ensure_relative_returns_relative(tmp_path):
     base = tmp_path / "base"

--- a/tests/unit/test_repository.py
+++ b/tests/unit/test_repository.py
@@ -11,6 +11,8 @@ import pytest
 from app.core.repository import FileRequirementRepository
 from app.core.store import ConflictError
 
+pytestmark = pytest.mark.unit
+
 
 def sample(req_id: int = 1) -> dict:
     return {

--- a/tests/unit/test_requirement_model.py
+++ b/tests/unit/test_requirement_model.py
@@ -4,6 +4,8 @@ import pytest
 from app.ui.requirement_model import RequirementModel
 from app.core.model import Requirement, RequirementType, Status, Priority, Verification
 
+pytestmark = pytest.mark.unit
+
 
 def _req(id: int, status: Status) -> Requirement:
     return Requirement(

--- a/tests/unit/test_requirement_ops.py
+++ b/tests/unit/test_requirement_ops.py
@@ -13,6 +13,8 @@ from app.mcp.tools_write import (
 from app.mcp.utils import ErrorCode
 from app.core.store import load, filename_for
 
+pytestmark = pytest.mark.unit
+
 
 def _base_req(req_id: int) -> dict:
     return {

--- a/tests/unit/test_schema.py
+++ b/tests/unit/test_schema.py
@@ -4,6 +4,8 @@ import pytest
 
 from app.core.schema import validate
 
+pytestmark = pytest.mark.unit
+
 
 def make_valid() -> dict:
     return {

--- a/tests/unit/test_search.py
+++ b/tests/unit/test_search.py
@@ -16,6 +16,9 @@ from app.core.search import (
     search_text,
 )
 from app.core.requirements import filter_by_status
+import pytest
+
+pytestmark = pytest.mark.unit
 
 
 def sample_requirements():

--- a/tests/unit/test_settings_validation.py
+++ b/tests/unit/test_settings_validation.py
@@ -7,6 +7,8 @@ import pytest
 
 from app.settings import load_app_settings
 
+pytestmark = pytest.mark.unit
+
 
 def test_invalid_settings_raises(tmp_path):
     file = tmp_path / "settings.json"

--- a/tests/unit/test_store.py
+++ b/tests/unit/test_store.py
@@ -24,6 +24,8 @@ from app.core.store import (
     _scan_ids,
 )
 
+pytestmark = pytest.mark.unit
+
 
 def sample(req_id: int = 1) -> dict:
     return {

--- a/tests/unit/test_telemetry.py
+++ b/tests/unit/test_telemetry.py
@@ -7,6 +7,9 @@ from pathlib import Path
 import app.telemetry as telemetry
 from app.log import JsonlHandler, logger
 from app.telemetry import REDACTED, log_event, sanitize
+import pytest
+
+pytestmark = pytest.mark.unit
 
 
 def test_sanitize_redacts_sensitive_keys() -> None:

--- a/tests/unit/test_validate.py
+++ b/tests/unit/test_validate.py
@@ -6,6 +6,8 @@ import pytest
 from app.core.store import load_index
 from app.core.validate import ValidationError, validate
 
+pytestmark = pytest.mark.unit
+
 
 def make_valid() -> dict:
     return {


### PR DESCRIPTION
## Summary
- document unit, integration, gui and slow markers in pytest.ini
- tag every test module with appropriate pytest markers

## Testing
- `pytest`
- `pytest -m "not slow"`
- `pytest tests/gui -m gui`


------
https://chatgpt.com/codex/tasks/task_e_68c6813cb7fc8320b45de3fa0df954ef