### PR TITLE
Enable additional Ruff rules and standardize config API

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -48,37 +48,37 @@ class ConfigManager:
 
     # ------------------------------------------------------------------
     # basic ``wx.Config`` API
-    def Read(self, key: str, default: str = "") -> str:
+    def read(self, key: str, default: str = "") -> str:
         """Read string value for ``key``."""
 
         return self._cfg.Read(key, default)
 
-    def ReadInt(self, key: str, default: int = 0) -> int:
+    def read_int(self, key: str, default: int = 0) -> int:
         """Read integer value for ``key``."""
 
         return self._cfg.ReadInt(key, default)
 
-    def ReadBool(self, key: str, default: bool = False) -> bool:
+    def read_bool(self, key: str, default: bool = False) -> bool:
         """Read boolean value for ``key``."""
 
         return self._cfg.ReadBool(key, default)
 
-    def Write(self, key: str, value: str) -> None:
+    def write(self, key: str, value: str) -> None:
         """Write string ``value`` under ``key``."""
 
         self._cfg.Write(key, value)
 
-    def WriteInt(self, key: str, value: int) -> None:
+    def write_int(self, key: str, value: int) -> None:
         """Write integer ``value`` under ``key``."""
 
         self._cfg.WriteInt(key, value)
 
-    def WriteBool(self, key: str, value: bool) -> None:
+    def write_bool(self, key: str, value: bool) -> None:
         """Write boolean ``value`` under ``key``."""
 
         self._cfg.WriteBool(key, value)
 
-    def Flush(self) -> None:  # pragma: no cover - simple wrapper
+    def flush(self) -> None:  # pragma: no cover - simple wrapper
         """Persist configuration to disk."""
 
         self._cfg.Flush()
@@ -363,4 +363,4 @@ class ConfigManager:
             self._cfg.WriteBool("log_shown", False)
         panel.save_column_widths(self)
         panel.save_column_order(self)
-        self.Flush()
+        self.flush()

--- a/app/ui/labels_dialog.py
+++ b/app/ui/labels_dialog.py
@@ -180,13 +180,13 @@ class LabelsDialog(wx.Dialog):
         dlg.Destroy()
 
     def _load_layout(self) -> None:
-        w = self._config.ReadInt("labels_w", 300)
-        h = self._config.ReadInt("labels_h", 200)
+        w = self._config.read_int("labels_w", 300)
+        h = self._config.read_int("labels_h", 200)
         w = max(200, min(w, 1000))
         h = max(150, min(h, 800))
         self.SetSize((w, h))
-        x = self._config.ReadInt("labels_x", -1)
-        y = self._config.ReadInt("labels_y", -1)
+        x = self._config.read_int("labels_x", -1)
+        y = self._config.read_int("labels_y", -1)
         if x != -1 and y != -1:
             self.SetPosition((x, y))
             rect = self.GetRect()
@@ -209,11 +209,11 @@ class LabelsDialog(wx.Dialog):
     def _save_layout(self) -> None:
         w, h = self.GetSize()
         x, y = self.GetPosition()
-        self._config.WriteInt("labels_w", w)
-        self._config.WriteInt("labels_h", h)
-        self._config.WriteInt("labels_x", x)
-        self._config.WriteInt("labels_y", y)
-        self._config.Flush()
+        self._config.write_int("labels_w", w)
+        self._config.write_int("labels_h", h)
+        self._config.write_int("labels_x", x)
+        self._config.write_int("labels_y", y)
+        self._config.flush()
 
     def Destroy(self) -> bool:  # pragma: no cover - GUI side effect
         """Save window geometry before closing dialog."""

--- a/app/ui/list_panel.py
+++ b/app/ui/list_panel.py
@@ -18,6 +18,9 @@ from .enums import ENUMS
 from .filter_dialog import FilterDialog
 from .requirement_model import RequirementModel
 
+if TYPE_CHECKING:
+    from ..config import ConfigManager
+
 if TYPE_CHECKING:  # pragma: no cover
     from wx import ContextMenuEvent, ListEvent
 
@@ -199,26 +202,26 @@ class ListPanel(wx.Panel, ColumnSorterMixin):
         self.list.Bind(wx.EVT_LIST_COL_CLICK, self._on_col_click)
 
     # Columns ---------------------------------------------------------
