### PR TITLE
chore: enforce init docstrings and drop prints

### DIFF
--- a/app/agent/local_agent.py
+++ b/app/agent/local_agent.py
@@ -23,6 +23,7 @@ class LocalAgent:
         mcp: MCPClient | None = None,
         confirm: Callable[[str], bool] | None = None,
     ) -> None:
+        """Initialize agent with optional settings or prebuilt clients."""
         if settings is not None:
             if confirm is None:
                 confirm = default_confirm

--- a/app/cli/commands.py
+++ b/app/cli/commands.py
@@ -36,7 +36,7 @@ def cmd_list(args: argparse.Namespace, repo: RequirementRepository) -> None:
         status=args.status,
     )
     for r in reqs:
-        print(f"{r.id}: {r.title}")
+        sys.stdout.write(f"{r.id}: {r.title}\n")
 
 
 def add_list_arguments(p: argparse.ArgumentParser) -> None:
@@ -54,15 +54,15 @@ def cmd_add(args: argparse.Namespace, repo: RequirementRepository) -> None:
         with Path(args.file).open(encoding="utf-8") as fh:
             data = json.load(fh)
     except json.JSONDecodeError as exc:
-        print(_("Invalid JSON file: {error}").format(error=exc))
+        sys.stdout.write(_("Invalid JSON file: {error}\n").format(error=exc))
         return
     try:
         obj = model.requirement_from_dict(data)
     except ValueError as exc:
-        print(_("Invalid requirement data: {error}").format(error=exc))
+        sys.stdout.write(_("Invalid requirement data: {error}\n").format(error=exc))
         return
     path = repo.save(args.directory, obj, modified_at=args.modified_at)
-    print(path)
+    sys.stdout.write(f"{path}\n")
 
 
 def add_add_arguments(p: argparse.ArgumentParser) -> None:
@@ -78,18 +78,18 @@ def cmd_edit(args: argparse.Namespace, repo: RequirementRepository) -> None:
         with Path(args.file).open(encoding="utf-8") as fh:
             data = json.load(fh)
     except json.JSONDecodeError as exc:
-        print(_("Invalid JSON file: {error}").format(error=exc))
+        sys.stdout.write(_("Invalid JSON file: {error}\n").format(error=exc))
         return
     try:
         obj = model.requirement_from_dict(data)
     except ValueError as exc:
-        print(_("Invalid requirement data: {error}").format(error=exc))
+        sys.stdout.write(_("Invalid requirement data: {error}\n").format(error=exc))
         return
     mtime = None
     with suppress(FileNotFoundError):
         mtime = repo.load(args.directory, obj.id)[1]
     path = repo.save(args.directory, obj, mtime=mtime, modified_at=args.modified_at)
-    print(path)
+    sys.stdout.write(f"{path}\n")
 
 
 def add_edit_arguments(p: argparse.ArgumentParser) -> None:
@@ -104,10 +104,10 @@ def cmd_delete(args: argparse.Namespace, repo: RequirementRepository) -> None:
     try:
         repo.get(args.directory, args.id)
     except FileNotFoundError:
-        print(f"requirement {args.id} not found", file=sys.stderr)
+        sys.stderr.write(f"requirement {args.id} not found\n")
         return
     repo.delete(args.directory, args.id)
-    print("deleted")
+    sys.stdout.write("deleted\n")
 
 
 def add_delete_arguments(p: argparse.ArgumentParser) -> None:
@@ -121,12 +121,12 @@ def cmd_clone(args: argparse.Namespace, repo: RequirementRepository) -> None:
     try:
         req = repo.get(args.directory, args.source_id)
     except FileNotFoundError:
-        print(f"requirement {args.source_id} not found", file=sys.stderr)
+        sys.stdout.write(f"requirement {args.source_id} not found\n")
         return
     req.id = args.new_id
     req.revision = 1
     path = repo.save(args.directory, req, modified_at=args.modified_at)
-    print(path)
+    sys.stdout.write(f"{path}\n")
 
 
 def add_clone_arguments(p: argparse.ArgumentParser) -> None:
@@ -141,7 +141,7 @@ def cmd_show(args: argparse.Namespace, repo: RequirementRepository) -> None:
     """Show detailed JSON for requirement with *id*."""
     req = repo.get(args.directory, args.id)
     data = model.requirement_to_dict(req)
-    print(json.dumps(data, ensure_ascii=False, indent=2, sort_keys=True))
+    sys.stdout.write(json.dumps(data, ensure_ascii=False, indent=2, sort_keys=True) + "\n")
 
 
 def add_show_arguments(p: argparse.ArgumentParser) -> None:
@@ -158,7 +158,7 @@ def cmd_check(args: argparse.Namespace, _repo: RequirementRepository) -> None:
         results["llm"] = agent.check_llm()
     if args.mcp or not (args.llm or args.mcp):
         results["mcp"] = agent.check_tools()
