### PR TITLE
Expand Ruff lint rules and refactor code

### DIFF
--- a/app/cli/commands.py
+++ b/app/cli/commands.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 import json
 import sys
+from contextlib import suppress
 from dataclasses import dataclass
 from typing import Callable
 
@@ -84,10 +85,8 @@ def cmd_edit(args: argparse.Namespace, repo: RequirementRepository) -> None:
         print(_("Invalid requirement data: {error}").format(error=exc))
         return
     mtime = None
-    try:
+    with suppress(FileNotFoundError):
         mtime = repo.load(args.directory, obj.id)[1]
-    except FileNotFoundError:
-        pass
     path = repo.save(args.directory, obj, mtime=mtime, modified_at=args.modified_at)
     print(path)
 

--- a/app/core/requirements.py
+++ b/app/core/requirements.py
@@ -98,10 +98,7 @@ def save_requirement(
     modified_at: str | None = None,
 ):
     """Persist ``data`` as requirement in ``directory`` and return file path."""
-    if isinstance(data, Requirement):
-        obj = data
-    else:
-        obj = requirement_from_dict(dict(data))
+    obj = data if isinstance(data, Requirement) else requirement_from_dict(dict(data))
     obj.modified_at = (
         normalize_timestamp(modified_at) if modified_at else local_now_str()
     )

--- a/app/core/store.py
+++ b/app/core/store.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import json
+from contextlib import suppress
 from dataclasses import is_dataclass
 from pathlib import Path
 
@@ -135,10 +136,8 @@ def delete(directory: str | Path, req_id: int) -> None:
     """Remove requirement ``req_id`` from ``directory`` and update cache."""
     directory = Path(directory)
     path = directory / filename_for(req_id)
-    try:
+    with suppress(FileNotFoundError):
         path.unlink()
-    except FileNotFoundError:
-        pass
     remove_from_index(directory, req_id)
 
 

--- a/app/log.py
+++ b/app/log.py
@@ -42,5 +42,5 @@ def configure_logging(level: int = logging.INFO) -> None:
     logger.setLevel(level)
 
 
-__all__ = ["logger", "configure_logging", "JsonlHandler"]
+__all__ = ["JsonlHandler", "configure_logging", "logger"]
 

--- a/app/main.py
+++ b/app/main.py
@@ -24,10 +24,7 @@ def init_locale(language: str | None = None) -> wx.Locale:
     wx.Locale.AddCatalogLookupPathPrefix(LOCALE_DIR)
     if language and hasattr(wx.Locale, "FindLanguageInfo"):
         info = wx.Locale.FindLanguageInfo(language)
-        if info:
-            locale = wx.Locale(info.Language)
-        else:  # fallback to system default if code is unknown
-            locale = wx.Locale(wx.LANGUAGE_DEFAULT)
+        locale = wx.Locale(info.Language) if info else wx.Locale(wx.LANGUAGE_DEFAULT)
     else:
         locale = wx.Locale(wx.LANGUAGE_DEFAULT)
     locale.AddCatalog(APP_NAME)

--- a/app/settings.py
+++ b/app/settings.py
@@ -67,10 +67,7 @@ def load_app_settings(path: str | Path) -> AppSettings:
 
     p = Path(path)
     with p.open("rb") as fh:
-        if p.suffix.lower() == ".toml":
-            data = tomllib.load(fh)
-        else:
-            data = json.load(fh)
+        data = tomllib.load(fh) if p.suffix.lower() == ".toml" else json.load(fh)
     try:
         return AppSettings.model_validate(data)
     except ValidationError as exc:  # pragma: no cover - exercised via tests

--- a/app/ui/controllers/__init__.py
+++ b/app/ui/controllers/__init__.py
@@ -3,4 +3,4 @@
 from .labels import LabelsController
 from .requirements import RequirementsController
 
-__all__ = ["RequirementsController", "LabelsController"]
+__all__ = ["LabelsController", "RequirementsController"]