-    def load_column_widths(self, config: wx.Config) -> None:
+    def load_column_widths(self, config: ConfigManager) -> None:
         """Restore column widths from config with sane bounds."""
         count = self.list.GetColumnCount()
         for i in range(count):
-            width = config.ReadInt(f"col_width_{i}", -1)
+            width = config.read_int(f"col_width_{i}", -1)
             if width != -1:
                 width = max(self.MIN_COL_WIDTH, min(width, self.MAX_COL_WIDTH))
                 self.list.SetColumnWidth(i, width)
 
-    def save_column_widths(self, config: wx.Config) -> None:
+    def save_column_widths(self, config: ConfigManager) -> None:
         """Persist current column widths to config."""
         count = self.list.GetColumnCount()
         for i in range(count):
             width = self.list.GetColumnWidth(i)
             width = max(self.MIN_COL_WIDTH, min(width, self.MAX_COL_WIDTH))
-            config.WriteInt(f"col_width_{i}", width)
+            config.write_int(f"col_width_{i}", width)
 
-    def load_column_order(self, config: wx.Config) -> None:
+    def load_column_order(self, config: ConfigManager) -> None:
         """Restore column ordering from config."""
-        value = config.Read("col_order", "")
+        value = config.read("col_order", "")
         if not value:
             return
         names = [n for n in value.split(",") if n]
@@ -235,7 +238,7 @@ class ListPanel(wx.Panel, ColumnSorterMixin):
         with suppress(Exception):  # pragma: no cover - depends on GUI backend
             self.list.SetColumnsOrder(order)
 
-    def save_column_order(self, config: wx.Config) -> None:
+    def save_column_order(self, config: ConfigManager) -> None:
         """Persist current column ordering to config."""
         try:  # pragma: no cover - depends on GUI backend
             order = self.list.GetColumnsOrder()
@@ -247,7 +250,7 @@ class ListPanel(wx.Panel, ColumnSorterMixin):
                 names.append("title")
             elif 1 <= idx <= len(self.columns):
                 names.append(self.columns[idx - 1])
-        config.Write("col_order", ",".join(names))
+        config.write("col_order", ",".join(names))
 
     def reorder_columns(self, from_col: int, to_col: int) -> None:
         """Move column from ``from_col`` index to ``to_col`` index."""

--- a/app/util/time.py
+++ b/app/util/time.py
@@ -12,7 +12,11 @@ def utc_now_iso() -> str:
 
 def local_now_str() -> str:
     """Return local time in ``YYYY-MM-DD HH:MM:SS`` format."""
-    return datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    return (
+        datetime.datetime.now(datetime.UTC)
+        .astimezone()
+        .strftime("%Y-%m-%d %H:%M:%S")
+    )
 
 
 def normalize_timestamp(value: str | None) -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,12 +47,18 @@ select = [
     "PTH",
     "RET",
     "T20",
+    "N",
+    "DTZ",
+    "Q",
 ]
 
 ignore = ["RUF001", "RUF003"]
 
 [tool.ruff.lint.per-file-ignores]
