### PR TITLE
Enable performance linting and refactor loops

### DIFF
--- a/app/ui/filter_dialog.py
+++ b/app/ui/filter_dialog.py
@@ -10,6 +10,14 @@ from . import locale
 from .enums import ENUMS
 
 
+def _safe_colour(value: str) -> wx.Colour | None:
+    """Return ``wx.Colour`` from *value* or ``None`` on failure."""
+    try:  # pragma: no cover - platform dependent
+        return wx.Colour(value)
+    except Exception:  # pragma: no cover - platform dependent
+        return None
+
+
 class FilterDialog(wx.Dialog):
     """Dialog allowing to configure various filters."""
 
@@ -49,12 +57,10 @@ class FilterDialog(wx.Dialog):
         choices = [lbl.name for lbl in self._labels]
         self.labels_box = wx.CheckListBox(self, choices=choices)
         for i, lbl in enumerate(self._labels):
-            try:
-                colour = wx.Colour(lbl.color)
+            colour = _safe_colour(lbl.color)
+            if colour is not None:
                 self.labels_box.SetItemBackgroundColour(i, colour)
                 self.labels_box.SetItemForegroundColour(i, wx.BLACK)
-            except Exception:  # pragma: no cover - platform dependent
-                pass
         for lbl in values.get("labels", []):
             names = [label_obj.name for label_obj in self._labels]
             if lbl in names:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ select = [
     "T20",
     "N",
     "DTZ",
+    "PERF",
     "Q",
     "SLF",
     "TRY",

--- a/tests/mcp_utils.py
+++ b/tests/mcp_utils.py
@@ -13,11 +13,16 @@ def _request(port, headers=None):
     return resp.status, body
 
 
+def _try_request(port, headers=None) -> bool:
+    try:
+        _request(port, headers=headers)
+    except ConnectionRefusedError:
+        return False
+    return True
+
+
 def _wait_until_ready(port, headers=None):
     for _ in range(50):
-        try:
-            _request(port, headers=headers)
-        except ConnectionRefusedError:
-            time.sleep(0.1)
-        else:
+        if _try_request(port, headers=headers):
             return
+        time.sleep(0.1)


### PR DESCRIPTION
## Summary
- enable Ruff PERF rules for performance checks
- refactor label color setup to avoid try/except in loops
- simplify MCP test helpers to reduce loop overhead

## Testing
- `python3 -m ruff check`
- `python3 -m pydocstyle`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6ab26208483208486b2c7fa82c7d7