-    print(json.dumps(results, ensure_ascii=False, indent=2, sort_keys=True))
+    sys.stdout.write(json.dumps(results, ensure_ascii=False, indent=2, sort_keys=True) + "\n")
 
 
 def add_check_arguments(p: argparse.ArgumentParser) -> None:

--- a/app/config.py
+++ b/app/config.py
@@ -30,6 +30,15 @@ class ConfigManager:
     """Wrapper around :class:`wx.Config` with typed helpers."""
 
     def __init__(self, app_name: str = "CookaReq", path: Path | str | None = None) -> None:
+        """Initialize configuration storage.
+
+        Parameters
+        ----------
+        app_name:
+            Application name for config files.
+        path:
+            Optional explicit path for configuration file.
+        """
         if path is None:
             self._cfg = wx.Config(appName=app_name)
         else:

--- a/app/llm/client.py
+++ b/app/llm/client.py
@@ -26,6 +26,7 @@ class LLMClient:
     """High-level client for LLM operations."""
 
     def __init__(self, settings: LLMSettings) -> None:
+        """Initialize client with LLM configuration ``settings``."""
         import openai
 
         self.settings = settings

--- a/app/log.py
+++ b/app/log.py
@@ -16,6 +16,7 @@ class JsonlHandler(logging.Handler):
     """Write log records as JSON lines with timestamps."""
 
     def __init__(self, filename: Path | str) -> None:
+        """Create handler writing JSON lines to *filename*."""
         super().__init__(level=logging.INFO)
         self.filename = Path(filename)
 

--- a/app/mcp/client.py
+++ b/app/mcp/client.py
@@ -18,6 +18,7 @@ class MCPClient:
     """Simple HTTP client for the MCP server."""
 
     def __init__(self, settings: MCPSettings, *, confirm: Callable[[str], bool]) -> None:
+        """Initialize client with MCP ``settings`` and confirmation callback."""
         self.settings = settings
         self._confirm = confirm
 

--- a/app/ui/command_dialog.py
+++ b/app/ui/command_dialog.py
@@ -43,6 +43,7 @@ class CommandDialog(wx.Dialog):
         agent: LocalAgent,
         history_path: Path | None = None,
     ) -> None:
+        """Initialize dialog for interacting with ``agent``."""
         super().__init__(parent, title=_("Agent Command"))
         self._agent = agent
         self._history_path = history_path or _default_history_path()

--- a/app/ui/controllers/labels.py
+++ b/app/ui/controllers/labels.py
@@ -21,6 +21,7 @@ class LabelsController:
         directory: Path,
         repository: LabelRepository | None = None,
     ) -> None:
+        """Initialize controller with storage ``directory`` and model."""
         self.config = config
         self.model = model
         self.directory = directory

--- a/app/ui/controllers/requirements.py
+++ b/app/ui/controllers/requirements.py
@@ -23,6 +23,7 @@ class RequirementsController:
         directory: Path,
         repository: RequirementRepository | None = None,
     ) -> None:
+        """Initialize controller for given storage ``directory``."""
         self.config = config
         self.model = model
         self.directory = directory

--- a/app/ui/derivation_graph.py
+++ b/app/ui/derivation_graph.py
@@ -20,6 +20,7 @@ class DerivationGraphFrame(wx.Frame):
     """Render a graph of requirement derivations."""
 
     def __init__(self, parent: wx.Window | None, requirements: Sequence[Requirement]):
+        """Create frame displaying derivation graph for ``requirements``."""
         super().__init__(parent=parent, title=_("Derivation Graph"))
         self.SetSize((600, 400))
         self._panel = wx.ScrolledWindow(self)

--- a/app/ui/editor_panel.py
+++ b/app/ui/editor_panel.py
@@ -36,6 +36,7 @@ class EditorPanel(ScrolledPanel):
         on_save: Callable[[], None] | None = None,
         on_add_derived: Callable[[Requirement], None] | None = None,
     ):
+        """Initialize requirement editor widgets."""
         super().__init__(parent)
         self.fields: dict[str, wx.TextCtrl] = {}
         self.enums: dict[str, wx.Choice] = {}

--- a/app/ui/filter_dialog.py
+++ b/app/ui/filter_dialog.py
@@ -20,6 +20,7 @@ class FilterDialog(wx.Dialog):
         labels: list[Label],
         values: dict | None = None,
     ) -> None:
+        """Initialize filter dialog with current ``values``."""
         title = _("Filters")
         super().__init__(parent, title=title)
         self._labels = list(labels)

--- a/app/ui/helpers.py
+++ b/app/ui/helpers.py
@@ -26,6 +26,7 @@ class HelpStaticBox(wx.StaticBoxSizer):
         orient: int = wx.VERTICAL,
         border: int = 5,
     ) -> None:
