### PR TITLE
feat: enforce additional lint rules

### DIFF
--- a/app/llm/client.py
+++ b/app/llm/client.py
@@ -122,8 +122,6 @@ class LLMClient:
                 tool_call = message.tool_calls[0]
                 name = tool_call.function.name
                 arguments = json.loads(tool_call.function.arguments or "{}")
-            log_event("LLM_RESPONSE", {"tool": name, "arguments": arguments}, start_time=start)
-            return name, arguments
         except Exception as exc:  # pragma: no cover - network errors
             log_event(
                 "LLM_RESPONSE",
@@ -131,3 +129,6 @@ class LLMClient:
                 start_time=start,
             )
             raise
+        else:
+            log_event("LLM_RESPONSE", {"tool": name, "arguments": arguments}, start_time=start)
+            return name, arguments

--- a/app/mcp/client.py
+++ b/app/mcp/client.py
@@ -59,6 +59,11 @@ class MCPClient:
                 body = resp.read().decode()
             finally:
                 conn.close()
+        except Exception as exc:  # pragma: no cover - network errors
+            err = mcp_error(ErrorCode.INTERNAL, str(exc))["error"]
+            log_event("TOOL_RESULT", {"error": err}, start_time=start)
+            return err
+        else:
             data = json.loads(body or "{}")
             if resp.status == 200 and "error" not in data:
                 log_event("TOOL_RESULT", {"ok": True}, start_time=start)
@@ -66,10 +71,6 @@ class MCPClient:
             err = data.get("error")
             if not err:
                 err = {"code": str(resp.status), "message": data.get("message", "")}
-            log_event("TOOL_RESULT", {"error": err}, start_time=start)
-            return err
-        except Exception as exc:  # pragma: no cover - network errors
-            err = mcp_error(ErrorCode.INTERNAL, str(exc))["error"]
             log_event("TOOL_RESULT", {"error": err}, start_time=start)
             return err
 
@@ -107,6 +108,12 @@ class MCPClient:
                 body = resp.read().decode()
             finally:
                 conn.close()
+        except Exception as exc:  # pragma: no cover - network errors
+            err = mcp_error(ErrorCode.INTERNAL, str(exc))["error"]
+            log_event("TOOL_RESULT", {"error": err}, start_time=start)
+            log_event("ERROR", {"error": err})
+            return {"error": err}
+        else:
             data = json.loads(body or "{}")
             if resp.status == 200 and "error" not in data:
                 log_event("TOOL_RESULT", {"result": data}, start_time=start)
@@ -115,11 +122,6 @@ class MCPClient:
             err = data.get("error")
             if not err:
                 err = {"code": str(resp.status), "message": data.get("message", "")}
-            log_event("TOOL_RESULT", {"error": err}, start_time=start)
-            log_event("ERROR", {"error": err})
-            return {"error": err}
-        except Exception as exc:  # pragma: no cover - network errors
-            err = mcp_error(ErrorCode.INTERNAL, str(exc))["error"]
             log_event("TOOL_RESULT", {"error": err}, start_time=start)
             log_event("ERROR", {"error": err})
             return {"error": err}

--- a/app/mcp/server.py
+++ b/app/mcp/server.py
@@ -43,7 +43,7 @@ def _configure_request_logging(log_dir: str | Path) -> None:
     configure_logging()
     # Remove previous request handlers if any from the dedicated logger
     for h in list(request_logger.handlers):
-        if getattr(h, "_cookareq_request", False):
+        if getattr(h, "cookareq_request", False):
             request_logger.removeHandler(h)
             h.close()
 
@@ -53,12 +53,12 @@ def _configure_request_logging(log_dir: str | Path) -> None:
     text_path = log_dir_path / _TEXT_LOG_NAME
     text_handler = logging.FileHandler(text_path)
     text_handler.setFormatter(logging.Formatter("%(asctime)s %(levelname)s %(message)s"))