--- a/app/ui/controllers/requirements.py
+++ b/app/ui/controllers/requirements.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from contextlib import suppress
 from dataclasses import replace
 from pathlib import Path
 
@@ -79,8 +80,6 @@ class RequirementsController:
         if not req:
             return False
         self.model.delete(req_id)
-        try:
+        with suppress(Exception):
             self.repo.delete(self.directory, req.id)
-        except Exception:
-            pass
         return True

--- a/app/ui/main_frame.py
+++ b/app/ui/main_frame.py
@@ -529,7 +529,7 @@ class MainFrame(wx.Frame):
         link = DerivationLink(
             source_id=source.id, source_revision=source.revision, suspect=False
         )
-        clone.derived_from = list(source.derived_from) + [link]
+        clone.derived_from = [*source.derived_from, link]
         clone.derivation = None
         return clone
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,12 @@ select = [
     "I",
     "W",
     "C4",
+    "A",
+    "SIM",
+    "RUF",
 ]
+
+ignore = ["RUF001", "RUF003"]
 
 [build-system]
 requires = ["setuptools", "wheel"]

--- a/tests/gui/test_command_dialog.py
+++ b/tests/gui/test_command_dialog.py
@@ -31,7 +31,7 @@ def test_command_dialog_shows_result_and_saves_history(tmp_path, wx_app):
     assert dlg.history_list.GetCount() == 1
     saved = json.loads(history_file.read_text())
     assert saved[0]["command"] == "run"
-    assert saved[0]["tokens"] == len("run".split()) + len(dlg.output.GetValue().split())
+    assert saved[0]["tokens"] == len(["run"]) + len(dlg.output.GetValue().split())
 
     # clear and reload from history
     dlg._on_clear(None)
@@ -62,7 +62,7 @@ def test_command_dialog_shows_error(tmp_path, wx_app):
     dlg.input.SetValue("run")
     dlg._on_run(None)
     assert "FAIL" in dlg.output.GetValue()
-    assert dlg.history[0].tokens == len("run".split()) + len(dlg.output.GetValue().split())
+    assert dlg.history[0].tokens == len(["run"]) + len(dlg.output.GetValue().split())
     dlg.Destroy()
 
 

--- a/tests/gui/test_list_panel.py
+++ b/tests/gui/test_list_panel.py
@@ -362,9 +362,9 @@ def _build_wx_stub():
     return wx_mod, mixins_mod, ulc_mod
 
 
