### PR TITLE
chore: enable more ruff rules

### DIFF
--- a/app/core/labels.py
+++ b/app/core/labels.py
@@ -80,7 +80,7 @@ PRESET_SET_TITLES: Dict[str, str] = {
 
 def add_label(labels: List[Label], label: Label) -> None:
     """Add ``label`` to ``labels`` ensuring unique names."""
-    if any(l.name == label.name for l in labels):
+    if any(existing.name == label.name for existing in labels):
         raise ValueError(f"label exists: {label.name}")
     labels.append(label)
 

--- a/app/core/model.py
+++ b/app/core/model.py
@@ -123,8 +123,8 @@ def requirement_from_dict(data: dict[str, Any]) -> Requirement:
     derived_from = [RequirementLink(**d) for d in data.get("derived_from", [])]
     links_data = data.get("links", {})
     links = Links(
-        verifies=[RequirementLink(**l) for l in links_data.get("verifies", [])],
-        relates=[RequirementLink(**l) for l in links_data.get("relates", [])],
+        verifies=[RequirementLink(**link_data) for link_data in links_data.get("verifies", [])],
+        relates=[RequirementLink(**link_data) for link_data in links_data.get("relates", [])],
     )
     derivation_data = data.get("derivation")
     derivation = DerivationInfo(**derivation_data) if derivation_data else None

--- a/app/mcp/tools_write.py
+++ b/app/mcp/tools_write.py
@@ -277,12 +277,12 @@ def link_requirements(
     if link_type == "parent":
         data["parent"] = link
     elif link_type == "derived_from":
-        links = [l for l in data.get("derived_from", []) if l.get("source_id") != source_id]
+        links = [item for item in data.get("derived_from", []) if item.get("source_id") != source_id]
         links.append(link)
         data["derived_from"] = links
     else:
         links_obj = data.get("links", {})
-        lst = [l for l in links_obj.get(link_type, []) if l.get("source_id") != source_id]
+        lst = [item for item in links_obj.get(link_type, []) if item.get("source_id") != source_id]
         lst.append(link)
         links_obj[link_type] = lst
         data["links"] = links_obj

--- a/app/ui/controllers/labels.py
+++ b/app/ui/controllers/labels.py
@@ -39,9 +39,9 @@ class LabelsController:
         if not self.directory:
             return []
         existing_colors = {lbl.name: lbl.color for lbl in self.labels}
-        used_names = {l for req in self.model.get_all() for l in req.labels}
+        used_names = {label for req in self.model.get_all() for label in req.labels}
         all_names = sorted(existing_colors.keys() | used_names)
-        self.labels = [Label(name=n, color=existing_colors.get(n, "#ffffff")) for n in all_names]
+        self.labels = [Label(name=name, color=existing_colors.get(name, "#ffffff")) for name in all_names]
         try:
             req_ops.save_labels(self.directory, self.labels, repo=self.repo)
         except Exception as exc:
@@ -73,7 +73,7 @@ class LabelsController:
         if remove_from_requirements:
             for req in self.model.get_all():
                 before = list(req.labels)
-                req.labels = [l for l in req.labels if l not in removed_set]
+                req.labels = [label for label in req.labels if label not in removed_set]
                 if before != req.labels:
                     try:
                         req_ops.save_requirement(self.directory, req)

--- a/app/ui/editor_panel.py
+++ b/app/ui/editor_panel.py
@@ -668,11 +668,11 @@ class EditorPanel(ScrolledPanel):
             self.derived_id.ChangeValue("")
             self._refresh_links_visibility("derived_from")
             links = data.get("links", {})
-            self.verifies = [dict(l) for l in links.get("verifies", [])]
+            self.verifies = [dict(link) for link in links.get("verifies", [])]
             self._rebuild_links_list("verifies")
             self.verifies_id.ChangeValue("")
             self._refresh_links_visibility("verifies")
-            self.relates = [dict(l) for l in links.get("relates", [])]
+            self.relates = [dict(link) for link in links.get("relates", [])]
             self._rebuild_links_list("relates")
             self.relates_id.ChangeValue("")
             self._refresh_links_visibility("relates")
@@ -811,14 +811,16 @@ class EditorPanel(ScrolledPanel):
         """Update available labels and reapply selection."""
         self._label_defs = list(labels)
         current = [
-            lbl for lbl in self.extra.get("labels", []) if any(l.name == lbl for l in labels)
+            lbl
+            for lbl in self.extra.get("labels", [])
+            if any(label.name == lbl for label in labels)
         ]
         self.extra["labels"] = current
         self._refresh_labels_display()
 
     def apply_label_selection(self, labels: list[str]) -> None:
         """Apply selected ``labels`` to requirement and refresh display."""
-        available = {l.name for l in self._label_defs}
+        available = {label.name for label in self._label_defs}
         self.extra["labels"] = [lbl for lbl in labels if lbl in available]
         self._refresh_labels_display()
 
@@ -836,7 +838,10 @@ class EditorPanel(ScrolledPanel):
             sizer.Add(placeholder, 0)
         else:
             for i, name in enumerate(labels):
-                lbl_def = next((l for l in self._label_defs if l.name == name), None)
+                lbl_def = next(
+                    (label_def for label_def in self._label_defs if label_def.name == name),
+                    None,
+                )
                 color = lbl_def.color if lbl_def else "#cccccc"
                 txt = wx.StaticText(self.labels_panel, label=name)
                 txt.SetBackgroundColour(color)

--- a/app/ui/filter_dialog.py
+++ b/app/ui/filter_dialog.py
@@ -57,7 +57,7 @@ class FilterDialog(wx.Dialog):
             except Exception:  # pragma: no cover - platform dependent
                 pass
         for lbl in values.get("labels", []):
-            names = [l.name for l in self._labels]
+            names = [label_obj.name for label_obj in self._labels]
             if lbl in names:
                 idx = names.index(lbl)
                 self.labels_box.Check(idx)

--- a/app/ui/labels_dialog.py
+++ b/app/ui/labels_dialog.py
@@ -16,7 +16,7 @@ class LabelsDialog(wx.Dialog):
         style = wx.DEFAULT_DIALOG_STYLE | wx.RESIZE_BORDER
         super().__init__(parent, title=_("Labels"), style=style)
         # copy labels to avoid modifying caller until OK
-        self._labels: list[Label] = [Label(l.name, l.color) for l in labels]
+        self._labels: list[Label] = [Label(lbl.name, lbl.color) for lbl in labels]
         cfg = getattr(parent, "config", None)
         if cfg is None:
             cfg = ConfigManager()
@@ -171,7 +171,7 @@ class LabelsDialog(wx.Dialog):
             if not new_name:
                 dlg.Destroy()
                 return
-            existing = {l.name for i, l in enumerate(self._labels) if i != idx}
+            existing = {lbl.name for i, lbl in enumerate(self._labels) if i != idx}
             if new_name in existing:
                 wx.MessageBox(_("Label already exists"), _("Error"), style=wx.ICON_ERROR)
             else:
@@ -196,12 +196,12 @@ class LabelsDialog(wx.Dialog):
                     visible = True
                     break
             if not visible:
-                if parent := self.GetParent():
+                if self.GetParent():
                     self.CentreOnParent()
                 else:
                     self.Centre()
         else:
-            if parent := self.GetParent():
+            if self.GetParent():
                 self.CentreOnParent()
             else:
                 self.Centre()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ exclude = [
 ]
 
 [tool.ruff.lint]
-select = ["E9", "F63", "F7", "F82", "F401"]
+select = ["E9", "E741", "F63", "F7", "F82", "F401", "F841"]
 
 [build-system]
 requires = ["setuptools", "wheel"]

--- a/tests/gui/test_app_icon.py
+++ b/tests/gui/test_app_icon.py
@@ -9,7 +9,7 @@ pytestmark = pytest.mark.gui
 
 def test_main_frame_loads_multiple_icon_sizes(wx_app):
     """Main frame should expose all icon sizes for taskbar usage."""
-    wx = pytest.importorskip("wx")
+    pytest.importorskip("wx")
     frame = MainFrame(None)
     try:
         bundle = frame.GetIcons()

--- a/tests/gui/test_command_dialog.py
+++ b/tests/gui/test_command_dialog.py
@@ -44,7 +44,7 @@ def test_command_dialog_shows_result_and_saves_history(tmp_path, wx_app):
 
 
 def test_command_dialog_shows_error(tmp_path, wx_app):
-    wx = pytest.importorskip("wx")
+    pytest.importorskip("wx")
     from app.ui.command_dialog import CommandDialog
 
     class DummyLLM:
@@ -66,7 +66,7 @@ def test_command_dialog_shows_error(tmp_path, wx_app):
 
 
 def test_command_dialog_persists_between_instances(tmp_path, wx_app):
-    wx = pytest.importorskip("wx")
+    pytest.importorskip("wx")
     from app.ui.command_dialog import CommandDialog
 
     class DummyAgent:
@@ -88,7 +88,7 @@ def test_command_dialog_persists_between_instances(tmp_path, wx_app):
 
 
 def test_command_dialog_handles_invalid_history(tmp_path, wx_app):
-    wx = pytest.importorskip("wx")
+    pytest.importorskip("wx")
     from app.ui.command_dialog import CommandDialog
 
     bad_file = tmp_path / "history.json"

--- a/tests/gui/test_editor_panel.py
+++ b/tests/gui/test_editor_panel.py
@@ -115,7 +115,7 @@ def test_get_data_requires_valid_id(wx_app):
 
 
 def test_enum_localization_roundtrip(wx_app):
-    wx = pytest.importorskip("wx")
+    pytest.importorskip("wx")
     from app.ui import locale
 
     panel = _make_panel()

--- a/tests/gui/test_gui.py
+++ b/tests/gui/test_gui.py
@@ -6,7 +6,7 @@ pytestmark = pytest.mark.gui
 
 
 def test_gui_imports(wx_app):
-    wx = pytest.importorskip("wx")
+    pytest.importorskip("wx")
     from app.main import main
     from app.ui.main_frame import MainFrame
     from app.ui.list_panel import ListPanel

--- a/tests/gui/test_labels_dialog.py
+++ b/tests/gui/test_labels_dialog.py
@@ -45,14 +45,14 @@ def test_labels_dialog_displays_color_rect(wx_app):
 
 
 def test_labels_dialog_adds_presets(wx_app):
-    wx = pytest.importorskip("wx")
+    pytest.importorskip("wx")
     from app.ui.labels_dialog import LabelsDialog
     from app.core.labels import PRESET_SETS
 
     dlg = LabelsDialog(None, [])
     dlg._on_add_preset_set("basic")
     labels = dlg.get_labels()
-    assert {l.name for l in labels} == {l.name for l in PRESET_SETS["basic"]}
+    assert {label.name for label in labels} == {label.name for label in PRESET_SETS["basic"]}
     # calling again should not duplicate
     dlg._on_add_preset_set("basic")
     assert len(dlg.get_labels()) == len(PRESET_SETS["basic"])
@@ -67,13 +67,13 @@ def test_labels_dialog_deletes_selected(wx_app):
     dlg.list.SetItemState(0, wx.LIST_STATE_SELECTED, wx.LIST_STATE_SELECTED)
     dlg.list.SetItemState(2, wx.LIST_STATE_SELECTED, wx.LIST_STATE_SELECTED)
     dlg._on_delete_selected(None)
-    names = [l.name for l in dlg.get_labels()]
+    names = [label.name for label in dlg.get_labels()]
     assert names == ["b"]
     dlg.Destroy()
 
 
 def test_labels_dialog_clear_all(wx_app):
-    wx = pytest.importorskip("wx")
+    pytest.importorskip("wx")
     from app.ui.labels_dialog import LabelsDialog
 
     dlg = LabelsDialog(None, [Label("a", "#111111")])
@@ -160,7 +160,7 @@ def test_main_frame_manage_labels_saves(monkeypatch, tmp_path, wx_app):
 
     class DummyLabelsDialog:
         def __init__(self, parent, labels):
-            self._labels = [Label(l.name, "#123456") for l in labels]
+            self._labels = [Label(label.name, "#123456") for label in labels]
 
         def ShowModal(self):
             return wx.ID_OK
@@ -175,10 +175,10 @@ def test_main_frame_manage_labels_saves(monkeypatch, tmp_path, wx_app):
 
     captured: list[tuple[str, list[str]]] = []
     frame.editor.update_labels_list = lambda labels: captured.append(
-        ("editor", [l.name for l in labels])
+        ("editor", [label.name for label in labels])
     )
     frame.panel.update_labels_list = lambda labels: captured.append(
-        ("panel", [l.name for l in labels])
+        ("panel", [label.name for label in labels])
     )
 
     evt = wx.CommandEvent(wx.EVT_MENU.typeId, frame.manage_labels_id)

--- a/tests/gui/test_labels_sync.py
+++ b/tests/gui/test_labels_sync.py
@@ -25,11 +25,11 @@ def _create_requirement(directory):
 
 
 def test_sync_labels_preserves_unused(monkeypatch, tmp_path, wx_app):
-    wx = pytest.importorskip("wx")
+    pytest.importorskip("wx")
     label_store.save_labels(tmp_path, PRESET_SETS["basic"])
     _create_requirement(tmp_path)
     from app.ui.main_frame import MainFrame
     frame = MainFrame(None)
     frame._load_directory(tmp_path)
-    assert {l.name for l in frame.labels} == {l.name for l in PRESET_SETS["basic"]}
+    assert {label.name for label in frame.labels} == {label.name for label in PRESET_SETS["basic"]}
     frame.Destroy()

--- a/tests/gui/test_main_frame_gui.py
+++ b/tests/gui/test_main_frame_gui.py
@@ -112,7 +112,7 @@ def test_main_frame_run_command_history_persists(monkeypatch, tmp_path, wx_app):
 
 
 def test_log_handler_not_duplicated(tmp_path, wx_app):
-    wx = pytest.importorskip("wx")
+    pytest.importorskip("wx")
 
     import app.ui.main_frame as main_frame
 

--- a/tests/gui/test_recent_dirs.py
+++ b/tests/gui/test_recent_dirs.py
@@ -6,7 +6,7 @@ import pytest
 pytestmark = pytest.mark.gui
 
 def test_recent_dirs_history(tmp_path, wx_app):
-    wx = pytest.importorskip("wx")
+    pytest.importorskip("wx")
     import app.ui.list_panel as list_panel
     import app.ui.main_frame as main_frame
     importlib.reload(list_panel)

--- a/tests/gui/test_settings_dialog.py
+++ b/tests/gui/test_settings_dialog.py
@@ -6,7 +6,7 @@ pytestmark = [pytest.mark.gui, pytest.mark.integration]
 
 
 def test_available_translations_contains_locales():
-    wx = pytest.importorskip("wx")
+    pytest.importorskip("wx")
     from app.ui.settings_dialog import available_translations
 
     langs = available_translations()
@@ -16,7 +16,7 @@ def test_available_translations_contains_locales():
 
 
 def test_settings_dialog_returns_language(wx_app):
-    wx = pytest.importorskip("wx")
+    pytest.importorskip("wx")
     from app.ui.settings_dialog import SettingsDialog
 
     dlg = SettingsDialog(

--- a/tests/integration/test_mcp_llm_integration.py
+++ b/tests/integration/test_mcp_llm_integration.py
@@ -50,7 +50,7 @@ def test_create_and_delete_requirement_via_llm(tmp_path: Path, monkeypatch, mcp_
                 }
             },
         )
-        create_result = client.run_command(text_create)
+        client.run_command(text_create)
         path = tmp_path / "10.json"
         data = json.loads(path.read_text())
         assert data["title"] == "LLM test"


### PR DESCRIPTION
## Summary
- enable ruff rules for ambiguous variables and unused assignments
- rename unclear temporary names and drop unused variables

## Testing
- `python3 -m ruff check app tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c69260109483209e8e90d47dd2287a