### PR TITLE
feat: enforce unused-argument rule

### DIFF
--- a/app/ui/command_dialog.py
+++ b/app/ui/command_dialog.py
@@ -78,7 +78,7 @@ class CommandDialog(wx.Dialog):
         self.SetSize((600, 400))
         self._refresh_history_list()
 
-    def _on_run(self, event: wx.Event) -> None:
+    def _on_run(self, _event: wx.Event) -> None:
         text = self.input.GetValue().strip()
         if not text:
             return
@@ -94,7 +94,7 @@ class CommandDialog(wx.Dialog):
         self.output.ShowPosition(self.output.GetLastPosition())
         self._append_history(text, display)
 
-    def _on_clear(self, event: wx.Event) -> None:
+    def _on_clear(self, _event: wx.Event) -> None:
         self.input.SetValue("")
         self.output.SetValue("")
         self.history_list.SetSelection(wx.NOT_FOUND)

--- a/app/ui/labels_dialog.py
+++ b/app/ui/labels_dialog.py
@@ -122,11 +122,11 @@ class LabelsDialog(wx.Dialog):
         if added:
             self._populate()
 
-    def _on_show_presets_menu(self, event: wx.Event) -> None:  # pragma: no cover - GUI event
+    def _on_show_presets_menu(self, _event: wx.Event) -> None:  # pragma: no cover - GUI event
         menu = wx.Menu()
         for key, title in PRESET_SET_TITLES.items():
             item = menu.Append(wx.ID_ANY, _(title))
-            menu.Bind(wx.EVT_MENU, lambda evt, k=key: self._on_add_preset_set(k), item)
+            menu.Bind(wx.EVT_MENU, lambda _evt, k=key: self._on_add_preset_set(k), item)
         self.PopupMenu(menu)
         menu.Destroy()
 

--- a/app/ui/list_panel.py
+++ b/app/ui/list_panel.py
@@ -88,7 +88,7 @@ class ListPanel(wx.Panel, ColumnSorterMixin):
         self.list.Bind(wx.EVT_LIST_ITEM_RIGHT_CLICK, self._on_right_click)
         self.list.Bind(wx.EVT_CONTEXT_MENU, self._on_context_menu)
         self.filter_btn.Bind(wx.EVT_BUTTON, self._on_filter)
-        self.reset_btn.Bind(wx.EVT_BUTTON, lambda evt: self.reset_filters())
+        self.reset_btn.Bind(wx.EVT_BUTTON, lambda _evt: self.reset_filters())
 
 # ColumnSorterMixin requirement
     def GetListCtrl(self):  # pragma: no cover - simple forwarding
@@ -546,13 +546,13 @@ class ListPanel(wx.Panel, ColumnSorterMixin):
         edit_item = None
         if field and field != "title":
             edit_item = menu.Append(wx.ID_ANY, _("Edit {field}").format(field=field))
-            menu.Bind(wx.EVT_MENU, lambda evt, c=column: self._on_edit_field(c), edit_item)
+            menu.Bind(wx.EVT_MENU, lambda _evt, c=column: self._on_edit_field(c), edit_item)
         if self._on_clone:
-            menu.Bind(wx.EVT_MENU, lambda evt, i=req_id: self._on_clone(i), clone_item)
+            menu.Bind(wx.EVT_MENU, lambda _evt, i=req_id: self._on_clone(i), clone_item)
         if self._on_delete:
-            menu.Bind(wx.EVT_MENU, lambda evt, i=req_id: self._on_delete(i), delete_item)
+            menu.Bind(wx.EVT_MENU, lambda _evt, i=req_id: self._on_delete(i), delete_item)
         if self._on_derive:
-            menu.Bind(wx.EVT_MENU, lambda evt, i=req_id: self._on_derive(i), derive_item)
+            menu.Bind(wx.EVT_MENU, lambda _evt, i=req_id: self._on_derive(i), derive_item)
         return menu, clone_item, delete_item, edit_item
 
     def _get_selected_indices(self) -> list[int]:

--- a/app/ui/main_frame.py
+++ b/app/ui/main_frame.py
@@ -170,7 +170,7 @@ class MainFrame(wx.Frame):
 
         return self.labels_controller.labels if self.labels_controller else []
 
-    def on_open_folder(self, event: wx.Event) -> None:
+    def on_open_folder(self, _event: wx.Event) -> None:
         """Handle "Open Folder" menu action."""
 
         dlg = wx.DirDialog(self, _("Select requirements folder"))
@@ -185,7 +185,7 @@ class MainFrame(wx.Frame):
         if path:
             self._load_directory(path)
 
