### PR TITLE
chore: enable additional ruff rules and refactor imports

### DIFF
--- a/app/agent/local_agent.py
+++ b/app/agent/local_agent.py
@@ -4,12 +4,12 @@ from __future__ import annotations
 
 from typing import Any, Callable
 
+from ..confirm import confirm as default_confirm
 from ..llm.client import LLMClient
 from ..mcp.client import MCPClient
 from ..mcp.utils import ErrorCode, mcp_error
 from ..settings import AppSettings
 from ..telemetry import log_event
-from ..confirm import confirm as default_confirm
 
 
 class LocalAgent:

--- a/app/cli/commands.py
+++ b/app/cli/commands.py
@@ -8,10 +8,10 @@ import sys
 from dataclasses import dataclass
 from typing import Callable
 
-from app.core import model
-from app.core.repository import RequirementRepository
 from app.agent import LocalAgent
 from app.confirm import confirm
+from app.core import model
+from app.core.repository import RequirementRepository
 from app.i18n import _
 
 

--- a/app/cli/main.py
+++ b/app/cli/main.py
@@ -8,11 +8,11 @@ import os
 from pathlib import Path
 
 from app import i18n
+from app.confirm import auto_confirm, set_confirm
+from app.core.repository import FileRequirementRepository, RequirementRepository
 from app.i18n import _
-from app.core.repository import RequirementRepository, FileRequirementRepository
 from app.log import configure_logging
 from app.settings import AppSettings, load_app_settings
-from app.confirm import set_confirm, auto_confirm
 
 from .commands import COMMANDS
 

--- a/app/config.py
+++ b/app/config.py
@@ -7,7 +7,7 @@ from typing import Protocol
 
 import wx
 
-from .settings import LLMSettings, MCPSettings, AppSettings, UISettings
+from .settings import AppSettings, LLMSettings, MCPSettings, UISettings
 
 
 class ListPanelLike(Protocol):

--- a/app/confirm.py
+++ b/app/confirm.py
@@ -24,6 +24,7 @@ def confirm(message: str) -> bool:
 def wx_confirm(message: str) -> bool:
     """GUI confirmation dialog using wxWidgets."""
     import wx  # type: ignore