-def _req(id: int, title: str, **kwargs) -> Requirement:
+def _req(req_id: int, title: str, **kwargs) -> Requirement:
     base = {
-        "id": id,
+        "id": req_id,
         "title": title,
         "statement": "",
         "type": RequirementType.REQUIREMENT,

--- a/tests/gui/test_list_panel_gui.py
+++ b/tests/gui/test_list_panel_gui.py
@@ -16,9 +16,9 @@ from app.core.model import (
 pytestmark = pytest.mark.gui
 
 
-def _req(id: int, title: str, **kwargs) -> Requirement:
+def _req(req_id: int, title: str, **kwargs) -> Requirement:
     base = {
-        "id": id,
+        "id": req_id,
         "title": title,
         "statement": "",
         "type": RequirementType.REQUIREMENT,

--- a/tests/gui/test_main.py
+++ b/tests/gui/test_main.py
@@ -3,6 +3,7 @@
 import importlib
 import sys
 import types
+from typing import ClassVar
 
 import pytest
 
@@ -42,7 +43,7 @@ def test_main_runs(monkeypatch):
     monkeypatch.setitem(sys.modules, "wx", wx_stub)
 
     class DummyFrame:
-        instances = []
+        instances: ClassVar[list] = []
         shown = False
 
         def __init__(self, parent):

--- a/tests/gui/test_main_frame_gui.py
+++ b/tests/gui/test_main_frame_gui.py
@@ -320,7 +320,7 @@ def test_main_frame_clone_requirement_creates_copy(monkeypatch, tmp_path, wx_app
     data = _sample_requirement()
     save(tmp_path, data)
 
-    wx, frame = _prepare_frame(monkeypatch, tmp_path)
+    _wx, frame = _prepare_frame(monkeypatch, tmp_path)
 
     frame.on_clone_requirement(frame.model.get_all()[0].id)
 
@@ -353,7 +353,7 @@ def test_main_frame_delete_requirement_removes_file(monkeypatch, tmp_path, wx_ap
     data = _sample_requirement()
     path = save(tmp_path, data)
 
-    wx, frame = _prepare_frame(monkeypatch, tmp_path)
+    _wx, frame = _prepare_frame(monkeypatch, tmp_path)
 
     assert path.exists()
     assert frame.panel.list.GetItemCount() == 1
@@ -371,7 +371,7 @@ def test_main_frame_select_any_column_updates_editor(monkeypatch, tmp_path, wx_a
 
     save(tmp_path, _sample_requirement())
 
-    wx, frame = _prepare_frame(monkeypatch, tmp_path)
+    _wx, frame = _prepare_frame(monkeypatch, tmp_path)
 
     # Add an extra column so clicks on it should still update the editor
     frame.panel.set_columns(["id"])

--- a/tests/integration/test_mcp_tools.py
+++ b/tests/integration/test_mcp_tools.py
@@ -47,7 +47,7 @@ def test_list_requirements_filters_and_paginates(tmp_path: Path) -> None:
 
 def test_list_requirements_errors(tmp_path: Path, monkeypatch) -> None:
     # directory missing
-    def not_found(_):  # noqa: ANN001
+    def not_found(_):
         raise FileNotFoundError
 
     monkeypatch.setattr("app.core.requirements.load_all", not_found)
@@ -55,7 +55,7 @@ def test_list_requirements_errors(tmp_path: Path, monkeypatch) -> None:
     assert err["error"]["code"] == ErrorCode.NOT_FOUND
 
     # internal error
-    def boom(_):  # noqa: ANN001
+    def boom(_):
         raise RuntimeError("boom")
 
     monkeypatch.setattr("app.core.requirements.load_all", boom)
@@ -75,7 +75,7 @@ def test_get_requirement_errors(tmp_path: Path, monkeypatch) -> None:
     err = get_requirement(tmp_path, 99)
     assert err["error"]["code"] == ErrorCode.NOT_FOUND
 
-    def boom(*args, **kwargs):  # noqa: ANN001, ANN002
+    def boom(*args, **kwargs):
         raise RuntimeError("boom")
 
     monkeypatch.setattr("app.core.requirements.load_requirement", boom)
@@ -96,14 +96,14 @@ def test_search_requirements(tmp_path: Path) -> None:
 
 
 def test_search_requirements_errors(tmp_path: Path, monkeypatch) -> None:
-    def not_found(_):  # noqa: ANN001
+    def not_found(_):
         raise FileNotFoundError
 
     monkeypatch.setattr("app.core.requirements.load_all", not_found)
     err = search_requirements(tmp_path / "nope", query="login")
     assert err["error"]["code"] == ErrorCode.NOT_FOUND
 
-    def boom(_):  # noqa: ANN001
+    def boom(_):
         raise RuntimeError("boom")
 
     monkeypatch.setattr("app.core.requirements.load_all", boom)

--- a/tests/llm_utils.py
+++ b/tests/llm_utils.py
@@ -26,7 +26,7 @@ def make_openai_mock(responses: dict[str, tuple[str, dict] | Exception]):
     """
 
     class _Completions:
-        def create(self, *, model, messages, tools=None, **kwargs):  # noqa: D401
+        def create(self, *, model, messages, tools=None, **kwargs):
             user_msg = messages[-1]["content"]
             result = responses.get(user_msg, ("noop", {}))
             if isinstance(result, Exception):

--- a/tests/unit/test_requirement_model.py
+++ b/tests/unit/test_requirement_model.py
@@ -8,9 +8,9 @@ from app.ui.requirement_model import RequirementModel
 pytestmark = pytest.mark.unit
 
 
-def _req(id: int, status: Status) -> Requirement:
+def _req(req_id: int, status: Status) -> Requirement:
     return Requirement(
-        id=id,
+        id=req_id,
         title="T",
         statement="S",
         type=RequirementType.REQUIREMENT,

--- a/tests/unit/test_requirement_ops.py
+++ b/tests/unit/test_requirement_ops.py
@@ -93,7 +93,7 @@ def test_link_requirements(tmp_path: Path):
 def test_create_requirement_errors(tmp_path: Path, monkeypatch) -> None:
     from app.core.store import ConflictError
 
-    def conflict(*args, **kwargs):  # noqa: ANN001, ANN002
+    def conflict(*args, **kwargs):
         raise ConflictError("exists")
 
     monkeypatch.setattr("app.core.requirements.save_requirement", conflict)
@@ -103,7 +103,7 @@ def test_create_requirement_errors(tmp_path: Path, monkeypatch) -> None:
     err = create_requirement(tmp_path, {"id": 2})
     assert err["error"]["code"] == ErrorCode.VALIDATION_ERROR
 
-    def boom(*args, **kwargs):  # noqa: ANN001, ANN002
+    def boom(*args, **kwargs):
         raise RuntimeError("boom")
 
     monkeypatch.setattr("app.core.requirements.save_requirement", boom)
@@ -122,7 +122,7 @@ def test_patch_requirement_errors(tmp_path: Path, monkeypatch) -> None:
     err = patch_requirement(tmp_path, 1, [{"path": "/title", "value": "Y"}], rev=1)
     assert err["error"]["code"] == ErrorCode.VALIDATION_ERROR
 
-    def boom(*args, **kwargs):  # noqa: ANN001, ANN002
+    def boom(*args, **kwargs):
         raise RuntimeError("boom")
 
     monkeypatch.setattr("app.core.requirements.save_requirement", boom)
@@ -136,7 +136,7 @@ def test_delete_requirement_errors(tmp_path: Path, monkeypatch) -> None:
 
     create_requirement(tmp_path, _base_req(1))
 
-    def boom(*args, **kwargs):  # noqa: ANN001, ANN002
+    def boom(*args, **kwargs):
         raise RuntimeError("boom")
 
     monkeypatch.setattr("app.core.requirements.delete_requirement", boom)
@@ -155,7 +155,7 @@ def test_link_requirements_errors(tmp_path: Path, monkeypatch) -> None:
     err = link_requirements(tmp_path, source_id=1, derived_id=3, link_type="derived_from", rev=1)
     assert err["error"]["code"] == ErrorCode.NOT_FOUND
 
-    def val_err(*args, **kwargs):  # noqa: ANN001, ANN002
+    def val_err(*args, **kwargs):
         raise ValueError("bad")
 
     orig = tools_write.requirement_from_dict
@@ -165,7 +165,7 @@ def test_link_requirements_errors(tmp_path: Path, monkeypatch) -> None:
 
     monkeypatch.setattr(tools_write, "requirement_from_dict", orig)
 
-    def boom(*args, **kwargs):  # noqa: ANN001, ANN002
+    def boom(*args, **kwargs):
         raise RuntimeError("boom")
 
     monkeypatch.setattr("app.core.requirements.save_requirement", boom)


### PR DESCRIPTION
## Summary
- enable Ruff plugins for builtins, simplify and Ruff-specific checks
- refactor code to use `contextlib.suppress`, compact conditionals and sorted exports
- clean up tests to respect new lint rules

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c69d01cd0c83209cbdee50491da04e