+        """Create static box sizer with help button."""
         box = wx.StaticBox(parent, label=label)
         super().__init__(box, orient)
 

--- a/app/ui/label_selection_dialog.py
+++ b/app/ui/label_selection_dialog.py
@@ -18,6 +18,7 @@ class LabelSelectionDialog(wx.Dialog):
     """Dialog allowing to choose labels while displaying their colors."""
 
     def __init__(self, parent: wx.Window | None, labels: list[Label], selected: list[str]):
+        """Initialize dialog listing ``labels`` with ``selected`` prechecked."""
         style = wx.DEFAULT_DIALOG_STYLE | wx.RESIZE_BORDER
         super().__init__(parent, title=_("Labels"), style=style)
         self._labels = list(labels)

--- a/app/ui/labels_dialog.py
+++ b/app/ui/labels_dialog.py
@@ -12,6 +12,7 @@ class LabelsDialog(wx.Dialog):
     """Dialog allowing to view labels and adjust their colors."""
 
     def __init__(self, parent: wx.Window | None, labels: list[Label]):
+        """Initialize labels dialog with editable label list."""
         style = wx.DEFAULT_DIALOG_STYLE | wx.RESIZE_BORDER
         super().__init__(parent, title=_("Labels"), style=style)
         # copy labels to avoid modifying caller until OK

--- a/app/ui/list_panel.py
+++ b/app/ui/list_panel.py
@@ -38,6 +38,7 @@ class ListPanel(wx.Panel, ColumnSorterMixin):
         on_sort_changed: Callable[[int, bool], None] | None = None,
         on_derive: Callable[[int], None] | None = None,
     ):
+        """Initialize list view and controls for requirements."""
         wx.Panel.__init__(self, parent)
         self.model = model if model is not None else RequirementModel()
         sizer = wx.BoxSizer(wx.VERTICAL)

--- a/app/ui/main_frame.py
+++ b/app/ui/main_frame.py
@@ -33,6 +33,7 @@ class WxLogHandler(logging.Handler):
     """Forward log records to a ``wx.TextCtrl``."""
 
     def __init__(self, target: wx.TextCtrl) -> None:
+        """Initialize handler redirecting log output to ``target``."""
         super().__init__()
         self._target = target
         self.setFormatter(logging.Formatter("%(levelname)s: %(message)s"))
@@ -56,6 +57,7 @@ class MainFrame(wx.Frame):
         config: ConfigManager | None = None,
         model: RequirementModel | None = None,
     ) -> None:
+        """Set up main application window and controllers."""
         self._base_title = "CookaReq"
         self.config = config if config is not None else ConfigManager()
         self.model = model if model is not None else RequirementModel()

--- a/app/ui/navigation.py
+++ b/app/ui/navigation.py
@@ -32,6 +32,7 @@ class Navigation:
         on_new_requirement: Callable[[wx.Event], None],
         on_run_command: Callable[[wx.Event], None],
     ) -> None:
+        """Initialize navigation menus and event handlers."""
         self.frame = frame
         self.config = config
         self.available_fields = available_fields

--- a/app/ui/requirement_model.py
+++ b/app/ui/requirement_model.py
@@ -13,6 +13,7 @@ class RequirementModel:
     """Maintain requirement data and apply filters/sorting."""
 
     def __init__(self) -> None:
+        """Initialize empty requirement collections."""
         self._all: list[Requirement] = []
         self._visible: list[Requirement] = []
         self._labels: list[str] = []

--- a/app/ui/settings_dialog.py
+++ b/app/ui/settings_dialog.py
@@ -89,6 +89,7 @@ class SettingsDialog(wx.Dialog):
         require_token: bool,
         token: str,
     ) -> None:
+        """Create settings dialog with LLM and MCP configuration."""
         super().__init__(parent, title=_("Settings"))
 
         # General settings -------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
 dev = ["pytest", "polib", "pydocstyle", "ruff"]
 
 [tool.pydocstyle]
-select = ["D100", "D101", "D102", "D103"]
+select = ["D100", "D101", "D102", "D103", "D104", "D107"]
 
 [tool.ruff]
 exclude = [
@@ -46,6 +46,7 @@ select = [
     "RUF",
     "PTH",
     "RET",
+    "T20",
 ]
 
 ignore = ["RUF001", "RUF003"]


### PR DESCRIPTION
## Summary
- require docstrings in `__init__` methods and add them across UI/logic modules
- enable pydocstyle D104/D107 and ruff T20 checks
- replace `print` calls in CLI commands with explicit stdout/stderr writes

## Testing
- `pydocstyle`
- `ruff check`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c6a53dfbb48320b0aa06eadd13f04c