+
     from .i18n import _
 
     return (

--- a/app/core/label_repository.py
+++ b/app/core/label_repository.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Protocol
 
-from .labels import Label
 from . import label_store
+from .labels import Label
 
 
 class LabelRepository(Protocol):

--- a/app/core/label_store.py
+++ b/app/core/label_store.py
@@ -1,12 +1,11 @@
 """JSON file storage for label data."""
 from __future__ import annotations
 
-from dataclasses import asdict
 import json
+from dataclasses import asdict
 from pathlib import Path
 
 from ..log import logger
-
 from .labels import Label
 
 LABELS_FILENAME = "labels.json"

--- a/app/core/model.py
+++ b/app/core/model.py
@@ -1,7 +1,7 @@
 """Domain models for requirements."""
 from __future__ import annotations
 
-from dataclasses import dataclass, field, asdict
+from dataclasses import asdict, dataclass, field
 from enum import Enum
 from typing import Any
 

--- a/app/core/repository.py
+++ b/app/core/repository.py
@@ -2,12 +2,12 @@
 
 from __future__ import annotations
 
-from pathlib import Path
 from collections.abc import Mapping, Sequence
+from pathlib import Path
 from typing import Protocol
 
-from .model import Requirement
 from . import requirements as req_ops
+from .model import Requirement
 
 
 class RequirementRepository(Protocol):

--- a/app/core/requirements.py
+++ b/app/core/requirements.py
@@ -6,21 +6,21 @@ GUI components.
 """
 from __future__ import annotations
 
-from pathlib import Path
 from collections.abc import Iterable, Mapping, Sequence
+from pathlib import Path
 
-from .model import Requirement, requirement_from_dict, Status
-from .labels import Label
+from ..util.time import local_now_str, normalize_timestamp
 from . import search as core_search
+from .label_repository import FileLabelRepository, LabelRepository
+from .labels import Label
+from .model import Requirement, Status, requirement_from_dict
 from .store import (
+    delete,
+    filename_for,
     load,
     load_index,
-    filename_for,
     save,
-    delete,
 )
-from .label_repository import LabelRepository, FileLabelRepository
-from ..util.time import local_now_str, normalize_timestamp
 
 # Re-export searchable fields for UI components
 SEARCHABLE_FIELDS = core_search.SEARCHABLE_FIELDS

--- a/app/core/search.py
+++ b/app/core/search.py
@@ -1,7 +1,7 @@
 """In-memory search helpers for requirements."""
 from __future__ import annotations
 
-from collections.abc import Iterable, Sequence, Mapping
+from collections.abc import Iterable, Mapping, Sequence
 
 from .model import Requirement
 
@@ -14,7 +14,7 @@ SEARCHABLE_FIELDS = {
     "owner",
     "notes",
 }
- 
+
 def filter_by_labels(
     requirements: Iterable[Requirement],
     labels: Sequence[str],

--- a/app/core/store.py
+++ b/app/core/store.py
@@ -1,15 +1,14 @@
 """JSON file storage for requirements."""
 from __future__ import annotations
 
-from dataclasses import is_dataclass
 import json
+from dataclasses import is_dataclass
 from pathlib import Path
 
 from ..log import logger
-
-from .validate import validate
-from .model import requirement_to_dict
 from .label_store import LABELS_FILENAME
+from .model import requirement_to_dict
+from .validate import validate
 
 # in-memory cache of requirement ids per directory
 _ID_CACHE: dict[Path, set[int]] = {}

--- a/app/core/validate.py
+++ b/app/core/validate.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from pathlib import Path
 from collections.abc import Iterable
+from pathlib import Path
 
 from .schema import validate as validate_schema
 

--- a/app/i18n.py
+++ b/app/i18n.py
@@ -7,9 +7,9 @@ the active language.
 """
 from __future__ import annotations
 
-from pathlib import Path
-from collections.abc import Iterable
 import threading
+from collections.abc import Iterable
+from pathlib import Path
 
 
 def _unescape(text: str) -> str:

--- a/app/llm/client.py
+++ b/app/llm/client.py
@@ -4,15 +4,15 @@ from __future__ import annotations
 
 import json
 import time
-from typing import Any
 from collections.abc import Mapping
+from typing import Any
+
+from ..settings import LLMSettings
 
 # ``OpenAI`` импортируется динамически в конструкторе, чтобы тесты могли
 # подменять ``openai.OpenAI`` до первого использования и тем самым избежать
 # реальных сетевых запросов.
-
 from ..telemetry import log_event
-from ..settings import LLMSettings
 from .spec import SYSTEM_PROMPT, TOOLS
 
 # When the backend does not require authentication, the official OpenAI client

--- a/app/main.py
+++ b/app/main.py
@@ -1,17 +1,17 @@
 """Application entry point for CookaReq."""
 
-import os
 import atexit
+import os
 from pathlib import Path
+
 import wx
 
-from .ui.main_frame import MainFrame
-from .log import configure_logging
-from .config import ConfigManager
-from .ui.requirement_model import RequirementModel
 from . import i18n
+from .config import ConfigManager
 from .confirm import set_confirm, wx_confirm
-
+from .log import configure_logging
+from .ui.main_frame import MainFrame
+from .ui.requirement_model import RequirementModel
 
 APP_NAME = "CookaReq"
 LOCALE_DIR = os.path.join(os.path.dirname(__file__), "locale")

--- a/app/mcp/client.py
+++ b/app/mcp/client.py
@@ -3,16 +3,15 @@
 from __future__ import annotations
 
 import json
-
 import time
+from collections.abc import Callable, Mapping
 from http.client import HTTPConnection
 from typing import Any
-from collections.abc import Mapping, Callable
 
 from ..i18n import _
+from ..settings import MCPSettings
 from ..telemetry import log_event
 from .utils import ErrorCode, mcp_error, sanitize
-from ..settings import MCPSettings
 
 
 class MCPClient:

--- a/app/mcp/controller.py
+++ b/app/mcp/controller.py
@@ -6,8 +6,9 @@ from dataclasses import dataclass
 from enum import Enum
 from http.client import HTTPConnection
 
-from .server import start_server, stop_server, is_running as server_is_running
 from ..settings import MCPSettings
+from .server import is_running as server_is_running
+from .server import start_server, stop_server
 
 
 class MCPStatus(str, Enum):

--- a/app/mcp/server.py
+++ b/app/mcp/server.py
@@ -13,15 +13,15 @@ import os
 import threading
 from collections.abc import Mapping
 
+import uvicorn
 from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
-import uvicorn
 from mcp.server.fastmcp import FastMCP
 
 from ..log import JsonlHandler, configure_logging, logger
 from ..util.time import utc_now_iso
-from .utils import ErrorCode, mcp_error, sanitize
 from . import tools_read, tools_write
+from .utils import ErrorCode, mcp_error, sanitize
 
 # Dedicated logger for MCP request logging so global handlers remain untouched
 request_logger = logger.getChild("mcp.requests")

--- a/app/mcp/tools_read.py
+++ b/app/mcp/tools_read.py
@@ -1,8 +1,8 @@
 """Utility functions for MCP requirement access."""
 from __future__ import annotations
 
-from pathlib import Path
 from collections.abc import Sequence
+from pathlib import Path
 
 from ..core import requirements as req_ops
 from ..core.model import Requirement, requirement_to_dict

--- a/app/mcp/tools_write.py
+++ b/app/mcp/tools_write.py
@@ -1,16 +1,17 @@
 """Requirement mutation utilities for MCP server."""
 from __future__ import annotations
 
+from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
-from collections.abc import Mapping
 
 import jsonpatch
 import jsonschema
-from ..core.schema import SCHEMA
-from ..core.model import requirement_from_dict, requirement_to_dict
-from ..core.store import ConflictError
+
 from ..core import requirements as req_ops
+from ..core.model import requirement_from_dict, requirement_to_dict
+from ..core.schema import SCHEMA
+from ..core.store import ConflictError
 from .utils import ErrorCode, log_tool, mcp_error
 
 # Fields that must not be modified directly through patching

--- a/app/mcp/utils.py
+++ b/app/mcp/utils.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from enum import Enum
 from typing import Any
-from collections.abc import Mapping
 
 from ..log import logger
 from ..telemetry import sanitize

--- a/app/settings.py
+++ b/app/settings.py
@@ -2,10 +2,11 @@
 
 from __future__ import annotations
 
-from pathlib import Path
 import json
+from pathlib import Path
+
 import tomllib
-from pydantic import BaseModel, ValidationError, Field, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
 
 class LLMSettings(BaseModel):

--- a/app/telemetry.py
+++ b/app/telemetry.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 import json
 import time
-from typing import Any
 from collections.abc import Mapping
+from typing import Any
 
 from .log import logger
 

--- a/app/ui/command_dialog.py
+++ b/app/ui/command_dialog.py
@@ -3,13 +3,13 @@
 from __future__ import annotations
 
 import json
-from dataclasses import dataclass, asdict
+from dataclasses import asdict, dataclass
 from pathlib import Path
-from ..i18n import _
 
 import wx
 
 from ..agent import LocalAgent
+from ..i18n import _
 
 
 @dataclass

--- a/app/ui/controllers/__init__.py
+++ b/app/ui/controllers/__init__.py
@@ -1,6 +1,6 @@
 """Controller classes for user interface operations."""
 
-from .requirements import RequirementsController
 from .labels import LabelsController
+from .requirements import RequirementsController
 
 __all__ = ["RequirementsController", "LabelsController"]

--- a/app/ui/controllers/labels.py
+++ b/app/ui/controllers/labels.py
@@ -6,8 +6,8 @@ from pathlib import Path
 
 from ...config import ConfigManager
 from ...core import requirements as req_ops
+from ...core.label_repository import FileLabelRepository, LabelRepository
 from ...core.labels import Label
-from ...core.label_repository import LabelRepository, FileLabelRepository
 from ...log import logger
 
 

--- a/app/ui/controllers/requirements.py
+++ b/app/ui/controllers/requirements.py
@@ -5,11 +5,10 @@ from __future__ import annotations
 from dataclasses import replace
 from pathlib import Path
 
-from ...i18n import _
-
 from ...config import ConfigManager
 from ...core.model import Requirement
-from ...core.repository import RequirementRepository, FileRequirementRepository
+from ...core.repository import FileRequirementRepository, RequirementRepository
+from ...i18n import _
 from ...log import logger
 
 

--- a/app/ui/derivation_graph.py
+++ b/app/ui/derivation_graph.py
@@ -7,13 +7,13 @@ packages are missing, a friendly message is shown instead of the graph.
 
 from __future__ import annotations
 
-from ..i18n import _
 import io
 from collections.abc import Sequence
 
 import wx
 
 from ..core.model import Requirement
+from ..i18n import _
 
 
 class DerivationGraphFrame(wx.Frame):

--- a/app/ui/editor_panel.py
+++ b/app/ui/editor_panel.py
@@ -1,11 +1,9 @@
 """Requirement editor panel."""
 from __future__ import annotations
 
+from contextlib import contextmanager
 from pathlib import Path
 from typing import Any, Callable
-from contextlib import contextmanager
-
-from ..i18n import _
 
 import wx
 import wx.adv
@@ -14,18 +12,19 @@ from wx.lib.scrolledpanel import ScrolledPanel
 from ..core import requirements as req_ops
 from ..core.labels import Label
 from ..core.model import (
+    Priority,
     Requirement,
     RequirementType,
     Status,
-    Priority,
     Verification,
     requirement_from_dict,
     requirement_to_dict,
 )
+from ..i18n import _
 from . import locale
-from .label_selection_dialog import LabelSelectionDialog
-from .helpers import HelpStaticBox, make_help_button, show_help
 from .enums import ENUMS
+from .helpers import HelpStaticBox, make_help_button, show_help
+from .label_selection_dialog import LabelSelectionDialog
 
 
 class EditorPanel(ScrolledPanel):

--- a/app/ui/enums.py
+++ b/app/ui/enums.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 
 from enum import Enum
 
+from ..core.model import Priority, RequirementType, Status, Verification
 from ..i18n import _
-from ..core.model import RequirementType, Status, Priority, Verification
 
 
 def _enum_label(e: Enum) -> str:

--- a/app/ui/filter_dialog.py
+++ b/app/ui/filter_dialog.py
@@ -1,12 +1,11 @@
 """Dialog for configuring requirement filters."""
 from __future__ import annotations
 
-from ..i18n import _
-
 import wx
 
 from ..core import requirements as req_ops
 from ..core.labels import Label
+from ..i18n import _
 from . import locale
 from .enums import ENUMS
 

--- a/app/ui/label_selection_dialog.py
+++ b/app/ui/label_selection_dialog.py
@@ -1,10 +1,9 @@
 """Dialog for selecting labels with color icons."""
-from ..i18n import _
-
 import wx
 from wx.lib.mixins.listctrl import CheckListCtrlMixin
 
 from ..core.labels import Label
+from ..i18n import _
 
 
 class _CheckListCtrl(wx.ListCtrl, CheckListCtrlMixin):

--- a/app/ui/labels_dialog.py
+++ b/app/ui/labels_dialog.py
@@ -1,12 +1,11 @@
 """Dialog for managing label colors."""
 
-from ..i18n import _
-from ..confirm import confirm
-
 import wx
 
-from ..core.labels import Label, PRESET_SETS, PRESET_SET_TITLES
 from ..config import ConfigManager
+from ..confirm import confirm
+from ..core.labels import PRESET_SET_TITLES, PRESET_SETS, Label
+from ..i18n import _
 
 
 class LabelsDialog(wx.Dialog):

--- a/app/ui/list_panel.py
+++ b/app/ui/list_panel.py
@@ -2,24 +2,23 @@
 
 from __future__ import annotations
 
-from ..i18n import _
+from collections.abc import Callable, Sequence
+from enum import Enum
+from typing import TYPE_CHECKING
 
 import wx
 from wx.lib.mixins.listctrl import ColumnSorterMixin
 
-from collections.abc import Callable, Sequence
-from typing import TYPE_CHECKING
-from enum import Enum
-
-from ..core.model import Requirement
 from ..core.labels import Label, _color_from_name
-from .requirement_model import RequirementModel
-from .filter_dialog import FilterDialog
+from ..core.model import Requirement
+from ..i18n import _
 from . import locale
 from .enums import ENUMS
+from .filter_dialog import FilterDialog
+from .requirement_model import RequirementModel
 
 if TYPE_CHECKING:  # pragma: no cover
-    from wx import ListEvent, ContextMenuEvent
+    from wx import ContextMenuEvent, ListEvent
 
 
 class ListPanel(wx.Panel, ColumnSorterMixin):

--- a/app/ui/main_frame.py
+++ b/app/ui/main_frame.py
@@ -1,34 +1,32 @@
 """Main application window."""
 
-from ..i18n import _
-
 import logging
+from dataclasses import fields, replace
 from importlib import resources
 from pathlib import Path
-from dataclasses import fields, replace
 
 import wx
 
-from ..log import logger
-
+from ..agent import LocalAgent
 from ..config import ConfigManager
+from ..confirm import confirm
 from ..core import requirements as req_ops
-from ..core.model import Requirement, DerivationLink
+from ..core.label_repository import FileLabelRepository
 from ..core.labels import Label
+from ..core.model import DerivationLink, Requirement
+from ..core.repository import FileRequirementRepository
+from ..i18n import _
+from ..log import logger
 from ..mcp.controller import MCPController
 from ..settings import AppSettings, LLMSettings, MCPSettings
-from ..agent import LocalAgent
-from ..confirm import confirm
-from .list_panel import ListPanel
-from .editor_panel import EditorPanel
-from .settings_dialog import SettingsDialog
-from .requirement_model import RequirementModel
-from .labels_dialog import LabelsDialog
-from .navigation import Navigation
 from .command_dialog import CommandDialog
-from .controllers import RequirementsController, LabelsController
-from ..core.repository import FileRequirementRepository
-from ..core.label_repository import FileLabelRepository
+from .controllers import LabelsController, RequirementsController
+from .editor_panel import EditorPanel
+from .labels_dialog import LabelsDialog
+from .list_panel import ListPanel
+from .navigation import Navigation
+from .requirement_model import RequirementModel
+from .settings_dialog import SettingsDialog
 
 
 class WxLogHandler(logging.Handler):

--- a/app/ui/navigation.py
+++ b/app/ui/navigation.py
@@ -2,15 +2,14 @@
 
 from __future__ import annotations
 
-from ..i18n import _
-from pathlib import Path
 from collections.abc import Callable
-
-from . import locale
+from pathlib import Path
 
 import wx
 
 from ..config import ConfigManager
+from ..i18n import _
+from . import locale
 
 
 class Navigation:

--- a/app/ui/requirement_model.py
+++ b/app/ui/requirement_model.py
@@ -2,8 +2,8 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
-from enum import Enum
 from dataclasses import asdict, is_dataclass
+from enum import Enum
 
 from ..core import requirements as req_ops
 from ..core.model import Requirement

--- a/app/ui/settings_dialog.py
+++ b/app/ui/settings_dialog.py
@@ -1,15 +1,15 @@
 """Dialog for application settings with MCP controls."""
 
-from ..i18n import _
 from importlib import resources
 
 import wx
 
-from .helpers import make_help_button
+from ..i18n import _
 from ..llm.client import LLMClient
 from ..mcp.client import MCPClient
 from ..mcp.controller import MCPController, MCPStatus
 from ..settings import LLMSettings, MCPSettings
+from .helpers import make_help_button
 
 LLM_HELP: dict[str, str] = {
     "base_url": _(

--- a/build.py
+++ b/build.py
@@ -4,9 +4,9 @@ This script generates a one-folder distribution in the ``dist``
 folder. It requires PyInstaller to be installed in the active
 environment.
 """
-from pathlib import Path
 import os
 import sys
+from pathlib import Path
 
 import PyInstaller.__main__  # type: ignore
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,20 @@ exclude = [
 ]
 
 [tool.ruff.lint]
-select = ["E9", "E741", "F63", "F7", "F82", "F401", "F841", "B", "UP"]
+select = [
+    "E9",
+    "E741",
+    "F63",
+    "F7",
+    "F82",
+    "F401",
+    "F841",
+    "B",
+    "UP",
+    "I",
+    "W",
+    "C4",
+]
 
 [build-system]
 requires = ["setuptools", "wheel"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,11 +8,13 @@ from pathlib import Path
 # Ensure project root is on sys.path for imports
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
+import socket
+
 import pytest
-from app.confirm import set_confirm, auto_confirm
+
+from app.confirm import auto_confirm, set_confirm
 from app.mcp.server import start_server, stop_server
 from tests.mcp_utils import _wait_until_ready
-import socket
 
 
 @pytest.fixture(autouse=True)

--- a/tests/gui/test_command_dialog.py
+++ b/tests/gui/test_command_dialog.py
@@ -1,6 +1,7 @@
 """Tests for command dialog."""
 
 import json
+
 import pytest
 
 from app.agent.local_agent import LocalAgent

--- a/tests/gui/test_confirm.py
+++ b/tests/gui/test_confirm.py
@@ -3,7 +3,7 @@
 import pytest
 
 from app import confirm as confirm_mod
-from app.confirm import set_confirm, auto_confirm, wx_confirm
+from app.confirm import auto_confirm, set_confirm, wx_confirm
 
 pytestmark = pytest.mark.gui
 

--- a/tests/gui/test_editor_panel.py
+++ b/tests/gui/test_editor_panel.py
@@ -1,11 +1,12 @@
 """Tests for editor panel."""
 
 import os
-import pytest
-from app.i18n import _
 
-from app.core.model import RequirementType, Status, Priority, Verification
+import pytest
+
 from app.core.labels import Label
+from app.core.model import Priority, RequirementType, Status, Verification
+from app.i18n import _
 
 pytestmark = pytest.mark.gui
 

--- a/tests/gui/test_editor_panel_gui.py
+++ b/tests/gui/test_editor_panel_gui.py
@@ -1,10 +1,11 @@
 """Tests for editor panel gui."""
 
-import pytest
 from dataclasses import asdict
 
-from app.core.model import RequirementType, Status, Priority, Verification
+import pytest
+
 from app.core.labels import Label
+from app.core.model import Priority, RequirementType, Status, Verification
 
 pytestmark = pytest.mark.gui
 

--- a/tests/gui/test_filter_dialog.py
+++ b/tests/gui/test_filter_dialog.py
@@ -1,6 +1,7 @@
+import pytest
+
 from app.core.labels import Label
 from app.ui.filter_dialog import FilterDialog
-import pytest
 
 pytestmark = pytest.mark.gui
 

--- a/tests/gui/test_gui.py
+++ b/tests/gui/test_gui.py
@@ -8,9 +8,9 @@ pytestmark = pytest.mark.gui
 def test_gui_imports(wx_app):
     pytest.importorskip("wx")
     from app.main import main
-    from app.ui.main_frame import MainFrame
-    from app.ui.list_panel import ListPanel
     from app.ui.editor_panel import EditorPanel
+    from app.ui.list_panel import ListPanel
+    from app.ui.main_frame import MainFrame
 
     frame = MainFrame(None)
     list_panel = ListPanel(frame)

--- a/tests/gui/test_help_static_box.py
+++ b/tests/gui/test_help_static_box.py
@@ -1,7 +1,7 @@
+import pytest
 import wx
 
 from app.ui.helpers import HelpStaticBox
-import pytest
 
 pytestmark = pytest.mark.gui
 

--- a/tests/gui/test_labels_dialog.py
+++ b/tests/gui/test_labels_dialog.py
@@ -46,8 +46,8 @@ def test_labels_dialog_displays_color_rect(wx_app):
 
 def test_labels_dialog_adds_presets(wx_app):
     pytest.importorskip("wx")
-    from app.ui.labels_dialog import LabelsDialog
     from app.core.labels import PRESET_SETS
+    from app.ui.labels_dialog import LabelsDialog
 
     dlg = LabelsDialog(None, [])
     dlg._on_add_preset_set("basic")

--- a/tests/gui/test_labels_sync.py
+++ b/tests/gui/test_labels_sync.py
@@ -1,7 +1,8 @@
 """Tests for labels sync."""
 
 import pytest
-from app.core import store, label_store
+
+from app.core import label_store, store
 from app.core.labels import PRESET_SETS
 
 pytestmark = pytest.mark.gui

--- a/tests/gui/test_link_column_width.py
+++ b/tests/gui/test_link_column_width.py
@@ -1,8 +1,9 @@
-import wx
-from app.ui.editor_panel import EditorPanel
-from app.core.model import Requirement, RequirementType, Status, Priority, Verification
-from app.core import requirements as req_ops
 import pytest
+import wx
+
+from app.core import requirements as req_ops
+from app.core.model import Priority, Requirement, RequirementType, Status, Verification
+from app.ui.editor_panel import EditorPanel
 
 pytestmark = pytest.mark.gui
 

--- a/tests/gui/test_link_titles.py
+++ b/tests/gui/test_link_titles.py
@@ -1,8 +1,9 @@
-import wx
-from app.ui.editor_panel import EditorPanel
-from app.core.model import Requirement, RequirementType, Status, Priority, Verification
-from app.core import requirements as req_ops
 import pytest
+import wx
+
+from app.core import requirements as req_ops
+from app.core.model import Priority, Requirement, RequirementType, Status, Verification
+from app.ui.editor_panel import EditorPanel
 
 pytestmark = pytest.mark.gui
 

--- a/tests/gui/test_links_visibility.py
+++ b/tests/gui/test_links_visibility.py
@@ -1,6 +1,7 @@
-import wx
-from app.ui.editor_panel import EditorPanel
 import pytest
+import wx
+
+from app.ui.editor_panel import EditorPanel
 
 pytestmark = pytest.mark.gui
 

--- a/tests/gui/test_list_panel.py
+++ b/tests/gui/test_list_panel.py
@@ -1,11 +1,12 @@
 """Tests for list panel."""
 
+import importlib
 import sys
 import types
-import importlib
 
-from app.core.model import Requirement, RequirementType, Status, Priority, Verification
 import pytest
+
+from app.core.model import Priority, Requirement, RequirementType, Status, Verification
 
 pytestmark = pytest.mark.gui
 
@@ -362,17 +363,17 @@ def _build_wx_stub():
 
 
 def _req(id: int, title: str, **kwargs) -> Requirement:
-    base = dict(
-        id=id,
-        title=title,
-        statement="",
-        type=RequirementType.REQUIREMENT,
-        status=Status.DRAFT,
-        owner="",
-        priority=Priority.MEDIUM,
-        source="",
-        verification=Verification.ANALYSIS,
-    )
+    base = {
+        "id": id,
+        "title": title,
+        "statement": "",
+        "type": RequirementType.REQUIREMENT,
+        "status": Status.DRAFT,
+        "owner": "",
+        "priority": Priority.MEDIUM,
+        "source": "",
+        "verification": Verification.ANALYSIS,
+    }
     base.update(kwargs)
     return Requirement(**base)
 

--- a/tests/gui/test_list_panel_gui.py
+++ b/tests/gui/test_list_panel_gui.py
@@ -1,31 +1,33 @@
 """Tests for list panel gui."""
 
 import importlib
+
 import pytest
+
 from app.core.model import (
+    DerivationLink,
+    Priority,
     Requirement,
     RequirementType,
     Status,
-    Priority,
     Verification,
-    DerivationLink,
 )
 
 pytestmark = pytest.mark.gui
 
 
 def _req(id: int, title: str, **kwargs) -> Requirement:
-    base = dict(
-        id=id,
-        title=title,
-        statement="",
-        type=RequirementType.REQUIREMENT,
-        status=Status.DRAFT,
-        owner="",
-        priority=Priority.MEDIUM,
-        source="",
-        verification=Verification.ANALYSIS,
-    )
+    base = {
+        "id": id,
+        "title": title,
+        "statement": "",
+        "type": RequirementType.REQUIREMENT,
+        "status": Status.DRAFT,
+        "owner": "",
+        "priority": Priority.MEDIUM,
+        "source": "",
+        "verification": Verification.ANALYSIS,
+    }
     base.update(kwargs)
     return Requirement(**base)
 

--- a/tests/gui/test_main.py
+++ b/tests/gui/test_main.py
@@ -1,8 +1,9 @@
 """Tests for main."""
 
+import importlib
 import sys
 import types
-import importlib
+
 import pytest
 
 pytestmark = pytest.mark.gui

--- a/tests/gui/test_main_frame_gui.py
+++ b/tests/gui/test_main_frame_gui.py
@@ -1,8 +1,9 @@
 """Tests for main frame gui."""
 
 import importlib
-import pytest
 import logging
+
+import pytest
 
 pytestmark = pytest.mark.gui
 
@@ -146,8 +147,8 @@ def test_log_handler_not_duplicated(tmp_path, wx_app):
 
 def test_log_console_shows_label(wx_app):
     wx = pytest.importorskip("wx")
-    from app.i18n import _
     import app.ui.main_frame as main_frame
+    from app.i18n import _
 
     frame = main_frame.MainFrame(None)
     frame.navigation.log_menu_item.Check(True)
@@ -211,8 +212,9 @@ def test_main_frame_loads_requirements(monkeypatch, tmp_path, wx_app):
 
 def test_main_frame_select_opens_editor(monkeypatch, tmp_path, wx_app):
     wx = pytest.importorskip("wx")
-    from app.core.store import save
     import importlib
+
+    from app.core.store import save
 
     data = {
         "id": 1,
@@ -309,8 +311,8 @@ def _prepare_frame(monkeypatch, tmp_path):
 
 
 def test_main_frame_clone_requirement_creates_copy(monkeypatch, tmp_path, wx_app):
-    from app.core.store import save
     from app import i18n
+    from app.core.store import save
     from app.main import APP_NAME, LOCALE_DIR
 
     i18n.install(APP_NAME, LOCALE_DIR, ["en"])

--- a/tests/gui/test_main_frame_llm_integration.py
+++ b/tests/gui/test_main_frame_llm_integration.py
@@ -5,11 +5,11 @@ from pathlib import Path
 
 import pytest
 
-from app.mcp.server import app as mcp_app
-from app.settings import MCPSettings, LLMSettings
-from tests.llm_utils import make_openai_mock, settings_with_llm
-import app.ui.main_frame as main_frame
 import app.ui.command_dialog as cmd
+import app.ui.main_frame as main_frame
+from app.mcp.server import app as mcp_app
+from app.settings import LLMSettings, MCPSettings
+from tests.llm_utils import make_openai_mock, settings_with_llm
 
 pytestmark = [pytest.mark.gui, pytest.mark.integration]
 

--- a/tests/gui/test_recent_dirs.py
+++ b/tests/gui/test_recent_dirs.py
@@ -1,6 +1,7 @@
 """Tests for recent dirs."""
 
 import importlib
+
 import pytest
 
 pytestmark = pytest.mark.gui

--- a/tests/gui/test_settings_dialog.py
+++ b/tests/gui/test_settings_dialog.py
@@ -60,9 +60,9 @@ def test_settings_dialog_returns_language(wx_app):
 
 def test_mcp_start_stop_server(monkeypatch, wx_app):
     wx = pytest.importorskip("wx")
-    from app.ui.settings_dialog import SettingsDialog
     import app.ui.settings_dialog as sd
-    from app.mcp.controller import MCPStatus, MCPCheckResult
+    from app.mcp.controller import MCPCheckResult, MCPStatus
+    from app.ui.settings_dialog import SettingsDialog
 
     class FakeMCP:
         def __init__(self) -> None:
@@ -134,9 +134,9 @@ def test_mcp_start_stop_server(monkeypatch, wx_app):
 
 def test_mcp_check_status(monkeypatch, wx_app):
     wx = pytest.importorskip("wx")
-    from app.ui.settings_dialog import SettingsDialog
     import app.ui.settings_dialog as sd
-    from app.mcp.controller import MCPStatus, MCPCheckResult
+    from app.mcp.controller import MCPCheckResult, MCPStatus
+    from app.ui.settings_dialog import SettingsDialog
 
     class DummyMCP:
         def __init__(self):
@@ -198,8 +198,8 @@ def test_mcp_check_status(monkeypatch, wx_app):
 
 def test_llm_agent_checks(monkeypatch, wx_app):
     wx = pytest.importorskip("wx")
-    from app.ui.settings_dialog import SettingsDialog
     import app.ui.settings_dialog as sd
+    from app.ui.settings_dialog import SettingsDialog
 
     class DummyLLM:
         def __init__(self, *, settings):
@@ -251,8 +251,8 @@ def test_llm_agent_checks(monkeypatch, wx_app):
 
 def test_settings_help_buttons(monkeypatch, wx_app):
     wx = pytest.importorskip("wx")
-    from app.ui.settings_dialog import SettingsDialog, LLM_HELP, MCP_HELP
     from app.ui import helpers
+    from app.ui.settings_dialog import LLM_HELP, MCP_HELP, SettingsDialog
 
     shown: list[str] = []
     monkeypatch.setattr(helpers, "show_help", lambda parent, msg: shown.append(msg))

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -7,10 +7,11 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
+from app.cli.main import main
 from app.core.store import save
 from app.settings import AppSettings
-from app.cli.main import main
-import pytest
 
 pytestmark = pytest.mark.integration
 

--- a/tests/integration/test_health_endpoint.py
+++ b/tests/integration/test_health_endpoint.py
@@ -4,8 +4,9 @@ import pytest
 pytestmark = pytest.mark.integration
 
 def test_health_endpoint_returns_ok():
-    from app.mcp.server import app
     from fastapi.testclient import TestClient
+
+    from app.mcp.server import app
 
     client = TestClient(app)
     resp = client.get('/health')

--- a/tests/integration/test_llm_client.py
+++ b/tests/integration/test_llm_client.py
@@ -3,15 +3,15 @@
 import json
 import logging
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
+from app.llm.client import NO_API_KEY, LLMClient
 from app.log import logger
-from app.llm.client import LLMClient, NO_API_KEY
 from app.mcp.server import JsonlHandler
-from tests.llm_utils import make_openai_mock, settings_with_llm
 from app.settings import LLMSettings
-from types import SimpleNamespace
+from tests.llm_utils import make_openai_mock, settings_with_llm
 
 pytestmark = pytest.mark.integration
 

--- a/tests/integration/test_llm_openrouter_integration.py
+++ b/tests/integration/test_llm_openrouter_integration.py
@@ -3,8 +3,8 @@ from pathlib import Path
 
 import pytest
 
-from tests.llm_utils import settings_with_llm
 from app.llm.client import LLMClient
+from tests.llm_utils import settings_with_llm
 
 pytestmark = pytest.mark.integration
 

--- a/tests/integration/test_local_agent.py
+++ b/tests/integration/test_local_agent.py
@@ -4,8 +4,8 @@ import pytest
 
 from app.agent import local_agent as la
 from app.agent.local_agent import LocalAgent
-from app.settings import AppSettings
 from app.mcp.utils import ErrorCode
+from app.settings import AppSettings
 
 pytestmark = pytest.mark.integration
 

--- a/tests/integration/test_mcp_auth.py
+++ b/tests/integration/test_mcp_auth.py
@@ -1,8 +1,9 @@
 """Tests for mcp auth."""
 
+import pytest
+
 from app.mcp.server import start_server, stop_server
 from tests.mcp_utils import _request, _wait_until_ready
-import pytest
 
 pytestmark = pytest.mark.integration
 

--- a/tests/integration/test_mcp_client.py
+++ b/tests/integration/test_mcp_client.py
@@ -4,13 +4,14 @@ import json
 import logging
 from pathlib import Path
 
+import pytest
+
 from app.log import logger
 from app.mcp.client import MCPClient
 from app.mcp.server import JsonlHandler, start_server, stop_server
 from app.settings import MCPSettings
 from tests.llm_utils import settings_with_mcp
 from tests.mcp_utils import _wait_until_ready
-import pytest
 
 pytestmark = pytest.mark.integration
 

--- a/tests/integration/test_mcp_http_tools.py
+++ b/tests/integration/test_mcp_http_tools.py
@@ -6,10 +6,11 @@ import json
 from http.client import HTTPConnection
 from pathlib import Path
 
-from app.mcp.server import start_server, stop_server
-from app.core import store
-from tests.mcp_utils import _wait_until_ready
 import pytest
+
+from app.core import store
+from app.mcp.server import start_server, stop_server
+from tests.mcp_utils import _wait_until_ready
 
 pytestmark = pytest.mark.integration
 

--- a/tests/integration/test_mcp_llm_integration.py
+++ b/tests/integration/test_mcp_llm_integration.py
@@ -4,11 +4,13 @@ import json
 import logging
 from pathlib import Path
 
-from app.log import logger
-from app.agent import LocalAgent
-from app.mcp.server import JsonlHandler, app as mcp_app
-from tests.llm_utils import make_openai_mock, settings_with_mcp
 import pytest
+
+from app.agent import LocalAgent
+from app.log import logger
+from app.mcp.server import JsonlHandler
+from app.mcp.server import app as mcp_app
+from tests.llm_utils import make_openai_mock, settings_with_mcp
 
 pytestmark = pytest.mark.integration
 

--- a/tests/integration/test_mcp_logging.py
+++ b/tests/integration/test_mcp_logging.py
@@ -4,9 +4,10 @@ import json
 import os
 from tempfile import TemporaryDirectory
 
+import pytest
+
 from app.mcp.server import start_server, stop_server
 from tests.mcp_utils import _request, _wait_until_ready
-import pytest
 
 pytestmark = pytest.mark.integration
 

--- a/tests/integration/test_mcp_server.py
+++ b/tests/integration/test_mcp_server.py
@@ -2,9 +2,10 @@
 
 import json
 
+import pytest
+
 from app.mcp.server import start_server, stop_server
 from tests.mcp_utils import _request, _wait_until_ready
-import pytest
 
 pytestmark = pytest.mark.integration
 

--- a/tests/integration/test_mcp_text_commands.py
+++ b/tests/integration/test_mcp_text_commands.py
@@ -4,11 +4,13 @@ import json
 import logging
 from pathlib import Path
 
-from app.log import logger
-from app.agent import LocalAgent
-from app.mcp.server import JsonlHandler, app as mcp_app
-from tests.llm_utils import make_openai_mock, settings_with_mcp
 import pytest
+
+from app.agent import LocalAgent
+from app.log import logger
+from app.mcp.server import JsonlHandler
+from app.mcp.server import app as mcp_app
+from tests.llm_utils import make_openai_mock, settings_with_mcp
 
 pytestmark = pytest.mark.integration
 
@@ -41,7 +43,7 @@ def test_run_command_list_logs(tmp_path: Path, monkeypatch, mcp_server) -> None:
     entries = [json.loads(line) for line in log_file.read_text().splitlines()]
     events = {e.get("event") for e in entries}
     assert {"LLM_REQUEST", "LLM_RESPONSE", "TOOL_CALL", "TOOL_RESULT", "DONE"} <= events
-    
+
 
 
 def test_run_command_error_logs(tmp_path: Path, monkeypatch, mcp_server) -> None:

--- a/tests/integration/test_mcp_tools.py
+++ b/tests/integration/test_mcp_tools.py
@@ -2,10 +2,11 @@
 
 from pathlib import Path
 
-from app.core import store
-from app.mcp.tools_read import list_requirements, get_requirement, search_requirements
-from app.mcp.utils import ErrorCode
 import pytest
+
+from app.core import store
+from app.mcp.tools_read import get_requirement, list_requirements, search_requirements
+from app.mcp.utils import ErrorCode
 
 pytestmark = pytest.mark.integration
 

--- a/tests/integration/test_tool_logging.py
+++ b/tests/integration/test_tool_logging.py
@@ -1,15 +1,15 @@
 """Tests for tool logging."""
 
 import json
+import logging
 from pathlib import Path
 
-import logging
+import pytest
 
 from app.log import logger
 from app.mcp.server import JsonlHandler
 from app.mcp.tools_read import list_requirements
 from app.mcp.utils import log_tool
-import pytest
 
 pytestmark = pytest.mark.integration
 

--- a/tests/slow/test_pydocstyle.py
+++ b/tests/slow/test_pydocstyle.py
@@ -1,5 +1,6 @@
 import subprocess
 import sys
+
 import pytest
 
 pytestmark = pytest.mark.slow

--- a/tests/slow/test_ruff.py
+++ b/tests/slow/test_ruff.py
@@ -1,5 +1,6 @@
 import subprocess
 import sys
+
 import pytest
 
 pytestmark = pytest.mark.slow

--- a/tests/slow/test_translation_coverage.py
+++ b/tests/slow/test_translation_coverage.py
@@ -1,7 +1,8 @@
 """Tests for translation coverage."""
 
-import polib
 from pathlib import Path
+
+import polib
 import pytest
 
 pytestmark = pytest.mark.slow

--- a/tests/unit/test_config_manager.py
+++ b/tests/unit/test_config_manager.py
@@ -3,7 +3,7 @@
 import pytest
 
 from app.config import ConfigManager
-from app.settings import LLMSettings, MCPSettings, UISettings, AppSettings
+from app.settings import AppSettings, LLMSettings, MCPSettings, UISettings
 
 pytestmark = pytest.mark.unit
 

--- a/tests/unit/test_config_manager_proxies.py
+++ b/tests/unit/test_config_manager_proxies.py
@@ -1,7 +1,8 @@
 """Tests for config manager proxies."""
 
-from app.config import ConfigManager
 import pytest
+
+from app.config import ConfigManager
 
 pytestmark = pytest.mark.unit
 

--- a/tests/unit/test_derived_requirements.py
+++ b/tests/unit/test_derived_requirements.py
@@ -1,12 +1,14 @@
 """Tests for derived requirements."""
 
 from __future__ import annotations
+
 from pathlib import Path
 
-from app.core.store import save, load, filename_for
+import pytest
+
 from app.core.model import Requirement, requirement_from_dict
 from app.core.search import search
-import pytest
+from app.core.store import filename_for, load, save
 
 pytestmark = pytest.mark.unit
 

--- a/tests/unit/test_hashing.py
+++ b/tests/unit/test_hashing.py
@@ -1,7 +1,8 @@
 """Tests for hashing."""
 
-from app.util.hashing import id_to_hash
 import pytest
+
+from app.util.hashing import id_to_hash
 
 pytestmark = pytest.mark.unit
 

--- a/tests/unit/test_i18n.py
+++ b/tests/unit/test_i18n.py
@@ -1,7 +1,8 @@
 """Tests for i18n."""
 
-from app import i18n
 import pytest
+
+from app import i18n
 
 pytestmark = pytest.mark.unit
 

--- a/tests/unit/test_i18n_escape.py
+++ b/tests/unit/test_i18n_escape.py
@@ -1,7 +1,8 @@
 """Tests for i18n escape."""
 
-from app import i18n
 import pytest
+
+from app import i18n
 
 pytestmark = pytest.mark.unit
 

--- a/tests/unit/test_labels.py
+++ b/tests/unit/test_labels.py
@@ -1,10 +1,12 @@
 """Tests for labels."""
 
-from app.core.labels import Label, add_label, get_label, update_label, delete_label
+from pathlib import Path
+
+import pytest
+
 from app.core import label_store
 from app.core.label_repository import FileLabelRepository
-from pathlib import Path
-import pytest
+from app.core.labels import Label, add_label, delete_label, get_label, update_label
 
 pytestmark = pytest.mark.unit
 

--- a/tests/unit/test_locale.py
+++ b/tests/unit/test_locale.py
@@ -1,10 +1,10 @@
 """Tests for locale."""
 
 import pytest
-from app.i18n import _, install
 
-from app.ui import locale
 from app.core import model
+from app.i18n import _, install
+from app.ui import locale
 
 pytestmark = pytest.mark.unit
 

--- a/tests/unit/test_logging_config.py
+++ b/tests/unit/test_logging_config.py
@@ -1,6 +1,7 @@
 """Tests for logging config."""
 
 import logging
+
 import pytest
 
 from app.log import configure_logging, logger

--- a/tests/unit/test_missing_translations.py
+++ b/tests/unit/test_missing_translations.py
@@ -1,8 +1,10 @@
 """Tests for missing translations."""
 
 import threading
-from app import i18n
+
 import pytest
+
+from app import i18n
 
 pytestmark = pytest.mark.unit
 

--- a/tests/unit/test_model.py
+++ b/tests/unit/test_model.py
@@ -1,5 +1,7 @@
 """Tests for model."""
 
+import pytest
+
 from app.core.model import (
     Priority,
     Requirement,
@@ -9,7 +11,6 @@ from app.core.model import (
     requirement_from_dict,
     requirement_to_dict,
 )
-import pytest
 
 pytestmark = pytest.mark.unit
 

--- a/tests/unit/test_requirement_model.py
+++ b/tests/unit/test_requirement_model.py
@@ -1,8 +1,9 @@
 """Tests for requirement model."""
 
 import pytest
+
+from app.core.model import Priority, Requirement, RequirementType, Status, Verification
 from app.ui.requirement_model import RequirementModel
-from app.core.model import Requirement, RequirementType, Status, Priority, Verification
 
 pytestmark = pytest.mark.unit
 

--- a/tests/unit/test_requirement_ops.py
+++ b/tests/unit/test_requirement_ops.py
@@ -1,17 +1,18 @@
 """Tests for requirement ops."""
 
-import pytest
 from pathlib import Path
 
+import pytest
+
 import app.mcp.tools_write as tools_write
+from app.core.store import filename_for, load
 from app.mcp.tools_write import (
     create_requirement,
-    patch_requirement,
     delete_requirement,
     link_requirements,
+    patch_requirement,
 )
 from app.mcp.utils import ErrorCode
-from app.core.store import load, filename_for
 
 pytestmark = pytest.mark.unit
 

--- a/tests/unit/test_search.py
+++ b/tests/unit/test_search.py
@@ -1,13 +1,16 @@
 """Tests for search."""
 
+import pytest
+
 from app.core.model import (
+    DerivationLink,
     Priority,
     Requirement,
     RequirementType,
     Status,
     Verification,
-    DerivationLink,
 )
+from app.core.requirements import filter_by_status
 from app.core.search import (
     filter_by_labels,
     filter_has_derived,
@@ -15,8 +18,6 @@ from app.core.search import (
     search,
     search_text,
 )
-from app.core.requirements import filter_by_status
-import pytest
 
 pytestmark = pytest.mark.unit
 

--- a/tests/unit/test_settings_validation.py
+++ b/tests/unit/test_settings_validation.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+
 import pytest
 
 from app.settings import load_app_settings

--- a/tests/unit/test_store.py
+++ b/tests/unit/test_store.py
@@ -17,11 +17,11 @@ from app.core.model import (
 )
 from app.core.store import (
     ConflictError,
+    _scan_ids,
+    delete,
     filename_for,
     load,
     save,
-    delete,
-    _scan_ids,
 )
 
 pytestmark = pytest.mark.unit
@@ -81,7 +81,7 @@ def test_scan_ids_skips_invalid_and_labels(tmp_path: Path):
 def test_save_accepts_dataclass(tmp_path: Path):
     req = Requirement(
         id=10,
-        title="Dataclass", 
+        title="Dataclass",
         statement="Save dataclass",
         type=RequirementType.REQUIREMENT,
         status=Status.DRAFT,

--- a/tests/unit/test_telemetry.py
+++ b/tests/unit/test_telemetry.py
@@ -4,10 +4,11 @@ import json
 import logging
 from pathlib import Path
 
+import pytest
+
 import app.telemetry as telemetry
 from app.log import JsonlHandler, logger
 from app.telemetry import REDACTED, log_event, sanitize
-import pytest
 
 pytestmark = pytest.mark.unit
 

--- a/tests/unit/test_validate.py
+++ b/tests/unit/test_validate.py
@@ -1,6 +1,7 @@
 """Tests for validate."""
 
 import json
+
 import pytest
 
 from app.core.store import load_index


### PR DESCRIPTION
## Summary
- add `I`, `W`, `C4` to Ruff rule set
- sort imports and remove trailing whitespace
- replace unnecessary `dict()` calls with literals

## Testing
- `python3 -m ruff check .`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c699ca40d88320a53f89be5c19ec0e