### PR TITLE
chore: enforce unused-import rule

### DIFF
--- a/app/core/requirements.py
+++ b/app/core/requirements.py
@@ -18,7 +18,6 @@ from .store import (
     filename_for,
     save,
     delete,
-    ConflictError,
 )
 from .label_repository import LabelRepository, FileLabelRepository
 from ..util.time import local_now_str, normalize_timestamp

--- a/app/mcp/server.py
+++ b/app/mcp/server.py
@@ -8,7 +8,6 @@ loop remains responsive.
 
 from __future__ import annotations
 
-import json
 import logging
 import os
 import threading

--- a/app/telemetry.py
+++ b/app/telemetry.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import datetime
 import json
 import time
 from typing import Any, Mapping

--- a/app/ui/editor_panel.py
+++ b/app/ui/editor_panel.py
@@ -13,16 +13,7 @@ from wx.lib.scrolledpanel import ScrolledPanel
 
 from ..core import requirements as req_ops
 from ..core.labels import Label
-from ..core.model import (
-    Requirement,
-    RequirementType,
-    Status,
-    Priority,
-    Verification,
-    Attachment,
-    requirement_from_dict,
-    requirement_to_dict,
-)
+from ..core.model import Requirement, requirement_from_dict, requirement_to_dict
 from . import locale
 from .label_selection_dialog import LabelSelectionDialog
 from .helpers import HelpStaticBox, make_help_button, show_help

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ exclude = [
 ]
 
 [tool.ruff.lint]
-select = ["E9", "F63", "F7", "F82"]
+select = ["E9", "F63", "F7", "F82", "F401"]
 
 [build-system]
 requires = ["setuptools", "wheel"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,7 @@ sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 import pytest
 from app.confirm import set_confirm, auto_confirm
-from app.mcp.server import start_server, stop_server, app as mcp_app
+from app.mcp.server import start_server, stop_server
 from tests.mcp_utils import _wait_until_ready
 import socket
 

--- a/tests/gui/test_list_panel.py
+++ b/tests/gui/test_list_panel.py
@@ -5,7 +5,6 @@ import types
 import importlib
 
 from app.core.model import Requirement, RequirementType, Status, Priority, Verification
-from app.core.labels import Label
 import pytest
 
 pytestmark = pytest.mark.gui

--- a/tests/unit/test_i18n_escape.py
+++ b/tests/unit/test_i18n_escape.py
@@ -1,6 +1,5 @@
 """Tests for i18n escape."""
 
-from pathlib import Path
 from app import i18n
 import pytest
 


### PR DESCRIPTION
## Summary
- enable ruff F401 unused-import check
- drop unused imports across core, server, UI, telemetry and tests

## Testing
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c688be9c688320afccd8680c32792e