### PR TITLE
feat: centralize UI enums and auto labels

### DIFF
--- a/app/ui/editor_panel.py
+++ b/app/ui/editor_panel.py
@@ -25,15 +25,7 @@ from ..core.model import (
 from . import locale
 from .label_selection_dialog import LabelSelectionDialog
 from .helpers import HelpStaticBox, make_help_button, show_help
-
-
-# Mapping of enumerated requirement fields to their Enum classes
-ENUMS = {
-    "type": RequirementType,
-    "status": Status,
-    "priority": Priority,
-    "verification": Verification,
-}
+from .enums import ENUMS
 
 
 class EditorPanel(ScrolledPanel):

--- a/app/ui/enums.py
+++ b/app/ui/enums.py
@@ -1,0 +1,30 @@
+"""Common Enum definitions and label utilities for UI."""
+from __future__ import annotations
+
+from enum import Enum
+
+from ..i18n import _
+from ..core.model import RequirementType, Status, Priority, Verification
+
+
+def _enum_label(e: Enum) -> str:
+    """Convert enum member name to human-readable English label."""
+    return e.name.replace("_", " ").lower().capitalize()
+
+
+def enum_labels(enum_cls: type[Enum]) -> dict[str, str]:
+    """Return mapping of enum values to localized labels."""
+    return {e.value: _(_enum_label(e)) for e in enum_cls}
+
+
+# Mapping of requirement field names to their Enum classes
+ENUMS: dict[str, type[Enum]] = {
+    "type": RequirementType,
+    "status": Status,
+    "priority": Priority,
+    "verification": Verification,
+}
+
+
+# Pre-generated localized labels for each enumerated field
+LABELS: dict[str, dict[str, str]] = {name: enum_labels(cls) for name, cls in ENUMS.items()}

--- a/app/ui/filter_dialog.py
+++ b/app/ui/filter_dialog.py
@@ -7,9 +7,9 @@ from typing import Dict
 import wx
 
 from ..core import requirements as req_ops
-from ..core.model import Status
 from ..core.labels import Label
 from . import locale
+from .enums import ENUMS
 
 
 class FilterDialog(wx.Dialog):
@@ -69,8 +69,9 @@ class FilterDialog(wx.Dialog):
 
         # Status filter
         sizer.Add(wx.StaticText(self, label=_("Status")), 0, wx.ALL, 5)
-        self._status_values = [s.value for s in Status]
-        status_choices = [_("(any)")] + [locale.STATUS[v] for v in self._status_values]
+        enum_cls = ENUMS["status"]
+        self._status_values = [s.value for s in enum_cls]
+        status_choices = [_("(any)")] + [locale.code_to_label("status", v) for v in self._status_values]
         self.status_choice = wx.Choice(self, choices=status_choices)
         selected = 0
         if values.get("status") in self._status_values:

--- a/app/ui/locale.py
+++ b/app/ui/locale.py
@@ -1,31 +1,14 @@
-"""Localization helpers for enumerated fields using gettext."""
+"""Localization helpers for requirement fields and enums."""
+from __future__ import annotations
 
 from ..i18n import _
-from enum import Enum
+from .enums import LABELS as EN_LABELS
 
-from ..core.model import RequirementType, Status, Priority, Verification
-
-
-def _enum_label(e: Enum) -> str:
-    """Convert enum member name to human-readable English label."""
-    return e.name.replace("_", " ").lower().capitalize()
-
-
-# English labels generated from enum values
-TYPE = {e.value: _(_enum_label(e)) for e in RequirementType}
-
-STATUS = {e.value: _(_enum_label(e)) for e in Status}
-
-PRIORITY = {e.value: _(_enum_label(e)) for e in Priority}
-
-VERIFICATION = {e.value: _(_enum_label(e)) for e in Verification}
-
-EN_LABELS = {
-    "type": TYPE,
-    "status": STATUS,
-    "priority": PRIORITY,
-    "verification": VERIFICATION,
-}
+# Backwards compatible aliases for enum label mappings
+TYPE = EN_LABELS.get("type", {})
+STATUS = EN_LABELS.get("status", {})
+PRIORITY = EN_LABELS.get("priority", {})
+VERIFICATION = EN_LABELS.get("verification", {})
 
 # Human-readable labels for requirement fields
 FIELD_LABELS = {
@@ -60,11 +43,11 @@ def field_label(name: str) -> str:
 
 
 def code_to_label(category: str, code: str) -> str:
-    """Return localized label for given code."""
-    return _(EN_LABELS.get(category, {}).get(code, code))
+    """Return localized label for given enum code."""
+    return EN_LABELS.get(category, {}).get(code, code)
 
 
 def label_to_code(category: str, label: str) -> str:
     """Return internal code for given localized label."""
-    mapping = {_(lbl): code for code, lbl in EN_LABELS.get(category, {}).items()}
+    mapping = {lbl: code for code, lbl in EN_LABELS.get(category, {}).items()}
     return mapping.get(label, label)


### PR DESCRIPTION
## Summary
- ensure list panel shows localized enum labels when editing inline
- verified no other modules duplicate enum/localization logic

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c68db4deb08320908c70f4236cb74e