### PR TITLE
Enable pathlib and return checks in ruff

### DIFF
--- a/app/cli/commands.py
+++ b/app/cli/commands.py
@@ -7,6 +7,7 @@ import json
 import sys
 from contextlib import suppress
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Callable
 
 from app.agent import LocalAgent
@@ -50,7 +51,7 @@ def add_list_arguments(p: argparse.ArgumentParser) -> None:
 def cmd_add(args: argparse.Namespace, repo: RequirementRepository) -> None:
     """Add requirement from JSON file to directory."""
     try:
-        with open(args.file, encoding="utf-8") as fh:
+        with Path(args.file).open(encoding="utf-8") as fh:
             data = json.load(fh)
     except json.JSONDecodeError as exc:
         print(_("Invalid JSON file: {error}").format(error=exc))
@@ -74,7 +75,7 @@ def add_add_arguments(p: argparse.ArgumentParser) -> None:
 def cmd_edit(args: argparse.Namespace, repo: RequirementRepository) -> None:
     """Edit existing requirement using data from JSON file."""
     try:
-        with open(args.file, encoding="utf-8") as fh:
+        with Path(args.file).open(encoding="utf-8") as fh:
             data = json.load(fh)
     except json.JSONDecodeError as exc:
         print(_("Invalid JSON file: {error}").format(error=exc))

--- a/app/cli/main.py
+++ b/app/cli/main.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import argparse
 import atexit
-import os
 from pathlib import Path
 
 from app import i18n
@@ -17,8 +16,8 @@ from app.settings import AppSettings, load_app_settings
 from .commands import COMMANDS
 
 APP_NAME = "CookaReq"
-LOCALE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "locale"))
-MISSING_PATH = Path(LOCALE_DIR) / "missing.po"
+LOCALE_DIR = Path(__file__).resolve().parent.parent / "locale"
+MISSING_PATH = LOCALE_DIR / "missing.po"
 atexit.register(i18n.flush_missing, MISSING_PATH)
 
 set_confirm(auto_confirm)

--- a/app/core/model.py
+++ b/app/core/model.py
@@ -169,6 +169,5 @@ def requirement_to_dict(req: Requirement) -> dict[str, Any]:
         value = data.get(key)
         if isinstance(value, Enum):
             data[key] = value.value
-    data = {k: v for k, v in data.items() if v is not None}
-    return data
+    return {k: v for k, v in data.items() if v is not None}
 

--- a/app/log.py
+++ b/app/log.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
+from pathlib import Path
 from typing import Any
 
 from .util.time import utc_now_iso
@@ -14,9 +15,9 @@ logger = logging.getLogger("cookareq")
 class JsonlHandler(logging.Handler):
     """Write log records as JSON lines with timestamps."""
 
-    def __init__(self, filename: str) -> None:
+    def __init__(self, filename: Path | str) -> None:
         super().__init__(level=logging.INFO)
-        self.filename = filename
+        self.filename = Path(filename)
 
     def emit(self, record: logging.LogRecord) -> None:  # pragma: no cover - simple IO
         """Serialize ``record`` to JSONL with a timestamp."""
@@ -26,7 +27,7 @@ class JsonlHandler(logging.Handler):
             data = {"message": record.getMessage(), "level": record.levelname}
         if "timestamp" not in data:
             data["timestamp"] = utc_now_iso()
-        with open(self.filename, "a", encoding="utf-8") as fh:
+        with self.filename.open("a", encoding="utf-8") as fh:
             json.dump(data, fh, ensure_ascii=False)
             fh.write("\n")
 

--- a/app/main.py
+++ b/app/main.py
@@ -1,7 +1,6 @@
 """Application entry point for CookaReq."""
 
 import atexit
-import os
 from pathlib import Path
 
 import wx
@@ -14,14 +13,14 @@ from .ui.main_frame import MainFrame
 from .ui.requirement_model import RequirementModel
 
 APP_NAME = "CookaReq"
-LOCALE_DIR = os.path.join(os.path.dirname(__file__), "locale")
-MISSING_PATH = Path(LOCALE_DIR) / "missing.po"
+LOCALE_DIR = Path(__file__).resolve().parent / "locale"
+MISSING_PATH = LOCALE_DIR / "missing.po"
 atexit.register(i18n.flush_missing, MISSING_PATH)
 
 
 def init_locale(language: str | None = None) -> wx.Locale:
     """Initialize wx locale and load translations."""