-    text_handler._cookareq_request = True
+    text_handler.cookareq_request = True
     request_logger.addHandler(text_handler)
 
     json_path = log_dir_path / _JSONL_LOG_NAME
     json_handler = JsonlHandler(json_path)
-    json_handler._cookareq_request = True
+    json_handler.cookareq_request = True
     request_logger.addHandler(json_handler)
 
 
@@ -312,6 +312,6 @@ def stop_server() -> None:
     _server_thread = None
 
     for h in list(request_logger.handlers):
-        if getattr(h, "_cookareq_request", False):
+        if getattr(h, "cookareq_request", False):
             request_logger.removeHandler(h)
             h.close()

--- a/app/ui/editor_panel.py
+++ b/app/ui/editor_panel.py
@@ -1001,9 +1001,11 @@ class EditorPanel(ScrolledPanel):
             return
         try:
             req_id = int(value)
-            if req_id <= 0:
-                raise ValueError
-        except Exception:
+        except (TypeError, ValueError):
+            ctrl.SetBackgroundColour(wx.Colour(255, 200, 200))
+            ctrl.Refresh()
+            return
+        if req_id <= 0:
             ctrl.SetBackgroundColour(wx.Colour(255, 200, 200))
             ctrl.Refresh()
             return

--- a/app/ui/main_frame.py
+++ b/app/ui/main_frame.py
@@ -38,6 +38,16 @@ class WxLogHandler(logging.Handler):
         self._target = target
         self.setFormatter(logging.Formatter("%(levelname)s: %(message)s"))
 
+    @property
+    def target(self) -> wx.TextCtrl:
+        """Current ``wx.TextCtrl`` receiving log output."""
+        return self._target
+
+    @target.setter
+    def target(self, new_target: wx.TextCtrl) -> None:
+        """Redirect log output to ``new_target``."""
+        self._target = new_target
+
     def emit(self, record: logging.LogRecord) -> None:  # pragma: no cover - GUI side effect
         """Append formatted ``record`` text to the log console."""
 
@@ -142,7 +152,7 @@ class MainFrame(wx.Frame):
         existing = next((h for h in logger.handlers if isinstance(h, WxLogHandler)), None)
         if existing:
             self.log_handler = existing
-            self.log_handler._target = self.log_console
+            self.log_handler.target = self.log_console
         else:
             self.log_handler = WxLogHandler(self.log_console)
             self.log_handler.setLevel(logging.WARNING)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,12 +50,14 @@ select = [
     "N",
     "DTZ",
     "Q",
+    "SLF",
+    "TRY",
 ]
 
-ignore = ["RUF001", "RUF003"]
+ignore = ["RUF001", "RUF003", "TRY003"]
 
 [tool.ruff.lint.per-file-ignores]
-"tests/**/*" = ["ARG001", "ARG002", "ARG003", "ARG004", "ARG005", "N802"]
+"tests/**/*" = ["ARG001", "ARG002", "ARG003", "ARG004", "ARG005", "N802", "SLF001"]
 "app/ui/helpers.py" = ["N802", "N803"]
 "app/ui/list_panel.py" = ["N802"]
 "app/ui/labels_dialog.py" = ["N802"]

--- a/tests/mcp_utils.py
+++ b/tests/mcp_utils.py
@@ -17,6 +17,7 @@ def _wait_until_ready(port, headers=None):
     for _ in range(50):
         try:
             _request(port, headers=headers)
-            return
         except ConnectionRefusedError:
             time.sleep(0.1)
+        else:
+            return


### PR DESCRIPTION
## Summary
- enable Ruff TRY and SLF rule sets, ignore TRY003 and tests' SLF001
- refactor code to avoid private member access and move returns to else blocks
- adjust tests to follow new exception handling lint rules

## Testing
- `ruff check`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c6a9a7f6b08320b0e8cdbf7ddd2ca4