### PR TITLE
Configure basic Ruff checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,10 +86,22 @@ Install the package along with development dependencies:
 pip install .[dev]
 ```
 
+If Ruff is missing, install it separately:
+
+```bash
+python3 -m pip install ruff
+```
+
 Check that every module has a docstring:
 
 ```bash
 pydocstyle app tests
+```
+
+Run Ruff to catch basic errors:
+
+```bash
+ruff check app tests
 ```
 
 ## License

--- a/app/core/validate.py
+++ b/app/core/validate.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from collections.abc import Iterable
 
 from .schema import validate as validate_schema
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,10 +13,21 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-dev = ["pytest", "polib", "pydocstyle"]
+dev = ["pytest", "polib", "pydocstyle", "ruff"]
 
 [tool.pydocstyle]
 select = ["D100", "D101", "D102", "D103"]
+
+[tool.ruff]
+exclude = [
+    "build",
+    "dist",
+    ".venv",
+    "**/migrations/*",
+]
+
+[tool.ruff.lint]
+select = ["E9", "F63", "F7", "F82"]
 
 [build-system]
 requires = ["setuptools", "wheel"]

--- a/tests/slow/test_ruff.py
+++ b/tests/slow/test_ruff.py
@@ -1,0 +1,11 @@
+import subprocess
+import sys
+import pytest
+
+pytestmark = pytest.mark.slow
+
+def test_ruff_conformance():
+    """Ensure code passes Ruff checks with basic rules."""
+    cmd = [sys.executable, "-m", "ruff", "check", "app", "tests"]
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    assert result.returncode == 0, result.stdout + result.stderr


### PR DESCRIPTION
## Summary
- add Ruff to dev dependencies and document installation
- limit Ruff linting to critical rules and run it in tests
- fix missing Iterable import uncovered by Ruff

## Testing
- `ruff check app tests`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c684bd72388320a976f11104a8ccb1