-    wx.Locale.AddCatalogLookupPathPrefix(LOCALE_DIR)
+    wx.Locale.AddCatalogLookupPathPrefix(str(LOCALE_DIR))
     if language and hasattr(wx.Locale, "FindLanguageInfo"):
         info = wx.Locale.FindLanguageInfo(language)
         locale = wx.Locale(info.Language) if info else wx.Locale(wx.LANGUAGE_DEFAULT)

--- a/app/mcp/server.py
+++ b/app/mcp/server.py
@@ -9,9 +9,9 @@ loop remains responsive.
 from __future__ import annotations
 
 import logging
-import os
 import threading
 from collections.abc import Mapping
+from pathlib import Path
 
 import uvicorn
 from fastapi import FastAPI, Request
@@ -38,7 +38,7 @@ _TEXT_LOG_NAME = "server.log"
 _JSONL_LOG_NAME = "server.jsonl"
 
 
-def _configure_request_logging(log_dir: str) -> None:
+def _configure_request_logging(log_dir: str | Path) -> None:
     """Attach file handlers for request logging without mutating the global logger."""
     configure_logging()
     # Remove previous request handlers if any from the dedicated logger
@@ -47,15 +47,16 @@ def _configure_request_logging(log_dir: str) -> None:
             request_logger.removeHandler(h)
             h.close()
 
-    os.makedirs(log_dir, exist_ok=True)
+    log_dir_path = Path(log_dir)
+    log_dir_path.mkdir(parents=True, exist_ok=True)
 
-    text_path = os.path.join(log_dir, _TEXT_LOG_NAME)
+    text_path = log_dir_path / _TEXT_LOG_NAME
     text_handler = logging.FileHandler(text_path)
     text_handler.setFormatter(logging.Formatter("%(asctime)s %(levelname)s %(message)s"))
     text_handler._cookareq_request = True
     request_logger.addHandler(text_handler)
 
-    json_path = os.path.join(log_dir, _JSONL_LOG_NAME)
+    json_path = log_dir_path / _JSONL_LOG_NAME
     json_handler = JsonlHandler(json_path)
     json_handler._cookareq_request = True
     request_logger.addHandler(json_handler)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,8 @@ select = [
     "ARG",
     "SIM",
     "RUF",
+    "PTH",
+    "RET",
 ]
 
 ignore = ["RUF001", "RUF003"]

--- a/tests/gui/test_language_switch.py
+++ b/tests/gui/test_language_switch.py
@@ -20,7 +20,6 @@ def test_switch_to_russian_updates_ui(monkeypatch, wx_app):
 
     def fake_init_locale(language):
         i18n.install(main_mod.APP_NAME, main_mod.LOCALE_DIR, [language])
-        return None
 
     monkeypatch.setattr(main_mod, "init_locale", fake_init_locale)
 

--- a/tests/integration/test_mcp_logging.py
+++ b/tests/integration/test_mcp_logging.py
@@ -1,7 +1,7 @@
 """Tests for mcp logging."""
 
 import json
-import os
+from pathlib import Path
 from tempfile import TemporaryDirectory
 
 import pytest
@@ -15,6 +15,7 @@ pytestmark = pytest.mark.integration
 def test_request_logged_and_token_masked():
     port = 8124
     with TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
         stop_server()
         start_server(port=port, base_path=tmp, token="secret")
         try:
@@ -24,17 +25,17 @@ def test_request_logged_and_token_masked():
         finally:
             stop_server()
 
-        log_path = os.path.join(tmp, "server.log")
-        jsonl_path = os.path.join(tmp, "server.jsonl")
-        assert os.path.exists(log_path)
-        assert os.path.exists(jsonl_path)
+        log_path = tmp_path / "server.log"
+        jsonl_path = tmp_path / "server.jsonl"
+        assert log_path.exists()
+        assert jsonl_path.exists()
 
-        with open(log_path, encoding="utf-8") as fh:
+        with log_path.open(encoding="utf-8") as fh:
             content = fh.read()
         assert "GET /health" in content
         assert "secret" not in content
 
-        with open(jsonl_path, encoding="utf-8") as fh:
+        with jsonl_path.open(encoding="utf-8") as fh:
             line = fh.readline()
         entry = json.loads(line)
         headers = entry["headers"]


### PR DESCRIPTION
## Summary
- extend ruff lint configuration with `PTH` and `RET`
- refactor path handling to `pathlib` and simplify a return expression
- adjust tests for the new rules

## Testing
- `python3 -m ruff check .`
- `python3 -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6a2b43f7c8320a461c11461355531