-    def on_open_settings(self, event: wx.Event) -> None:  # pragma: no cover - GUI event
+    def on_open_settings(self, _event: wx.Event) -> None:  # pragma: no cover - GUI event
         """Display settings dialog and apply changes."""
 
         dlg = SettingsDialog(
@@ -258,7 +258,7 @@ class MainFrame(wx.Frame):
             self._apply_language()
         dlg.Destroy()
 
-    def on_run_command(self, event: wx.Event) -> None:
+    def on_run_command(self, _event: wx.Event) -> None:
         """Invoke agent command dialog."""
 
         settings = AppSettings(llm=self.llm_settings, mcp=self.mcp_settings)
@@ -444,7 +444,7 @@ class MainFrame(wx.Frame):
         self.panel.load_column_order(self.config)
         self.config.set_columns(self.selected_fields)
 
-    def on_toggle_log_console(self, event: wx.CommandEvent) -> None:
+    def on_toggle_log_console(self, _event: wx.CommandEvent) -> None:
         """Toggle visibility of log console panel."""
 
         if self.navigation.log_menu_item.IsChecked():
@@ -488,7 +488,7 @@ class MainFrame(wx.Frame):
         self.config.set_sort_settings(column, ascending)
 
     # context menu actions -------------------------------------------
-    def on_new_requirement(self, event: wx.Event) -> None:
+    def on_new_requirement(self, _event: wx.Event) -> None:
         """Create and persist a new requirement."""
 
         if not self.req_controller:

--- a/app/ui/navigation.py
+++ b/app/ui/navigation.py
@@ -72,7 +72,7 @@ class Navigation:
         self.frame.Bind(wx.EVT_MENU, self.on_new_requirement, new_item)
         self.frame.Bind(wx.EVT_MENU, self.on_open_settings, settings_item)
         self.frame.Bind(wx.EVT_MENU, self.on_manage_labels, labels_item)
-        self.frame.Bind(wx.EVT_MENU, lambda evt: self.frame.Close(), exit_item)
+        self.frame.Bind(wx.EVT_MENU, lambda _evt: self.frame.Close(), exit_item)
         self._rebuild_recent_menu()
         self.manage_labels_id = labels_item.GetId()
         menu_bar.Append(file_menu, _("&File"))

--- a/app/ui/settings_dialog.py
+++ b/app/ui/settings_dialog.py
@@ -257,7 +257,7 @@ class SettingsDialog(wx.Dialog):
         self.SetSizerAndFit(dlg_sizer)
 
     # ------------------------------------------------------------------
-    def _on_toggle_token(self, event: wx.Event) -> None:  # pragma: no cover - GUI event
+    def _on_toggle_token(self, _event: wx.Event) -> None:  # pragma: no cover - GUI event
         self._token.Enable(self._require_token.GetValue())
 
     def _update_mcp_controls(self) -> None:
@@ -287,28 +287,28 @@ class SettingsDialog(wx.Dialog):
             token=self._token.GetValue(),
         )
 
-    def _on_start(self, event: wx.Event) -> None:  # pragma: no cover - GUI event
+    def _on_start(self, _event: wx.Event) -> None:  # pragma: no cover - GUI event
         settings = self._current_settings()
         self._mcp.start(settings)
         self._update_mcp_controls()
 
-    def _on_stop(self, event: wx.Event) -> None:  # pragma: no cover - GUI event
+    def _on_stop(self, _event: wx.Event) -> None:  # pragma: no cover - GUI event
         self._mcp.stop()
         self._update_mcp_controls()
 
-    def _on_check_llm(self, event: wx.Event) -> None:  # pragma: no cover - GUI event
+    def _on_check_llm(self, _event: wx.Event) -> None:  # pragma: no cover - GUI event
         client = LLMClient(settings=self._current_llm_settings())
         result = client.check_llm()
         label = _("ok") if result.get("ok") else _("error")
         self._llm_status.SetLabel(label)
 
-    def _on_check_tools(self, event: wx.Event) -> None:  # pragma: no cover - GUI event
+    def _on_check_tools(self, _event: wx.Event) -> None:  # pragma: no cover - GUI event
         client = MCPClient(settings=self._current_settings(), confirm=lambda _m: True)
         result = client.check_tools()
         label = _("ok") if result.get("ok") else _("error")
         self._tools_status.SetLabel(label)
 
-    def _on_check(self, event: wx.Event) -> None:  # pragma: no cover - GUI event
+    def _on_check(self, _event: wx.Event) -> None:  # pragma: no cover - GUI event
         result = self._mcp.check(self._current_settings())
         status = result.status
         running = status != MCPStatus.NOT_RUNNING

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,11 +41,15 @@ select = [
     "W",
     "C4",
     "A",
+    "ARG",
     "SIM",
     "RUF",
 ]
 
 ignore = ["RUF001", "RUF003"]
+
+[tool.ruff.lint.per-file-ignores]
+"tests/**/*" = ["ARG001", "ARG002", "ARG003", "ARG004", "ARG005"]
 
 [build-system]
 requires = ["setuptools", "wheel"]


### PR DESCRIPTION
## Summary
- enforce Ruff's ARG* unused-argument checks across the app
- prefix unused callback parameters with underscores for clarity
- allow test suite to ignore ARG checks to preserve fixture naming

## Testing
- `python3 -m ruff check app tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c6a0c72fa4832095eba69ffc154ce0