-"tests/**/*" = ["ARG001", "ARG002", "ARG003", "ARG004", "ARG005"]
+"tests/**/*" = ["ARG001", "ARG002", "ARG003", "ARG004", "ARG005", "N802"]
+"app/ui/helpers.py" = ["N802", "N803"]
+"app/ui/list_panel.py" = ["N802"]
+"app/ui/labels_dialog.py" = ["N802"]
 
 [build-system]
 requires = ["setuptools", "wheel"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,9 +45,11 @@ def wx_app():
         try:
             from pyvirtualdisplay import Display
         except Exception:
-            Display = None
-        if Display is not None:
-            display = Display(visible=False, size=(1280, 800))
+            display_cls = None
+        else:
+            display_cls = Display
+        if display_cls is not None:
+            display = display_cls(visible=False, size=(1280, 800))
             display.start()
     wx = pytest.importorskip("wx")
     app = wx.App()

--- a/tests/gui/test_link_column_width.py
+++ b/tests/gui/test_link_column_width.py
@@ -11,7 +11,7 @@ pytestmark = pytest.mark.gui
 def test_title_column_expands_to_available_width(wx_app, monkeypatch):
     frame = wx.Frame(None)
     panel = EditorPanel(frame)
-    panel.set_directory('dummy')
+    panel.set_directory("dummy")
 
     req = Requirement(
         id=1,
@@ -24,14 +24,14 @@ def test_title_column_expands_to_available_width(wx_app, monkeypatch):
         source="",
         verification=Verification.ANALYSIS,
     )
-    monkeypatch.setattr(req_ops, 'get_requirement', lambda d, i: req)
+    monkeypatch.setattr(req_ops, "get_requirement", lambda d, i: req)
 
     frame.SetClientSize((400, 300))
     frame.Show()
     wx.GetApp().Yield()
 
-    panel.derived_id.SetValue('1')
-    panel._on_add_link_generic('derived_from')
+    panel.derived_id.SetValue("1")
+    panel._on_add_link_generic("derived_from")
 
     panel.derived_list.SendSizeEvent()
     wx.GetApp().Yield()

--- a/tests/gui/test_link_titles.py
+++ b/tests/gui/test_link_titles.py
@@ -11,7 +11,7 @@ pytestmark = pytest.mark.gui
 def test_added_link_shows_id_and_title(wx_app, monkeypatch):
     frame = wx.Frame(None)
     panel = EditorPanel(frame)
-    panel.set_directory('dummy')
+    panel.set_directory("dummy")
 
     req = Requirement(
         id=123,
@@ -24,11 +24,11 @@ def test_added_link_shows_id_and_title(wx_app, monkeypatch):
         source="",
         verification=Verification.ANALYSIS,
     )
-    monkeypatch.setattr(req_ops, 'get_requirement', lambda d, i: req)
+    monkeypatch.setattr(req_ops, "get_requirement", lambda d, i: req)
 
-    panel.derived_id.SetValue('123')
-    panel._on_add_link_generic('derived_from')
+    panel.derived_id.SetValue("123")
+    panel._on_add_link_generic("derived_from")
 
-    assert panel.derived_list.GetItemText(0, 0) == '123'
-    assert panel.derived_list.GetItemText(0, 1) == 'Sample'
+    assert panel.derived_list.GetItemText(0, 0) == "123"
+    assert panel.derived_list.GetItemText(0, 1) == "Sample"
     frame.Destroy()

--- a/tests/gui/test_links_visibility.py
+++ b/tests/gui/test_links_visibility.py
@@ -14,12 +14,12 @@ def test_links_list_becomes_visible(wx_app, monkeypatch):
     called = {}
 
     def fake_fitinside():
-        called['called'] = True
+        called["called"] = True
 
     monkeypatch.setattr(panel, "FitInside", fake_fitinside)
-    panel.derived_id.SetValue('123')
-    panel._on_add_link_generic('derived_from')
+    panel.derived_id.SetValue("123")
+    panel._on_add_link_generic("derived_from")
 
     assert panel.derived_list.IsShown()
-    assert called.get('called')
+    assert called.get("called")
     frame.Destroy()

--- a/tests/gui/test_list_panel.py
+++ b/tests/gui/test_list_panel.py
@@ -259,7 +259,7 @@ def _build_wx_stub():
             return self._renderer
 
     class UltimateListCtrl(_BaseList):
-        def __init__(self, parent=None, agwStyle=0, **kwargs):
+        def __init__(self, parent=None, agw_style=0, **kwargs):
             super().__init__(parent)
         def SetItem(self, item):
             pass
@@ -292,13 +292,13 @@ def _build_wx_stub():
             return [types.SimpleNamespace(GetWindow=lambda w=child: w) for child in self._children]
 
     class Config:
-        def ReadInt(self, key, default):
+        def read_int(self, key, default):
             return default
-        def WriteInt(self, key, value):
+        def write_int(self, key, value):
             pass
-        def Read(self, key, default=""):
+        def read(self, key, default=""):
             return default
-        def Write(self, key, value):
+        def write(self, key, value):
             pass
 
     wx_mod = types.SimpleNamespace(
@@ -390,11 +390,11 @@ def test_list_panel_has_filter_and_list(monkeypatch):
     importlib.reload(list_panel_module)
     model_module = importlib.import_module("app.ui.requirement_model")
     importlib.reload(model_module)
-    ListPanel = list_panel_module.ListPanel
-    RequirementModel = model_module.RequirementModel
+    list_panel_cls = list_panel_module.ListPanel
+    requirement_model_cls = model_module.RequirementModel
 
     frame = wx_stub.Panel(None)
-    panel = ListPanel(frame, model=RequirementModel())
+    panel = list_panel_cls(frame, model=requirement_model_cls())
 
     assert isinstance(panel.filter_btn, wx_stub.Button)
     assert isinstance(panel.reset_btn, wx_stub.BitmapButton)
@@ -424,11 +424,11 @@ def test_column_click_sorts(monkeypatch):
 
     list_panel_module = importlib.import_module("app.ui.list_panel")
     importlib.reload(list_panel_module)
-    RequirementModel = importlib.import_module("app.ui.requirement_model").RequirementModel
-    ListPanel = list_panel_module.ListPanel
+    requirement_model_cls = importlib.import_module("app.ui.requirement_model").RequirementModel
+    list_panel_cls = list_panel_module.ListPanel
 
     frame = wx_stub.Panel(None)
-    panel = ListPanel(frame, model=RequirementModel())
+    panel = list_panel_cls(frame, model=requirement_model_cls())
     panel.set_columns(["id"])
     panel.set_requirements([
         _req(2, "B"),
@@ -455,11 +455,11 @@ def test_column_click_after_set_columns_triggers_sort(monkeypatch):
 
     list_panel_module = importlib.import_module("app.ui.list_panel")
     importlib.reload(list_panel_module)
-    RequirementModel = importlib.import_module("app.ui.requirement_model").RequirementModel
-    ListPanel = list_panel_module.ListPanel
+    requirement_model_cls = importlib.import_module("app.ui.requirement_model").RequirementModel
+    list_panel_cls = list_panel_module.ListPanel
 
     frame = wx_stub.Panel(None)
-    panel = ListPanel(frame, model=RequirementModel())
+    panel = list_panel_cls(frame, model=requirement_model_cls())
     panel.set_columns(["id"])
     panel.set_requirements([
         _req(2, "B"),
@@ -481,11 +481,11 @@ def test_search_and_label_filters(monkeypatch):
 
     list_panel_module = importlib.import_module("app.ui.list_panel")
     importlib.reload(list_panel_module)
-    RequirementModel = importlib.import_module("app.ui.requirement_model").RequirementModel
-    ListPanel = list_panel_module.ListPanel
+    requirement_model_cls = importlib.import_module("app.ui.requirement_model").RequirementModel
+    list_panel_cls = list_panel_module.ListPanel
 
     frame = wx_stub.Panel(None)
-    panel = ListPanel(frame, model=RequirementModel())
+    panel = list_panel_cls(frame, model=requirement_model_cls())
     panel.set_requirements([
         _req(1, "Login", labels=["ui"]),
         _req(2, "Export", labels=["report"]),
@@ -514,11 +514,11 @@ def test_apply_filters(monkeypatch):
 
     list_panel_module = importlib.import_module("app.ui.list_panel")
     importlib.reload(list_panel_module)
-    RequirementModel = importlib.import_module("app.ui.requirement_model").RequirementModel
-    ListPanel = list_panel_module.ListPanel
+    requirement_model_cls = importlib.import_module("app.ui.requirement_model").RequirementModel
+    list_panel_cls = list_panel_module.ListPanel
 
     frame = wx_stub.Panel(None)
-    panel = ListPanel(frame, model=RequirementModel())
+    panel = list_panel_cls(frame, model=requirement_model_cls())
     panel.set_requirements([
         _req(1, "Login", labels=["ui"], owner="alice"),
         _req(2, "Export", labels=["report"], owner="bob"),
@@ -541,11 +541,11 @@ def test_reset_button_visibility(monkeypatch):
 
     list_panel_module = importlib.import_module("app.ui.list_panel")
     importlib.reload(list_panel_module)
-    RequirementModel = importlib.import_module("app.ui.requirement_model").RequirementModel
-    ListPanel = list_panel_module.ListPanel
+    requirement_model_cls = importlib.import_module("app.ui.requirement_model").RequirementModel
+    list_panel_cls = list_panel_module.ListPanel
 
     frame = wx_stub.Panel(None)
-    panel = ListPanel(frame, model=RequirementModel())
+    panel = list_panel_cls(frame, model=requirement_model_cls())
     assert not panel.reset_btn.IsShown()
     panel.set_search_query("X")
     assert panel.reset_btn.IsShown()
@@ -563,11 +563,11 @@ def test_apply_status_filter(monkeypatch):
 
     list_panel_module = importlib.import_module("app.ui.list_panel")
     importlib.reload(list_panel_module)
-    RequirementModel = importlib.import_module("app.ui.requirement_model").RequirementModel
-    ListPanel = list_panel_module.ListPanel
+    requirement_model_cls = importlib.import_module("app.ui.requirement_model").RequirementModel
+    list_panel_cls = list_panel_module.ListPanel
 
     frame = wx_stub.Panel(None)
-    panel = ListPanel(frame, model=RequirementModel())
+    panel = list_panel_cls(frame, model=requirement_model_cls())
     panel.set_requirements([
         _req(1, "A", status=Status.DRAFT),
         _req(2, "B", status=Status.APPROVED),
@@ -589,11 +589,11 @@ def test_labels_column_uses_imagelist(monkeypatch):
 
     list_panel_module = importlib.import_module("app.ui.list_panel")
     importlib.reload(list_panel_module)
-    RequirementModel = importlib.import_module("app.ui.requirement_model").RequirementModel
-    ListPanel = list_panel_module.ListPanel
+    requirement_model_cls = importlib.import_module("app.ui.requirement_model").RequirementModel
+    list_panel_cls = list_panel_module.ListPanel
 
     frame = wx_stub.Panel(None)
-    panel = ListPanel(frame, model=RequirementModel())
+    panel = list_panel_cls(frame, model=requirement_model_cls())
     panel.set_columns(["labels"])
     panel.set_requirements([
         _req(1, "A", labels=["ui", "backend"]),
@@ -614,11 +614,11 @@ def test_sort_by_labels(monkeypatch):
 
     list_panel_module = importlib.import_module("app.ui.list_panel")
     importlib.reload(list_panel_module)
-    RequirementModel = importlib.import_module("app.ui.requirement_model").RequirementModel
-    ListPanel = list_panel_module.ListPanel
+    requirement_model_cls = importlib.import_module("app.ui.requirement_model").RequirementModel
+    list_panel_cls = list_panel_module.ListPanel
 
     frame = wx_stub.Panel(None)
-    panel = ListPanel(frame, model=RequirementModel())
+    panel = list_panel_cls(frame, model=requirement_model_cls())
     panel.set_columns(["labels"])
     panel.set_requirements([
         _req(1, "A", labels=["beta"]),
@@ -639,11 +639,11 @@ def test_sort_by_multiple_labels(monkeypatch):
 
     list_panel_module = importlib.import_module("app.ui.list_panel")
     importlib.reload(list_panel_module)
-    RequirementModel = importlib.import_module("app.ui.requirement_model").RequirementModel
-    ListPanel = list_panel_module.ListPanel
+    requirement_model_cls = importlib.import_module("app.ui.requirement_model").RequirementModel
+    list_panel_cls = list_panel_module.ListPanel
 
     frame = wx_stub.Panel(None)
-    panel = ListPanel(frame, model=RequirementModel())
+    panel = list_panel_cls(frame, model=requirement_model_cls())
     panel.set_columns(["labels"])
     panel.set_requirements([
         _req(1, "A", labels=["alpha", "zeta"]),
@@ -664,11 +664,11 @@ def test_bulk_edit_updates_requirements(monkeypatch):
 
     list_panel_module = importlib.import_module("app.ui.list_panel")
     importlib.reload(list_panel_module)
-    RequirementModel = importlib.import_module("app.ui.requirement_model").RequirementModel
-    ListPanel = list_panel_module.ListPanel
+    requirement_model_cls = importlib.import_module("app.ui.requirement_model").RequirementModel
+    list_panel_cls = list_panel_module.ListPanel
 
     frame = wx_stub.Panel(None)
-    panel = ListPanel(frame, model=RequirementModel())
+    panel = list_panel_cls(frame, model=requirement_model_cls())
     panel.set_columns(["version"])
     reqs = [
         _req(1, "A", version="1"),
@@ -691,12 +691,12 @@ def test_sort_method_and_callback(monkeypatch):
 
     list_panel_module = importlib.import_module("app.ui.list_panel")
     importlib.reload(list_panel_module)
-    RequirementModel = importlib.import_module("app.ui.requirement_model").RequirementModel
-    ListPanel = list_panel_module.ListPanel
+    requirement_model_cls = importlib.import_module("app.ui.requirement_model").RequirementModel
+    list_panel_cls = list_panel_module.ListPanel
 
     frame = wx_stub.Panel(None)
     calls = []
-    panel = ListPanel(frame, model=RequirementModel(), on_sort_changed=lambda c, a: calls.append((c, a)))
+    panel = list_panel_cls(frame, model=requirement_model_cls(), on_sort_changed=lambda c, a: calls.append((c, a)))
     panel.set_columns(["id"])
     panel.set_requirements([
         _req(2, "B"),
@@ -722,11 +722,11 @@ def test_reorder_columns(monkeypatch):
 
     list_panel_module = importlib.import_module("app.ui.list_panel")
     importlib.reload(list_panel_module)
-    RequirementModel = importlib.import_module("app.ui.requirement_model").RequirementModel
-    ListPanel = list_panel_module.ListPanel
+    requirement_model_cls = importlib.import_module("app.ui.requirement_model").RequirementModel
+    list_panel_cls = list_panel_module.ListPanel
 
     frame = wx_stub.Panel(None)
-    panel = ListPanel(frame, model=RequirementModel())
+    panel = list_panel_cls(frame, model=requirement_model_cls())
     panel.set_columns(["id", "status", "priority"])
     panel.reorder_columns(1, 3)
     assert panel.columns == ["status", "priority", "id"]

--- a/tests/gui/test_main.py
+++ b/tests/gui/test_main.py
@@ -25,8 +25,8 @@ def test_main_runs(monkeypatch):
             pass
 
     class DummyConfig:
-        def __init__(self, appName):
-            self.appName = appName
+        def __init__(self, **kwargs):
+            self.app_name = kwargs.get("appName")
         def Read(self, key):
             return ""
 

--- a/tests/integration/test_health_endpoint.py
+++ b/tests/integration/test_health_endpoint.py
@@ -9,6 +9,6 @@ def test_health_endpoint_returns_ok():
     from app.mcp.server import app
 
     client = TestClient(app)
-    resp = client.get('/health')
+    resp = client.get("/health")
     assert resp.status_code == 200
     assert resp.json() == {"status": "ok"}

--- a/tests/slow/test_translation_coverage.py
+++ b/tests/slow/test_translation_coverage.py
@@ -9,11 +9,11 @@ pytestmark = pytest.mark.slow
 
 
 def test_po_files_have_no_missing_translations():
-    base = Path('app/locale')
+    base = Path("app/locale")
     catalogs = {}
     all_ids = set()
     for lang_dir in base.iterdir():
-        po_path = lang_dir / 'LC_MESSAGES' / 'CookaReq.po'
+        po_path = lang_dir / "LC_MESSAGES" / "CookaReq.po"
         if po_path.exists():
             catalog = polib.pofile(str(po_path))
             catalogs[lang_dir.name] = catalog

--- a/tests/unit/test_config_manager.py
+++ b/tests/unit/test_config_manager.py
@@ -54,7 +54,7 @@ def test_save_and_restore_layout(tmp_path, log_shown, wx_app):
     cfg.save_layout(frame, splitter, main_splitter, panel)
 
     assert panel.saved_widths and panel.saved_order
-    assert cfg.ReadBool("log_shown") is log_shown
+    assert cfg.read_bool("log_shown") is log_shown
 
     new_frame = wx.Frame(None)
     new_main_splitter = wx.SplitterWindow(new_frame)
@@ -115,8 +115,8 @@ def test_sort_settings_round_trip(tmp_path, wx_app):
 
     cfg.set_sort_settings(3, False)
     assert cfg.get_sort_settings() == (3, False)
-    assert cfg.ReadInt("sort_column") == 3
-    assert cfg.ReadBool("sort_ascending") is False
+    assert cfg.read_int("sort_column") == 3
+    assert cfg.read_bool("sort_ascending") is False
 
 
 def test_restore_layout_without_show(tmp_path, wx_app):

--- a/tests/unit/test_config_manager_proxies.py
+++ b/tests/unit/test_config_manager_proxies.py
@@ -10,17 +10,17 @@ pytestmark = pytest.mark.unit
 def test_config_manager_proxy_methods(tmp_path, wx_app):
     cfg = ConfigManager(app_name="TestApp", path=tmp_path / "cfg.ini")
 
-    assert cfg.ReadInt("number", 5) == 5
-    cfg.WriteInt("number", 42)
-    cfg.Flush()
-    assert cfg.ReadInt("number", 0) == 42
+    assert cfg.read_int("number", 5) == 5
+    cfg.write_int("number", 42)
+    cfg.flush()
+    assert cfg.read_int("number", 0) == 42
 
-    assert cfg.Read("text", "") == ""
-    cfg.Write("text", "hello")
-    cfg.Flush()
-    assert cfg.Read("text", "") == "hello"
+    assert cfg.read("text", "") == ""
+    cfg.write("text", "hello")
+    cfg.flush()
+    assert cfg.read("text", "") == "hello"
 
-    assert cfg.ReadBool("flag", False) is False
-    cfg.WriteBool("flag", True)
-    cfg.Flush()
-    assert cfg.ReadBool("flag", False) is True
+    assert cfg.read_bool("flag", False) is False
+    cfg.write_bool("flag", True)
+    cfg.flush()
+    assert cfg.read_bool("flag", False) is True

--- a/tests/unit/test_i18n.py
+++ b/tests/unit/test_i18n.py
@@ -10,13 +10,13 @@ pytestmark = pytest.mark.unit
 def test_parse_po_multiline_and_unfinished(tmp_path):
     po_content = (
         "# comment\n"
-        "msgid \"hello\"\n"
-        "msgstr \"\"\n\n"
-        "msgid \"multi\"\n"
-        "\"id\"\n"
-        "msgstr \"multi\"\n"
-        "\"str\"\n\n"
-        "msgid \"unfinished\"\n"
+        'msgid "hello"\n'
+        'msgstr ""\n\n'
+        'msgid "multi"\n'
+        '"id"\n'
+        'msgstr "multi"\n'
+        '"str"\n\n'
+        'msgid "unfinished"\n'
         "# TODO\n"
     )
     po_path = tmp_path / "sample.po"

--- a/tests/unit/test_i18n_escape.py
+++ b/tests/unit/test_i18n_escape.py
@@ -18,7 +18,7 @@ def test_flush_missing_escape(tmp_path):
     path = tmp_path / "missing.po"
     i18n.flush_missing(path)
     content = path.read_text(encoding="utf-8")
-    assert 'Line\\nBreak\\tTab' in content
+    assert "Line\\nBreak\\tTab" in content
     parsed = i18n._parse_po(path)
     assert "Line\nBreak\tTab" in parsed
     i18n._missing.clear()

--- a/tests/unit/test_locale.py
+++ b/tests/unit/test_locale.py
@@ -18,16 +18,16 @@ def test_round_trip():
 
 
 def test_unknown_values_return_input():
-    assert locale.code_to_label('type', 'unknown') == 'unknown'
-    assert locale.label_to_code('type', 'Unknown') == 'Unknown'
+    assert locale.code_to_label("type", "unknown") == "unknown"
+    assert locale.label_to_code("type", "Unknown") == "Unknown"
 
 
 def _enum_label(e):
-    return e.name.replace('_', ' ').lower().capitalize()
+    return e.name.replace("_", " ").lower().capitalize()
 
 
 @pytest.mark.parametrize(
-    'enum_cls,mapping',
+    "enum_cls,mapping",
     [
         (model.RequirementType, locale.TYPE),
         (model.Status, locale.STATUS),


### PR DESCRIPTION
## Summary
- enable Ruff checks for naming, timezones, and quote style
- rename ConfigManager methods to snake_case and update UI components
- fix local time utility to use timezone-aware datetime

## Testing
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c6a78dd2608320b0da0ca7033687ee