### PR TITLE
Enable trailing comma rule in Ruff

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,3 +1,1 @@
 """Top-level package for the CookaReq application."""
-
-

--- a/app/cli/__init__.py
+++ b/app/cli/__init__.py
@@ -18,4 +18,3 @@ def __getattr__(name: str) -> Any:
 
 
 __all__ = ["main"]
-

--- a/app/cli/__main__.py
+++ b/app/cli/__main__.py
@@ -1,4 +1,5 @@
 """Module entry point for ``python -m app.cli``."""
+
 from .main import main
 
 if __name__ == "__main__":

--- a/app/cli/commands.py
+++ b/app/cli/commands.py
@@ -141,7 +141,9 @@ def cmd_show(args: argparse.Namespace, repo: RequirementRepository) -> None:
     """Show detailed JSON for requirement with *id*."""
     req = repo.get(args.directory, args.id)
     data = model.requirement_to_dict(req)
-    sys.stdout.write(json.dumps(data, ensure_ascii=False, indent=2, sort_keys=True) + "\n")
+    sys.stdout.write(
+        json.dumps(data, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+    )
 
 
 def add_show_arguments(p: argparse.ArgumentParser) -> None:
@@ -158,7 +160,9 @@ def cmd_check(args: argparse.Namespace, _repo: RequirementRepository) -> None:
         results["llm"] = agent.check_llm()
     if args.mcp or not (args.llm or args.mcp):
         results["mcp"] = agent.check_tools()
-    sys.stdout.write(json.dumps(results, ensure_ascii=False, indent=2, sort_keys=True) + "\n")
+    sys.stdout.write(
+        json.dumps(results, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+    )
 
 
 def add_check_arguments(p: argparse.ArgumentParser) -> None:

--- a/app/config.py
+++ b/app/config.py
@@ -29,7 +29,11 @@ class ListPanelLike(Protocol):
 class ConfigManager:
     """Wrapper around :class:`wx.Config` with typed helpers."""
 
-    def __init__(self, app_name: str = "CookaReq", path: Path | str | None = None) -> None:
+    def __init__(
+        self,
+        app_name: str = "CookaReq",
+        path: Path | str | None = None,
+    ) -> None:
         """Initialize configuration storage.
 
         Parameters
@@ -191,9 +195,7 @@ class ConfigManager:
             model=self._cfg.Read("llm_model", ""),
             api_key=self._cfg.Read("llm_api_key", "") or None,
             max_retries=self._cfg.ReadInt("llm_max_retries", 3),
-            max_output_tokens=(
-                self._cfg.ReadInt("llm_max_output_tokens", 0) or None
-            ),
+            max_output_tokens=(self._cfg.ReadInt("llm_max_output_tokens", 0) or None),
             timeout_minutes=self._cfg.ReadInt("llm_timeout_minutes", 60),
             stream=self._cfg.ReadBool("llm_stream", False),
         )
@@ -206,7 +208,8 @@ class ConfigManager:
         self._cfg.Write("llm_api_key", settings.api_key or "")
         self._cfg.WriteInt("llm_max_retries", settings.max_retries)
         self._cfg.WriteInt(
-            "llm_max_output_tokens", settings.max_output_tokens or 0
+            "llm_max_output_tokens",
+            settings.max_output_tokens or 0,
         )
         self._cfg.WriteInt("llm_timeout_minutes", settings.timeout_minutes)
         self._cfg.WriteBool("llm_stream", settings.stream)

--- a/app/core/label_repository.py
+++ b/app/core/label_repository.py
@@ -1,4 +1,5 @@
 """Label repository interface and implementations."""
+
 from __future__ import annotations
 
 from pathlib import Path

--- a/app/core/label_store.py
+++ b/app/core/label_store.py
@@ -1,4 +1,5 @@
 """JSON file storage for label data."""
+
 from __future__ import annotations
 
 import json
@@ -42,5 +43,11 @@ def save_labels(directory: str | Path, labels: list[Label]) -> Path:
     directory.mkdir(parents=True, exist_ok=True)
     path = directory / LABELS_FILENAME
     with path.open("w", encoding="utf-8") as fh:
-        json.dump([asdict(lbl) for lbl in labels], fh, ensure_ascii=False, indent=2, sort_keys=True)
+        json.dump(
+            [asdict(lbl) for lbl in labels],
+            fh,
+            ensure_ascii=False,
+            indent=2,
+            sort_keys=True,
+        )
     return path

--- a/app/core/labels.py
+++ b/app/core/labels.py
@@ -1,4 +1,5 @@
 """Label definitions, preset sets and in-memory CRUD helpers."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass
@@ -27,45 +28,55 @@ def _preset(names: list[str]) -> list[Label]:
 
 
 PRESET_SETS: dict[str, list[Label]] = {
-    "basic": _preset([
-        "functional",
-        "non-functional",
-        "ui",
-        "performance",
-        "reliability",
-        "safety",
-        "security",
-        "usability",
-        "constraint",
-        "regulatory",
-    ]),
-    "role": _preset([
-        "system",
-        "software",
-        "hardware",
-        "integration",
-        "test",
-    ]),
-    "status": _preset([
-        "draft",
-        "approved",
-        "in-progress",
-        "implemented",
-        "verified",
-        "obsolete",
-    ]),
-    "priority": _preset([
-        "high",
-        "medium",
-        "low",
-    ]),
-    "additional": _preset([
-        "critical",
-        "derived",
-        "untested",
-        "suspect-link",
-        "attachments",
-    ]),
+    "basic": _preset(
+        [
+            "functional",
+            "non-functional",
+            "ui",
+            "performance",
+            "reliability",
+            "safety",
+            "security",
+            "usability",
+            "constraint",
+            "regulatory",
+        ],
+    ),
+    "role": _preset(
+        [
+            "system",
+            "software",
+            "hardware",
+            "integration",
+            "test",
+        ],
+    ),
+    "status": _preset(
+        [
+            "draft",
+            "approved",
+            "in-progress",
+            "implemented",
+            "verified",
+            "obsolete",
+        ],
+    ),
+    "priority": _preset(
+        [
+            "high",
+            "medium",
+            "low",
+        ],
+    ),
+    "additional": _preset(
+        [
+            "critical",
+            "derived",
+            "untested",
+            "suspect-link",
+            "attachments",
+        ],
+    ),
 }
 
 PRESET_SET_TITLES: dict[str, str] = {

--- a/app/core/model.py
+++ b/app/core/model.py
@@ -1,4 +1,5 @@
 """Domain models for requirements."""
+
 from __future__ import annotations
 
 from dataclasses import asdict, dataclass, field
@@ -123,8 +124,12 @@ def requirement_from_dict(data: dict[str, Any]) -> Requirement:
     derived_from = [RequirementLink(**d) for d in data.get("derived_from", [])]
     links_data = data.get("links", {})
     links = Links(
-        verifies=[RequirementLink(**link_data) for link_data in links_data.get("verifies", [])],
-        relates=[RequirementLink(**link_data) for link_data in links_data.get("relates", [])],
+        verifies=[
+            RequirementLink(**link_data) for link_data in links_data.get("verifies", [])
+        ],
+        relates=[
+            RequirementLink(**link_data) for link_data in links_data.get("relates", [])
+        ],
     )
     derivation_data = data.get("derivation")
     derivation = DerivationInfo(**derivation_data) if derivation_data else None
@@ -163,11 +168,14 @@ def requirement_from_dict(data: dict[str, Any]) -> Requirement:
 def requirement_to_dict(req: Requirement) -> dict[str, Any]:
     """Convert ``req`` into a plain ``dict`` suitable for JSON storage."""
     data = asdict(req)
-    if "links" in data and not data["links"]["verifies"] and not data["links"]["relates"]:
+    if (
+        "links" in data
+        and not data["links"]["verifies"]
+        and not data["links"]["relates"]
+    ):
         del data["links"]
     for key in ("type", "status", "priority", "verification"):
         value = data.get(key)
         if isinstance(value, Enum):
             data[key] = value.value
     return {k: v for k, v in data.items() if v is not None}
-

--- a/app/core/repository.py
+++ b/app/core/repository.py
@@ -67,7 +67,11 @@ class FileRequirementRepository(RequirementRepository):
         """Search requirements in ``directory`` with optional filters."""
 
         return req_ops.search_requirements(
-            directory, query=query, labels=labels, fields=fields, status=status
+            directory,
+            query=query,
+            labels=labels,
+            fields=fields,
+            status=status,
         )
 
     def load(self, directory: str | Path, req_id: int) -> tuple[dict, float]:  # type: ignore[override]
@@ -91,7 +95,10 @@ class FileRequirementRepository(RequirementRepository):
         """Persist requirement ``data`` to ``directory`` and return path."""
 
         return req_ops.save_requirement(
-            directory, data, mtime=mtime, modified_at=modified_at
+            directory,
+            data,
+            mtime=mtime,
+            modified_at=modified_at,
         )
 
     def delete(self, directory: str | Path, req_id: int) -> None:  # type: ignore[override]

--- a/app/core/requirements.py
+++ b/app/core/requirements.py
@@ -4,6 +4,7 @@ This module centralizes business logic for loading, searching and
 modifying requirements. It is used by CLI, MCP tools and can be reused by
 GUI components.
 """
+
 from __future__ import annotations
 
 from collections.abc import Iterable, Mapping, Sequence
@@ -25,6 +26,7 @@ from .store import (
 # Re-export searchable fields for UI components
 SEARCHABLE_FIELDS = core_search.SEARCHABLE_FIELDS
 
+
 def load_all(directory: str | Path) -> list[Requirement]:
     """Load all requirements from *directory*.
 
@@ -41,7 +43,8 @@ def load_all(directory: str | Path) -> list[Requirement]:
 
 
 def filter_by_status(
-    requirements: Iterable[Requirement], status: str | Status | None
+    requirements: Iterable[Requirement],
+    status: str | Status | None,
 ) -> list[Requirement]:
     """Filter ``requirements`` by ``status`` if provided."""
     reqs = list(requirements)
@@ -69,7 +72,12 @@ def search_requirements(
     """
     reqs = load_all(directory)
     reqs = filter_by_status(reqs, status)
-    return core_search.search(reqs, labels=list(labels or []), query=query, fields=fields)
+    return core_search.search(
+        reqs,
+        labels=list(labels or []),
+        query=query,
+        fields=fields,
+    )
 
 
 def load_requirement(directory: str | Path, req_id: int) -> tuple[dict, float]:
@@ -142,7 +150,8 @@ def search_loaded(
 
 
 def load_labels(
-    directory: str | Path, repo: LabelRepository | None = None
+    directory: str | Path,
+    repo: LabelRepository | None = None,
 ) -> list[Label]:
     """Load labels from ``directory`` using ``repo`` if provided."""
     repo = repo or FileLabelRepository()
@@ -150,7 +159,9 @@ def load_labels(
 
 
 def save_labels(
-    directory: str | Path, labels: list[Label], repo: LabelRepository | None = None
+    directory: str | Path,
+    labels: list[Label],
+    repo: LabelRepository | None = None,
 ):
     """Persist ``labels`` into ``directory`` using ``repo`` if provided."""
     repo = repo or FileLabelRepository()

--- a/app/core/schema.py
+++ b/app/core/schema.py
@@ -1,4 +1,5 @@
 """JSON Schema for requirement files."""
+
 from __future__ import annotations
 
 from typing import Any

--- a/app/core/search.py
+++ b/app/core/search.py
@@ -1,4 +1,5 @@
 """In-memory search helpers for requirements."""
+
 from __future__ import annotations
 
 from collections.abc import Iterable, Mapping, Sequence
@@ -14,6 +15,7 @@ SEARCHABLE_FIELDS = {
     "owner",
     "notes",
 }
+
 
 def filter_by_labels(
     requirements: Iterable[Requirement],

--- a/app/core/store.py
+++ b/app/core/store.py
@@ -1,4 +1,5 @@
 """JSON file storage for requirements."""
+
 from __future__ import annotations
 
 import json
@@ -188,4 +189,3 @@ def mark_suspects(directory: str | Path, changed_id: int, new_revision: int) -> 
         if changed:
             with fp.open("w", encoding="utf-8") as fh:
                 json.dump(data, fh, ensure_ascii=False, indent=2, sort_keys=True)
-

--- a/app/i18n.py
+++ b/app/i18n.py
@@ -5,6 +5,7 @@ avoiding the need for compiled ``.mo`` binaries.  It provides a small subset
 of the ``gettext`` API: ``gettext`` (aliased as ``_``) and ``install`` to set
 the active language.
 """
+
 from __future__ import annotations
 
 import threading
@@ -30,6 +31,7 @@ def _escape(text: str) -> str:
         .replace("\n", "\\n")
         .replace("\t", "\\t")
     )
+
 
 _translations: dict[str, str] = {}
 _missing: set[str] = set()
@@ -124,7 +126,11 @@ def flush_missing(path: Path) -> None:
         _missing.clear()
 
 
-def install(domain: str, localedir: str, languages: Iterable[str] | None = None) -> None:
+def install(
+    domain: str,
+    localedir: str,
+    languages: Iterable[str] | None = None,
+) -> None:
     """Load translations for ``languages`` and make ``gettext`` use them."""
     global _translations
     languages = list(languages or [])

--- a/app/llm/client.py
+++ b/app/llm/client.py
@@ -64,7 +64,10 @@ class LLMClient:
                 {"error": {"type": type(exc).__name__, "message": str(exc)}},
                 start_time=start,
             )
-            return {"ok": False, "error": {"type": type(exc).__name__, "message": str(exc)}}
+            return {
+                "ok": False,
+                "error": {"type": type(exc).__name__, "message": str(exc)},
+            }
         log_event("LLM_RESPONSE", {"ok": True}, start_time=start)
         return {"ok": True}
 
@@ -130,5 +133,9 @@ class LLMClient:
             )
             raise
         else:
-            log_event("LLM_RESPONSE", {"tool": name, "arguments": arguments}, start_time=start)
+            log_event(
+                "LLM_RESPONSE",
+                {"tool": name, "arguments": arguments},
+                start_time=start,
+            )
             return name, arguments

--- a/app/llm/spec.py
+++ b/app/llm/spec.py
@@ -35,7 +35,7 @@ TOOLS: list[dict[str, Any]] = [
                     "per_page": {
                         "type": "integer",
                         "description": "number of items per page",
-                    }
+                    },
                 },
                 "required": [],
                 "additionalProperties": False,
@@ -93,7 +93,7 @@ TOOLS: list[dict[str, Any]] = [
                                     "requirement",
                                     "constraint",
                                     "interface",
-                                ]
+                                ],
                             },
                             "status": {
                                 "enum": [
@@ -102,11 +102,11 @@ TOOLS: list[dict[str, Any]] = [
                                     "approved",
                                     "baselined",
                                     "retired",
-                                ]
+                                ],
                             },
                             "owner": {"type": "string"},
                             "priority": {
-                                "enum": ["low", "medium", "high"]
+                                "enum": ["low", "medium", "high"],
                             },
                             "source": {"type": "string"},
                             "verification": {
@@ -115,7 +115,7 @@ TOOLS: list[dict[str, Any]] = [
                                     "analysis",
                                     "demonstration",
                                     "test",
-                                ]
+                                ],
                             },
                             "labels": {
                                 "type": "array",
@@ -134,7 +134,7 @@ TOOLS: list[dict[str, Any]] = [
                             "verification",
                         ],
                         "additionalProperties": True,
-                    }
+                    },
                 },
                 "required": ["data"],
                 "additionalProperties": False,
@@ -201,4 +201,3 @@ TOOLS: list[dict[str, Any]] = [
         },
     },
 ]
-

--- a/app/log.py
+++ b/app/log.py
@@ -45,4 +45,3 @@ def configure_logging(level: int = logging.INFO) -> None:
 
 
 __all__ = ["JsonlHandler", "configure_logging", "logger"]
-

--- a/app/mcp/__init__.py
+++ b/app/mcp/__init__.py
@@ -1,3 +1,1 @@
 """MCP server and client utilities package."""
-
-

--- a/app/mcp/client.py
+++ b/app/mcp/client.py
@@ -17,7 +17,12 @@ from .utils import ErrorCode, mcp_error, sanitize
 class MCPClient:
     """Simple HTTP client for the MCP server."""
 
-    def __init__(self, settings: MCPSettings, *, confirm: Callable[[str], bool]) -> None:
+    def __init__(
+        self,
+        settings: MCPSettings,
+        *,
+        confirm: Callable[[str], bool],
+    ) -> None:
         """Initialize client with MCP ``settings`` and confirmation callback."""
         self.settings = settings
         self._confirm = confirm
@@ -49,7 +54,7 @@ class MCPClient:
             try:
                 path = "/mcp"
                 payload = json.dumps(
-                    {"name": "list_requirements", "arguments": {"per_page": 1}}
+                    {"name": "list_requirements", "arguments": {"per_page": 1}},
                 )
                 headers = {"Content-Type": "application/json"}
                 if self.settings.require_token and self.settings.token:

--- a/app/mcp/controller.py
+++ b/app/mcp/controller.py
@@ -19,7 +19,6 @@ class MCPStatus(str, Enum):
     ERROR = "error"
 
 
-
 @dataclass
 class MCPCheckResult:
     """Detailed result of :meth:`MCPController.check`."""

--- a/app/mcp/server.py
+++ b/app/mcp/server.py
@@ -52,7 +52,9 @@ def _configure_request_logging(log_dir: str | Path) -> None:
 
     text_path = log_dir_path / _TEXT_LOG_NAME
     text_handler = logging.FileHandler(text_path)
-    text_handler.setFormatter(logging.Formatter("%(asctime)s %(levelname)s %(message)s"))
+    text_handler.setFormatter(
+        logging.Formatter("%(asctime)s %(levelname)s %(message)s"),
+    )
     text_handler.cookareq_request = True
     request_logger.addHandler(text_handler)
 
@@ -74,7 +76,11 @@ def _log_request(request: Request, status: int) -> None:
         "status": status,
     }
     request_logger.info(
-        "%s %s -> %s", request.method, request.url.path, status, extra={"json": entry}
+        "%s %s -> %s",
+        request.method,
+        request.url.path,
+        status,
+        extra={"json": entry},
     )
 
 
@@ -100,6 +106,7 @@ async def auth_middleware(request: Request, call_next):
 async def health() -> dict[str, str]:
     """Simple readiness probe used by external tools."""
     return {"status": "ok"}
+
 
 # FastMCP provides the server-side implementation of the MCP protocol.
 # Tools are registered via decorators below and invoked through the custom
@@ -224,7 +231,8 @@ async def call_tool(request: Request) -> JSONResponse:
         body = await request.json()
     except Exception:  # pragma: no cover - defensive
         return JSONResponse(
-            mcp_error(ErrorCode.VALIDATION_ERROR, "invalid json"), status_code=400
+            mcp_error(ErrorCode.VALIDATION_ERROR, "invalid json"),
+            status_code=400,
         )
 
     name = body.get("name")
@@ -246,9 +254,11 @@ async def call_tool(request: Request) -> JSONResponse:
         result = func(**arguments)
     except TypeError as exc:
         return JSONResponse(
-            mcp_error(ErrorCode.VALIDATION_ERROR, str(exc)), status_code=400
+            mcp_error(ErrorCode.VALIDATION_ERROR, str(exc)),
+            status_code=400,
         )
     return JSONResponse(result)
+
 
 # Internal state for the background server
 _uvicorn_server: uvicorn.Server | None = None

--- a/app/mcp/tools_read.py
+++ b/app/mcp/tools_read.py
@@ -1,4 +1,5 @@
 """Utility functions for MCP requirement access."""
+
 from __future__ import annotations
 
 from collections.abc import Sequence
@@ -43,11 +44,17 @@ def list_requirements(
         return log_tool(
             "list_requirements",
             params,
-            mcp_error(ErrorCode.NOT_FOUND, "directory not found", {"directory": str(directory)}),
+            mcp_error(
+                ErrorCode.NOT_FOUND,
+                "directory not found",
+                {"directory": str(directory)},
+            ),
         )
     except Exception as exc:  # pragma: no cover - defensive
         return log_tool(
-            "list_requirements", params, mcp_error(ErrorCode.INTERNAL, str(exc))
+            "list_requirements",
+            params,
+            mcp_error(ErrorCode.INTERNAL, str(exc)),
         )
     return log_tool("list_requirements", params, _paginate(reqs, page, per_page))
 
@@ -65,7 +72,9 @@ def get_requirement(directory: str | Path, req_id: int) -> dict:
         )
     except Exception as exc:  # pragma: no cover - defensive
         return log_tool(
-            "get_requirement", params, mcp_error(ErrorCode.INTERNAL, str(exc))
+            "get_requirement",
+            params,
+            mcp_error(ErrorCode.INTERNAL, str(exc)),
         )
     return log_tool("get_requirement", params, requirement_to_dict(req))
 
@@ -90,16 +99,25 @@ def search_requirements(
     }
     try:
         reqs = req_ops.search_requirements(
-            directory, query=query, labels=labels, status=status
+            directory,
+            query=query,
+            labels=labels,
+            status=status,
         )
     except FileNotFoundError:
         return log_tool(
             "search_requirements",
             params,
-            mcp_error(ErrorCode.NOT_FOUND, "directory not found", {"directory": str(directory)}),
+            mcp_error(
+                ErrorCode.NOT_FOUND,
+                "directory not found",
+                {"directory": str(directory)},
+            ),
         )
     except Exception as exc:  # pragma: no cover - defensive
         return log_tool(
-            "search_requirements", params, mcp_error(ErrorCode.INTERNAL, str(exc))
+            "search_requirements",
+            params,
+            mcp_error(ErrorCode.INTERNAL, str(exc)),
         )
     return log_tool("search_requirements", params, _paginate(reqs, page, per_page))

--- a/app/mcp/tools_write.py
+++ b/app/mcp/tools_write.py
@@ -1,4 +1,5 @@
 """Requirement mutation utilities for MCP server."""
+
 from __future__ import annotations
 
 from collections.abc import Mapping
@@ -57,6 +58,7 @@ PATCH_SCHEMA = {
     },
 }
 
+
 def create_requirement(directory: str | Path, data: Mapping[str, Any]) -> dict:
     """Create a new requirement in ``directory`` from ``data``.
 
@@ -71,15 +73,21 @@ def create_requirement(directory: str | Path, data: Mapping[str, Any]) -> dict:
         req_ops.save_requirement(directory, obj, modified_at=obj.modified_at or None)
     except ConflictError as exc:
         return log_tool(
-            "create_requirement", params, mcp_error(ErrorCode.CONFLICT, str(exc))
+            "create_requirement",
+            params,
+            mcp_error(ErrorCode.CONFLICT, str(exc)),
         )
     except (ValueError, KeyError) as exc:
         return log_tool(
-            "create_requirement", params, mcp_error(ErrorCode.VALIDATION_ERROR, str(exc))
+            "create_requirement",
+            params,
+            mcp_error(ErrorCode.VALIDATION_ERROR, str(exc)),
         )
     except Exception as exc:  # pragma: no cover - defensive
         return log_tool(
-            "create_requirement", params, mcp_error(ErrorCode.INTERNAL, str(exc))
+            "create_requirement",
+            params,
+            mcp_error(ErrorCode.INTERNAL, str(exc)),
         )
     return log_tool("create_requirement", params, requirement_to_dict(obj))
 
@@ -175,15 +183,21 @@ def patch_requirement(
         req_ops.save_requirement(directory, obj, mtime=mtime, modified_at=mod)
     except ConflictError as exc:
         return log_tool(
-            "patch_requirement", params, mcp_error(ErrorCode.CONFLICT, str(exc))
+            "patch_requirement",
+            params,
+            mcp_error(ErrorCode.CONFLICT, str(exc)),
         )
     except (ValueError, KeyError) as exc:
         return log_tool(
-            "patch_requirement", params, mcp_error(ErrorCode.VALIDATION_ERROR, str(exc))
+            "patch_requirement",
+            params,
+            mcp_error(ErrorCode.VALIDATION_ERROR, str(exc)),
         )
     except Exception as exc:  # pragma: no cover - defensive
         return log_tool(
-            "patch_requirement", params, mcp_error(ErrorCode.INTERNAL, str(exc))
+            "patch_requirement",
+            params,
+            mcp_error(ErrorCode.INTERNAL, str(exc)),
         )
     return log_tool("patch_requirement", params, requirement_to_dict(obj))
 
@@ -213,7 +227,9 @@ def delete_requirement(directory: str | Path, req_id: int, *, rev: int) -> dict 
         req_ops.delete_requirement(directory, req_id)
     except Exception as exc:  # pragma: no cover - defensive
         return log_tool(
-            "delete_requirement", params, mcp_error(ErrorCode.INTERNAL, str(exc))
+            "delete_requirement",
+            params,
+            mcp_error(ErrorCode.INTERNAL, str(exc)),
         )
     return log_tool("delete_requirement", params, {"id": req_id})
 
@@ -279,12 +295,20 @@ def link_requirements(
     if link_type == "parent":
         data["parent"] = link
     elif link_type == "derived_from":
-        links = [item for item in data.get("derived_from", []) if item.get("source_id") != source_id]
+        links = [
+            item
+            for item in data.get("derived_from", [])
+            if item.get("source_id") != source_id
+        ]
         links.append(link)
         data["derived_from"] = links
     else:
         links_obj = data.get("links", {})
-        lst = [item for item in links_obj.get(link_type, []) if item.get("source_id") != source_id]
+        lst = [
+            item
+            for item in links_obj.get(link_type, [])
+            if item.get("source_id") != source_id
+        ]
         lst.append(link)
         links_obj[link_type] = lst
         data["links"] = links_obj
@@ -294,14 +318,20 @@ def link_requirements(
         req_ops.save_requirement(directory, obj, mtime=mtime)
     except ConflictError as exc:
         return log_tool(
-            "link_requirements", params, mcp_error(ErrorCode.CONFLICT, str(exc))
+            "link_requirements",
+            params,
+            mcp_error(ErrorCode.CONFLICT, str(exc)),
         )
     except (ValueError, KeyError) as exc:
         return log_tool(
-            "link_requirements", params, mcp_error(ErrorCode.VALIDATION_ERROR, str(exc))
+            "link_requirements",
+            params,
+            mcp_error(ErrorCode.VALIDATION_ERROR, str(exc)),
         )
     except Exception as exc:  # pragma: no cover - defensive
         return log_tool(
-            "link_requirements", params, mcp_error(ErrorCode.INTERNAL, str(exc))
+            "link_requirements",
+            params,
+            mcp_error(ErrorCode.INTERNAL, str(exc)),
         )
     return log_tool("link_requirements", params, requirement_to_dict(obj))

--- a/app/mcp/utils.py
+++ b/app/mcp/utils.py
@@ -65,7 +65,11 @@ class ErrorCode(str, Enum):
     INTERNAL = "INTERNAL"
 
 
-def mcp_error(code: ErrorCode | str, message: str, details: Mapping[str, Any] | None = None) -> dict[str, Any]:
+def mcp_error(
+    code: ErrorCode | str,
+    message: str,
+    details: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
     """Return a structured error payload for MCP responses."""
 
     code_str = code.value if isinstance(code, ErrorCode) else str(code)

--- a/app/telemetry.py
+++ b/app/telemetry.py
@@ -67,7 +67,9 @@ def log_event(
     if payload:
         sanitized = sanitize(dict(payload))
         data["payload"] = sanitized
-        data["size_bytes"] = len(json.dumps(sanitized, ensure_ascii=False).encode("utf-8"))
+        data["size_bytes"] = len(
+            json.dumps(sanitized, ensure_ascii=False).encode("utf-8"),
+        )
     else:
         data["payload"] = {}
         data["size_bytes"] = 0

--- a/app/ui/__init__.py
+++ b/app/ui/__init__.py
@@ -1,3 +1,1 @@
 """Graphical user interface package."""
-
-

--- a/app/ui/command_dialog.py
+++ b/app/ui/command_dialog.py
@@ -52,7 +52,8 @@ class CommandDialog(wx.Dialog):
 
         self.input = wx.TextCtrl(self, style=wx.TE_PROCESS_ENTER)
         self.output = wx.TextCtrl(
-            self, style=wx.TE_MULTILINE | wx.TE_READONLY | wx.HSCROLL
+            self,
+            style=wx.TE_MULTILINE | wx.TE_READONLY | wx.HSCROLL,
         )
         self.history_list = wx.ListBox(self)
         self.history_list.Bind(wx.EVT_LISTBOX, self._on_select_history)
@@ -136,4 +137,9 @@ class CommandDialog(wx.Dialog):
     def _save_history(self) -> None:
         self._history_path.parent.mkdir(parents=True, exist_ok=True)
         with self._history_path.open("w", encoding="utf-8") as fh:
-            json.dump([asdict(h) for h in self.history], fh, ensure_ascii=False, indent=2)
+            json.dump(
+                [asdict(h) for h in self.history],
+                fh,
+                ensure_ascii=False,
+                indent=2,
+            )

--- a/app/ui/controllers/labels.py
+++ b/app/ui/controllers/labels.py
@@ -41,7 +41,10 @@ class LabelsController:
         existing_colors = {lbl.name: lbl.color for lbl in self.labels}
         used_names = {label for req in self.model.get_all() for label in req.labels}
         all_names = sorted(existing_colors.keys() | used_names)
-        self.labels = [Label(name=name, color=existing_colors.get(name, "#ffffff")) for name in all_names]
+        self.labels = [
+            Label(name=name, color=existing_colors.get(name, "#ffffff"))
+            for name in all_names
+        ]
         try:
             req_ops.save_labels(self.directory, self.labels, repo=self.repo)
         except Exception as exc:
@@ -49,7 +52,9 @@ class LabelsController:
         return [lbl.name for lbl in self.labels]
 
     def update_labels(
-        self, new_labels: list[Label], remove_from_requirements: bool
+        self,
+        new_labels: list[Label],
+        remove_from_requirements: bool,
     ) -> dict[str, list[int]]:
         """Update labels and optionally strip removed ones from requirements.
 

--- a/app/ui/editor_panel.py
+++ b/app/ui/editor_panel.py
@@ -1,4 +1,5 @@
 """Requirement editor panel."""
+
 from __future__ import annotations
 
 from contextlib import contextmanager
@@ -74,125 +75,125 @@ class EditorPanel(ScrolledPanel):
             "id": _(
                 "The 'Requirement ID' is a unique integer used as the stable anchor for a requirement. "
                 "Teams refer to it in traceability matrices, change requests and test reports to ensure everyone talks about the same item. "
-                "Once the identifier appears in external documents it should not be changed to avoid broken references."
+                "Once the identifier appears in external documents it should not be changed to avoid broken references.",
             ),
             "title": _(
                 "A concise human-readable summary shown in lists and diagrams. "
                 "It lets stakeholders skim large sets of requirements and quickly find relevant topics. "
-                "Use clear keywords so search and sorting produce meaningful results."
+                "Use clear keywords so search and sorting produce meaningful results.",
             ),
             "statement": _(
                 "The full requirement statement describing what the system must do or the constraint it imposes. "
                 "This wording becomes the authoritative baseline for implementation and contractual obligations. "
-                "Detailed phrasing here prevents ambiguity during design and review."
+                "Detailed phrasing here prevents ambiguity during design and review.",
             ),
             "acceptance": _(
                 "Acceptance criteria explain how to verify that the requirement is satisfied. "
                 "They may include test scenarios, measurable thresholds or review checklists. "
-                "Well-defined criteria let QA teams plan tests and give product owners a clear basis for acceptance."
+                "Well-defined criteria let QA teams plan tests and give product owners a clear basis for acceptance.",
             ),
             "conditions": _(
                 "Operating conditions and modes under which the requirement applies. "
                 "Describe environments, performance ranges or user roles that influence validity. "
-                "Such context helps engineers design correctly and testers reproduce the right setup."
+                "Such context helps engineers design correctly and testers reproduce the right setup.",
             ),
             "trace_up": _(
                 "Links to higher-level requirements or stakeholder needs. "
                 "Upward traceability shows why this requirement exists and simplifies impact analysis when parents change. "
-                "Use it to prove coverage of system objectives."
+                "Use it to prove coverage of system objectives.",
             ),
             "trace_down": _(
                 "References to lower-level derived requirements, design elements or test cases. "
                 "Downward traceability reveals how the requirement will be implemented and verified. "
-                "It supports audits and helps detect missing implementation pieces."
+                "It supports audits and helps detect missing implementation pieces.",
             ),
             "version": _(
                 "Sequential version number for change control. "
                 "Increase it whenever the requirement text changes to keep a revision history. "
-                "Versioning enables baselining and comparison of snapshots during reviews."
+                "Versioning enables baselining and comparison of snapshots during reviews.",
             ),
             "modified_at": _(
                 "Date and time of the last edit. "
                 "The value is filled automatically and aids audit trails. "
-                "Reviewers can sort by this field to focus on recently modified items."
+                "Reviewers can sort by this field to focus on recently modified items.",
             ),
             "owner": _(
                 "Person or team responsible for the requirement. "
                 "The owner coordinates discussions, approves updates and answers questions from other stakeholders. "
-                "Assigning ownership clarifies accountability and speeds up decisions."
+                "Assigning ownership clarifies accountability and speeds up decisions.",
             ),
             "source": _(
                 "Origin of the requirement such as a customer request, regulation or design document. "
                 "Recording the source explains why the requirement exists and where to look for additional context. "
-                "This trace is essential when validating compliance or revisiting negotiations."
+                "This trace is essential when validating compliance or revisiting negotiations.",
             ),
             "type": _(
                 "Classification of the requirement: functional, constraint, interface or quality attribute. "
                 "Types help filter large sets, assign specialists and apply different review processes. "
-                "Consistent categorization improves reporting and reuse."
+                "Consistent categorization improves reporting and reuse.",
             ),
             "status": _(
                 "Lifecycle state like draft, in review, approved or retired. "
                 "The status communicates readiness and controls workflow gates. "
-                "Dashboards and metrics rely on it to show project progress."
+                "Dashboards and metrics rely on it to show project progress.",
             ),
             "priority": _(
                 "Relative importance or urgency of the requirement. "
                 "High-priority items drive planning and resource allocation. "
-                "Use priority to focus effort on the capabilities that deliver most value."
+                "Use priority to focus effort on the capabilities that deliver most value.",
             ),
             "verification": _(
                 "Preferred method to prove compliance: inspection, analysis, demonstration or test. "
                 "Selecting a method early guides preparation of verification activities and needed tools. "
-                "It also clarifies expectations for acceptance."
+                "It also clarifies expectations for acceptance.",
             ),
             "rationale": _(
                 "Explanation of why the requirement exists or how it was derived. "
                 "Capturing rationale preserves design intent and helps future maintainers understand trade-offs. "
-                "This background is valuable during change discussions or audits."
+                "This background is valuable during change discussions or audits.",
             ),
             "assumptions": _(
                 "Assumptions made while formulating the requirement, such as available technologies or expected user behavior. "
                 "Listing assumptions exposes risks and clarifies the context that might change. "
-                "Revisit them regularly to ensure the requirement remains valid."
+                "Revisit them regularly to ensure the requirement remains valid.",
             ),
             "attachments": _(
                 "Supplementary files that give additional context like diagrams, logs or calculations. "
                 "Attachments travel with the requirement so reviewers and implementers see the same supporting evidence. "
-                "Keep file notes concise to explain relevance."
+                "Keep file notes concise to explain relevance.",
             ),
             "approved_at": _(
                 "Date when the requirement was formally accepted by stakeholders. "
                 "Recording the approval moment is useful for audits and for tracking baselines. "
-                "Leave empty while the requirement is still under discussion."
+                "Leave empty while the requirement is still under discussion.",
             ),
             "notes": _(
                 "Free-form remarks that do not fit other fields. "
                 "Use notes to capture review feedback, open questions or implementation hints. "
-                "Unlike acceptance criteria they are not part of the requirement contract."
+                "Unlike acceptance criteria they are not part of the requirement contract.",
             ),
             "labels": _(
                 "Tags that categorize the requirement. "
                 "Consistent labeling enables powerful filtering and helps group related items. "
-                "Use shared presets to avoid typos and duplicates."
+                "Use shared presets to avoid typos and duplicates.",
             ),
             "parent": _(
                 "Reference to the immediate higher-level requirement. "
                 "Establishing parenthood keeps the traceability chain intact and simplifies impact analysis. "
-                "Clear links are essential during audits and design reviews."
+                "Clear links are essential during audits and design reviews.",
             ),
             "verifies": _(
                 "Links to requirements that this one verifies or tests. "
-                "Use it to show downward traceability towards implementation or validation artifacts."
+                "Use it to show downward traceability towards implementation or validation artifacts.",
             ),
             "relates": _(
                 "Associations with requirements touching the same topic. "
                 "Related links help discover dependencies and avoid conflicting decisions. "
-                "They are informational and do not imply hierarchy."
+                "They are informational and do not imply hierarchy.",
             ),
             "derived_from": _(
                 "Source requirements from which this one was derived. "
-                "Capturing derivation clarifies reasoning and lets teams propagate changes upstream."
+                "Capturing derivation clarifies reasoning and lets teams propagate changes upstream.",
             ),
         }
 
@@ -280,11 +281,15 @@ class EditorPanel(ScrolledPanel):
 
         # attachments section --------------------------------------------
         a_sizer = HelpStaticBox(
-            self, _("Attachments"), self._help_texts["attachments"], lambda msg: show_help(self, msg)
+            self,
+            _("Attachments"),
+            self._help_texts["attachments"],
+            lambda msg: show_help(self, msg),
         )
         a_box = a_sizer.GetStaticBox()
         self.attachments_list = wx.ListCtrl(
-            a_box, style=wx.LC_REPORT | wx.BORDER_SUNKEN | wx.LC_SINGLE_SEL
+            a_box,
+            style=wx.LC_REPORT | wx.BORDER_SUNKEN | wx.LC_SINGLE_SEL,
         )
         self.attachments_list.InsertColumn(0, _("File"))
         self.attachments_list.InsertColumn(1, _("Note"))
@@ -308,7 +313,8 @@ class EditorPanel(ScrolledPanel):
         row.Add(help_btn, 0, wx.ALIGN_CENTER_VERTICAL | wx.LEFT, 5)
         container.Add(row, 0, wx.ALL, 5)
         self.approved_picker = wx.adv.DatePickerCtrl(
-            self, style=wx.adv.DP_ALLOWNONE
+            self,
+            style=wx.adv.DP_ALLOWNONE,
         )
         container.Add(self.approved_picker, 0, wx.ALL, 5)
         sizer.Add(container, 0, wx.ALL, 5)
@@ -334,7 +340,10 @@ class EditorPanel(ScrolledPanel):
 
         # labels section -------------------------------------------------
         box_sizer = HelpStaticBox(
-            self, _("Labels"), self._help_texts["labels"], lambda msg: show_help(self, msg)
+            self,
+            _("Labels"),
+            self._help_texts["labels"],
+            lambda msg: show_help(self, msg),
         )
         box = box_sizer.GetStaticBox()
         row = wx.BoxSizer(wx.HORIZONTAL)
@@ -355,7 +364,10 @@ class EditorPanel(ScrolledPanel):
 
         # parent section -------------------------------------------------
         pr_sizer = HelpStaticBox(
-            self, _("Parent"), self._help_texts["parent"], lambda msg: show_help(self, msg)
+            self,
+            _("Parent"),
+            self._help_texts["parent"],
+            lambda msg: show_help(self, msg),
         )
         pr_box = pr_sizer.GetStaticBox()
         row = wx.BoxSizer(wx.HORIZONTAL)
@@ -502,7 +514,10 @@ class EditorPanel(ScrolledPanel):
         list_name: str | None = None,
     ) -> wx.StaticBoxSizer:
         sizer = HelpStaticBox(
-            self, label, self._help_texts[help_key], lambda msg: show_help(self, msg)
+            self,
+            label,
+            self._help_texts[help_key],
+            lambda msg: show_help(self, msg),
         )
         box = sizer.GetStaticBox()
         row = wx.BoxSizer(wx.HORIZONTAL)
@@ -513,7 +528,10 @@ class EditorPanel(ScrolledPanel):
         add_btn.Bind(wx.EVT_BUTTON, lambda _evt, a=attr: self._on_add_link_generic(a))
         row.Add(add_btn, 0, wx.RIGHT, 5)
         remove_btn = wx.Button(box, label=_("Remove"))
-        remove_btn.Bind(wx.EVT_BUTTON, lambda _evt, a=attr: self._on_remove_link_generic(a))
+        remove_btn.Bind(
+            wx.EVT_BUTTON,
+            lambda _evt, a=attr: self._on_remove_link_generic(a),
+        )
         row.Add(remove_btn, 0)
         sizer.Add(row, 0, wx.EXPAND | wx.ALL, 5)
         lst = wx.ListCtrl(box, style=wx.LC_REPORT | wx.LC_SINGLE_SEL)
@@ -609,7 +627,10 @@ class EditorPanel(ScrolledPanel):
                 "type": locale.code_to_label("type", RequirementType.REQUIREMENT.value),
                 "status": locale.code_to_label("status", Status.DRAFT.value),
                 "priority": locale.code_to_label("priority", Priority.MEDIUM.value),
-                "verification": locale.code_to_label("verification", Verification.ANALYSIS.value),
+                "verification": locale.code_to_label(
+                    "verification",
+                    Verification.ANALYSIS.value,
+                ),
             }
             for name, choice in self.enums.items():
                 choice.SetStringSelection(defaults[name])
@@ -621,12 +642,14 @@ class EditorPanel(ScrolledPanel):
             self.current_path = None
             self.mtime = None
             self.original_id = None
-            self.extra.update({
-                "labels": [],
-                "revision": 1,
-                "approved_at": None,
-                "notes": "",
-            })
+            self.extra.update(
+                {
+                    "labels": [],
+                    "revision": 1,
+                    "approved_at": None,
+                    "notes": "",
+                },
+            )
             self.approved_picker.SetValue(wx.DefaultDateTime)
             self.notes_ctrl.ChangeValue("")
             self._refresh_attachments()
@@ -694,7 +717,7 @@ class EditorPanel(ScrolledPanel):
                 dt = wx.DateTime()
                 dt.ParseISODate(str(self.extra["approved_at"]))
                 self.approved_picker.SetValue(
-                    dt if dt.IsValid() else wx.DefaultDateTime
+                    dt if dt.IsValid() else wx.DefaultDateTime,
                 )
             else:
                 self.approved_picker.SetValue(wx.DefaultDateTime)
@@ -758,13 +781,23 @@ class EditorPanel(ScrolledPanel):
             "id": req_id,
             "title": self.fields["title"].GetValue(),
             "statement": self.fields["statement"].GetValue(),
-            "type": locale.label_to_code("type", self.enums["type"].GetStringSelection()),
-            "status": locale.label_to_code("status", self.enums["status"].GetStringSelection()),
+            "type": locale.label_to_code(
+                "type",
+                self.enums["type"].GetStringSelection(),
+            ),
+            "status": locale.label_to_code(
+                "status",
+                self.enums["status"].GetStringSelection(),
+            ),
             "owner": self.fields["owner"].GetValue(),
-            "priority": locale.label_to_code("priority", self.enums["priority"].GetStringSelection()),
+            "priority": locale.label_to_code(
+                "priority",
+                self.enums["priority"].GetStringSelection(),
+            ),
             "source": self.fields["source"].GetValue(),
             "verification": locale.label_to_code(
-                "verification", self.enums["verification"].GetStringSelection()
+                "verification",
+                self.enums["verification"].GetStringSelection(),
             ),
             "acceptance": self.fields["acceptance"].GetValue(),
             "conditions": self.fields["conditions"].GetValue(),
@@ -792,9 +825,7 @@ class EditorPanel(ScrolledPanel):
         self.extra["labels"] = data["labels"]
         self.extra["approved_at"] = approved_at
         self.extra["notes"] = notes
-        if any(
-            ctrl.GetValue().strip() for ctrl in self.derivation_fields.values()
-        ):
+        if any(ctrl.GetValue().strip() for ctrl in self.derivation_fields.values()):
             assumptions = [
                 s.strip()
                 for s in self.derivation_fields["assumptions"].GetValue().splitlines()
@@ -839,7 +870,11 @@ class EditorPanel(ScrolledPanel):
         else:
             for i, name in enumerate(labels):
                 lbl_def = next(
-                    (label_def for label_def in self._label_defs if label_def.name == name),
+                    (
+                        label_def
+                        for label_def in self._label_defs
+                        if label_def.name == name
+                    ),
                     None,
                 )
                 color = lbl_def.color if lbl_def else "#cccccc"
@@ -866,7 +901,8 @@ class EditorPanel(ScrolledPanel):
         self.attachments_list.DeleteAllItems()
         for att in self.attachments:
             idx = self.attachments_list.InsertItem(
-                self.attachments_list.GetItemCount(), att.get("path", "")
+                self.attachments_list.GetItemCount(),
+                att.get("path", ""),
             )
             self.attachments_list.SetItem(idx, 1, att.get("note", ""))
         visible = bool(self.attachments)
@@ -885,7 +921,11 @@ class EditorPanel(ScrolledPanel):
         self.FitInside()
 
     def _on_add_attachment(self, _event: wx.CommandEvent) -> None:
-        dlg = wx.FileDialog(self, _("Select attachment"), style=wx.FD_OPEN | wx.FD_FILE_MUST_EXIST)
+        dlg = wx.FileDialog(
+            self,
+            _("Select attachment"),
+            style=wx.FD_OPEN | wx.FD_FILE_MUST_EXIST,
+        )
         if dlg.ShowModal() != wx.ID_OK:
             dlg.Destroy()
             return
@@ -904,6 +944,7 @@ class EditorPanel(ScrolledPanel):
         if idx != -1:
             del self.attachments[idx]
             self._refresh_attachments()
+
     # generic link handlers -------------------------------------------
     def _on_add_link_generic(self, attr: str) -> None:
         id_ctrl, list_ctrl, links_list = self._link_widgets(attr)
@@ -924,7 +965,9 @@ class EditorPanel(ScrolledPanel):
                 title = req.title or ""
             except Exception:  # pragma: no cover - lookup errors
                 pass
-        links_list.append({"source_id": src_id, "source_revision": revision, "suspect": False})
+        links_list.append(
+            {"source_id": src_id, "source_revision": revision, "suspect": False},
+        )
         idx = list_ctrl.InsertItem(list_ctrl.GetItemCount(), str(src_id))
         list_ctrl.SetItem(idx, 1, title)
         id_ctrl.ChangeValue("")
@@ -963,7 +1006,11 @@ class EditorPanel(ScrolledPanel):
                 revision = req.revision or 1
             except Exception:
                 pass
-        self.parent = {"source_id": src_id, "source_revision": revision, "suspect": False}
+        self.parent = {
+            "source_id": src_id,
+            "source_revision": revision,
+            "suspect": False,
+        }
         self.parent_id.ChangeValue("")
         self._refresh_parent_display()
 
@@ -1032,7 +1079,10 @@ class EditorPanel(ScrolledPanel):
             else None
         )
         path = req_ops.save_requirement(
-            directory, req, mtime=self.mtime, modified_at=mod
+            directory,
+            req,
+            mtime=self.mtime,
+            modified_at=mod,
         )
         self.fields["modified_at"].ChangeValue(req.modified_at)
         self.original_modified_at = req.modified_at
@@ -1047,7 +1097,10 @@ class EditorPanel(ScrolledPanel):
         """Remove currently loaded requirement file if present."""
 
         if self.current_path and self.current_path.exists():
-            req_ops.delete_requirement(self.current_path.parent, int(self.current_path.stem))
+            req_ops.delete_requirement(
+                self.current_path.parent,
+                int(self.current_path.stem),
+            )
         self.current_path = None
         self.mtime = None
         self.original_id = None
@@ -1057,6 +1110,8 @@ class EditorPanel(ScrolledPanel):
 
         self.attachments.append({"path": path, "note": note})
         if hasattr(self, "attachments_list"):
-            idx = self.attachments_list.InsertItem(self.attachments_list.GetItemCount(), path)
+            idx = self.attachments_list.InsertItem(
+                self.attachments_list.GetItemCount(),
+                path,
+            )
             self.attachments_list.SetItem(idx, 1, note)
-

--- a/app/ui/enums.py
+++ b/app/ui/enums.py
@@ -1,4 +1,5 @@
 """Common Enum definitions and label utilities for UI."""
+
 from __future__ import annotations
 
 from enum import Enum
@@ -27,4 +28,6 @@ ENUMS: dict[str, type[Enum]] = {
 
 
 # Pre-generated localized labels for each enumerated field
-LABELS: dict[str, dict[str, str]] = {name: enum_labels(cls) for name, cls in ENUMS.items()}
+LABELS: dict[str, dict[str, str]] = {
+    name: enum_labels(cls) for name, cls in ENUMS.items()
+}

--- a/app/ui/filter_dialog.py
+++ b/app/ui/filter_dialog.py
@@ -1,4 +1,5 @@
 """Dialog for configuring requirement filters."""
+
 from __future__ import annotations
 
 import wx
@@ -46,7 +47,12 @@ class FilterDialog(wx.Dialog):
         # Per-field queries
         self.field_controls: dict[str, wx.TextCtrl] = {}
         for field in sorted(req_ops.SEARCHABLE_FIELDS):
-            sizer.Add(wx.StaticText(self, label=locale.field_label(field)), 0, wx.ALL, 5)
+            sizer.Add(
+                wx.StaticText(self, label=locale.field_label(field)),
+                0,
+                wx.ALL,
+                5,
+            )
             ctrl = wx.TextCtrl(self)
             ctrl.SetValue(values.get("field_queries", {}).get(field, ""))
             self.field_controls[field] = ctrl
@@ -76,7 +82,9 @@ class FilterDialog(wx.Dialog):
         sizer.Add(wx.StaticText(self, label=_("Status")), 0, wx.ALL, 5)
         enum_cls = ENUMS["status"]
         self._status_values = [s.value for s in enum_cls]
-        status_choices = [_("(any)")] + [locale.code_to_label("status", v) for v in self._status_values]
+        status_choices = [_("(any)")] + [
+            locale.code_to_label("status", v) for v in self._status_values
+        ]
         self.status_choice = wx.Choice(self, choices=status_choices)
         selected = 0
         if values.get("status") in self._status_values:
@@ -111,14 +119,25 @@ class FilterDialog(wx.Dialog):
 
     def get_filters(self) -> dict:
         """Return chosen filters as a dict."""
-        labels = [self._labels[i].name for i in range(self.labels_box.GetCount()) if self.labels_box.IsChecked(i)]
-        field_queries = {field: ctrl.GetValue() for field, ctrl in self.field_controls.items() if ctrl.GetValue()}
+        labels = [
+            self._labels[i].name
+            for i in range(self.labels_box.GetCount())
+            if self.labels_box.IsChecked(i)
+        ]
+        field_queries = {
+            field: ctrl.GetValue()
+            for field, ctrl in self.field_controls.items()
+            if ctrl.GetValue()
+        }
         return {
             "query": self.any_query.GetValue(),
             "labels": labels,
             "match_any": self.match_any.GetValue(),
-            "status": (self._status_values[self.status_choice.GetSelection() - 1]
-                        if self.status_choice.GetSelection() > 0 else None),
+            "status": (
+                self._status_values[self.status_choice.GetSelection() - 1]
+                if self.status_choice.GetSelection() > 0
+                else None
+            ),
             "is_derived": self.is_derived.GetValue(),
             "has_derived": self.has_derived.GetValue(),
             "suspect_only": self.suspect_only.GetValue(),

--- a/app/ui/helpers.py
+++ b/app/ui/helpers.py
@@ -1,4 +1,5 @@
 """Common helper widgets and functions for UI components."""
+
 from __future__ import annotations
 
 from typing import Callable
@@ -109,7 +110,11 @@ def show_help(parent: wx.Window, message: str, *, title: str | None = None) -> N
         Optional dialog title; defaults to ``"Hint"``.
     """
 
-    dlg = wx.Dialog(parent, title=title or _("Hint"), style=wx.DEFAULT_DIALOG_STYLE | wx.RESIZE_BORDER)
+    dlg = wx.Dialog(
+        parent,
+        title=title or _("Hint"),
+        style=wx.DEFAULT_DIALOG_STYLE | wx.RESIZE_BORDER,
+    )
     text = wx.TextCtrl(dlg, value=message, style=wx.TE_MULTILINE | wx.TE_READONLY)
     sizer = wx.BoxSizer(wx.VERTICAL)
     sizer.Add(text, 1, wx.ALL | wx.EXPAND, 10)

--- a/app/ui/label_selection_dialog.py
+++ b/app/ui/label_selection_dialog.py
@@ -1,4 +1,5 @@
 """Dialog for selecting labels with color icons."""
+
 import wx
 from wx.lib.mixins.listctrl import CheckListCtrlMixin
 
@@ -17,7 +18,12 @@ class _CheckListCtrl(wx.ListCtrl, CheckListCtrlMixin):
 class LabelSelectionDialog(wx.Dialog):
     """Dialog allowing to choose labels while displaying their colors."""
 
-    def __init__(self, parent: wx.Window | None, labels: list[Label], selected: list[str]):
+    def __init__(
+        self,
+        parent: wx.Window | None,
+        labels: list[Label],
+        selected: list[str],
+    ):
         """Initialize dialog listing ``labels`` with ``selected`` prechecked."""
         style = wx.DEFAULT_DIALOG_STYLE | wx.RESIZE_BORDER
         super().__init__(parent, title=_("Labels"), style=style)

--- a/app/ui/labels_dialog.py
+++ b/app/ui/labels_dialog.py
@@ -96,7 +96,10 @@ class LabelsDialog(wx.Dialog):
         self.color_picker.SetColour(colour)
         self.color_picker.Enable()
 
-    def _on_color_changed(self, event: wx.ColourPickerEvent) -> None:  # pragma: no cover - GUI event
+    def _on_color_changed(
+        self,
+        event: wx.ColourPickerEvent,
+    ) -> None:  # pragma: no cover - GUI event
         idx = self.list.GetFirstSelected()
         if idx == -1:
             return
@@ -123,7 +126,10 @@ class LabelsDialog(wx.Dialog):
         if added:
             self._populate()
 
-    def _on_show_presets_menu(self, _event: wx.Event) -> None:  # pragma: no cover - GUI event
+    def _on_show_presets_menu(
+        self,
+        _event: wx.Event,
+    ) -> None:  # pragma: no cover - GUI event
         menu = wx.Menu()
         for key, title in PRESET_SET_TITLES.items():
             item = menu.Append(wx.ID_ANY, _(title))
@@ -131,7 +137,10 @@ class LabelsDialog(wx.Dialog):
         self.PopupMenu(menu)
         menu.Destroy()
 
-    def _on_delete_selected(self, _event: wx.Event) -> None:  # pragma: no cover - GUI event
+    def _on_delete_selected(
+        self,
+        _event: wx.Event,
+    ) -> None:  # pragma: no cover - GUI event
         indices = self._get_selected_indices()
         if not indices:
             return
@@ -160,7 +169,10 @@ class LabelsDialog(wx.Dialog):
     def _on_list_size(self, _event: wx.Event) -> None:  # pragma: no cover - GUI event
         self._resize_column()
 
-    def _on_rename_selected(self, _event: wx.Event) -> None:  # pragma: no cover - GUI event
+    def _on_rename_selected(
+        self,
+        _event: wx.Event,
+    ) -> None:  # pragma: no cover - GUI event
         idx = self.list.GetFirstSelected()
         if idx == -1:
             return
@@ -173,7 +185,11 @@ class LabelsDialog(wx.Dialog):
                 return
             existing = {lbl.name for i, lbl in enumerate(self._labels) if i != idx}
             if new_name in existing:
-                wx.MessageBox(_("Label already exists"), _("Error"), style=wx.ICON_ERROR)
+                wx.MessageBox(
+                    _("Label already exists"),
+                    _("Error"),
+                    style=wx.ICON_ERROR,
+                )
             else:
                 self._labels[idx].name = new_name
                 self.list.SetItem(idx, 0, new_name)

--- a/app/ui/list_panel.py
+++ b/app/ui/list_panel.py
@@ -94,7 +94,7 @@ class ListPanel(wx.Panel, ColumnSorterMixin):
         self.filter_btn.Bind(wx.EVT_BUTTON, self._on_filter)
         self.reset_btn.Bind(wx.EVT_BUTTON, lambda _evt: self.reset_filters())
 
-# ColumnSorterMixin requirement
+    # ColumnSorterMixin requirement
     def GetListCtrl(self):  # pragma: no cover - simple forwarding
         """Return internal ``wx.ListCtrl`` for sorting mixin."""
 
@@ -448,7 +448,9 @@ class ListPanel(wx.Panel, ColumnSorterMixin):
                     self.list.SetItem(index, col, str(count))
                     continue
                 if field == "attachments":
-                    value = ", ".join(getattr(a, "path", "") for a in getattr(req, "attachments", []))
+                    value = ", ".join(
+                        getattr(a, "path", "") for a in getattr(req, "attachments", [])
+                    )
                     self.list.SetItem(index, col, value)
                     continue
                 value = getattr(req, field, "")
@@ -484,9 +486,7 @@ class ListPanel(wx.Panel, ColumnSorterMixin):
 
     def _on_col_click(self, event: ListEvent) -> None:  # pragma: no cover - GUI event
         col = event.GetColumn()
-        ascending = (
-            not self._sort_ascending if col == self._sort_column else True
-        )
+        ascending = not self._sort_ascending if col == self._sort_column else True
         self.sort(col, ascending)
 
     def sort(self, column: int, ascending: bool) -> None:
@@ -514,7 +514,10 @@ class ListPanel(wx.Panel, ColumnSorterMixin):
             col = None
         self._popup_context_menu(event.GetIndex(), col)
 
-    def _on_context_menu(self, event: ContextMenuEvent) -> None:  # pragma: no cover - GUI event
+    def _on_context_menu(
+        self,
+        event: ContextMenuEvent,
+    ) -> None:  # pragma: no cover - GUI event
         pos = event.GetPosition()
         if pos == wx.DefaultPosition:
             pos = wx.GetMousePosition()
@@ -550,13 +553,25 @@ class ListPanel(wx.Panel, ColumnSorterMixin):
         edit_item = None
         if field and field != "title":
             edit_item = menu.Append(wx.ID_ANY, _("Edit {field}").format(field=field))
-            menu.Bind(wx.EVT_MENU, lambda _evt, c=column: self._on_edit_field(c), edit_item)
+            menu.Bind(
+                wx.EVT_MENU,
+                lambda _evt, c=column: self._on_edit_field(c),
+                edit_item,
+            )
         if self._on_clone:
             menu.Bind(wx.EVT_MENU, lambda _evt, i=req_id: self._on_clone(i), clone_item)
         if self._on_delete:
-            menu.Bind(wx.EVT_MENU, lambda _evt, i=req_id: self._on_delete(i), delete_item)
+            menu.Bind(
+                wx.EVT_MENU,
+                lambda _evt, i=req_id: self._on_delete(i),
+                delete_item,
+            )
         if self._on_derive:
-            menu.Bind(wx.EVT_MENU, lambda _evt, i=req_id: self._on_derive(i), derive_item)
+            menu.Bind(
+                wx.EVT_MENU,
+                lambda _evt, i=req_id: self._on_derive(i),
+                derive_item,
+            )
         return menu, clone_item, delete_item, edit_item
 
     def _get_selected_indices(self) -> list[int]:
@@ -571,7 +586,12 @@ class ListPanel(wx.Panel, ColumnSorterMixin):
         if field in ENUMS:
             enum_cls = ENUMS[field]
             choices = [locale.code_to_label(field, e.value) for e in enum_cls]
-            dlg = wx.SingleChoiceDialog(self, _("Select {field}").format(field=field), _("Edit"), choices)
+            dlg = wx.SingleChoiceDialog(
+                self,
+                _("Select {field}").format(field=field),
+                _("Edit"),
+                choices,
+            )
             if dlg.ShowModal() == wx.ID_OK:
                 label = dlg.GetStringSelection()
                 code = locale.label_to_code(field, label)
@@ -581,7 +601,9 @@ class ListPanel(wx.Panel, ColumnSorterMixin):
             dlg.Destroy()
             return value
         dlg = wx.TextEntryDialog(
-            self, _("New value for {field}").format(field=field), _("Edit")
+            self,
+            _("New value for {field}").format(field=field),
+            _("Edit"),
         )
         value = dlg.GetValue() if dlg.ShowModal() == wx.ID_OK else None
         dlg.Destroy()

--- a/app/ui/locale.py
+++ b/app/ui/locale.py
@@ -1,4 +1,5 @@
 """Localization helpers for requirement fields and enums."""
+
 from __future__ import annotations
 
 from ..i18n import _

--- a/app/ui/main_frame.py
+++ b/app/ui/main_frame.py
@@ -48,7 +48,10 @@ class WxLogHandler(logging.Handler):
         """Redirect log output to ``new_target``."""
         self._target = new_target
 
-    def emit(self, record: logging.LogRecord) -> None:  # pragma: no cover - GUI side effect
+    def emit(
+        self,
+        record: logging.LogRecord,
+    ) -> None:  # pragma: no cover - GUI side effect
         """Append formatted ``record`` text to the log console."""
 
         if not wx.GetApp():
@@ -95,7 +98,9 @@ class MainFrame(wx.Frame):
         # platforms can pick the most appropriate resolution. Using
         # ``SetIcons`` with an ``IconBundle`` ensures both the title bar and
         # the taskbar use the custom application icon.
-        with resources.as_file(resources.files("app.resources") / "app.ico") as icon_path:
+        with resources.as_file(
+            resources.files("app.resources") / "app.ico",
+        ) as icon_path:
             icons = wx.IconBundle(str(icon_path), wx.BITMAP_TYPE_ANY)
             self.SetIcons(icons)
         self.navigation = Navigation(
@@ -149,7 +154,10 @@ class MainFrame(wx.Frame):
         log_sizer.Add(self.log_console, 1, wx.EXPAND | wx.ALL, 5)
         self.log_panel.SetSizer(log_sizer)
 
-        existing = next((h for h in logger.handlers if isinstance(h, WxLogHandler)), None)
+        existing = next(
+            (h for h in logger.handlers if isinstance(h, WxLogHandler)),
+            None,
+        )
         if existing:
             self.log_handler = existing
             self.log_handler.target = self.log_console
@@ -197,7 +205,10 @@ class MainFrame(wx.Frame):
         if path:
             self._load_directory(path)
 
-    def on_open_settings(self, _event: wx.Event) -> None:  # pragma: no cover - GUI event
+    def on_open_settings(
+        self,
+        _event: wx.Event,
+    ) -> None:  # pragma: no cover - GUI event
         """Display settings dialog and apply changes."""
 
         dlg = SettingsDialog(
@@ -334,7 +345,10 @@ class MainFrame(wx.Frame):
 
         self.Layout()
 
-    def on_manage_labels(self, _event: wx.Event) -> None:  # pragma: no cover - GUI event
+    def on_manage_labels(
+        self,
+        _event: wx.Event,
+    ) -> None:  # pragma: no cover - GUI event
         """Open dialog to manage defined labels."""
 
         if not self.labels_controller:
@@ -343,25 +357,30 @@ class MainFrame(wx.Frame):
         if dlg.ShowModal() == wx.ID_OK:
             new_labels = dlg.get_labels()
             used = self.labels_controller.update_labels(
-                new_labels, remove_from_requirements=False
+                new_labels,
+                remove_from_requirements=False,
             )
             if used:
                 lines = [f"{k}: {', '.join(map(str, v))}" for k, v in used.items()]
                 msg = _(
-                    "Labels in use will be removed from requirements:\n%s\nContinue?"
+                    "Labels in use will be removed from requirements:\n%s\nContinue?",
                 ) % "\n".join(lines)
                 if not confirm(msg):
                     dlg.Destroy()
                     return
                 self.labels_controller.update_labels(
-                    new_labels, remove_from_requirements=True
+                    new_labels,
+                    remove_from_requirements=True,
                 )
                 self.panel.refresh()
             self.editor.update_labels_list(self.labels_controller.labels)
             self.panel.update_labels_list(self.labels_controller.labels)
         dlg.Destroy()
 
-    def on_show_derivation_graph(self, _event: wx.Event) -> None:  # pragma: no cover - GUI event
+    def on_show_derivation_graph(
+        self,
+        _event: wx.Event,
+    ) -> None:  # pragma: no cover - GUI event
         """Open window displaying requirement derivation graph."""
         if not self.current_dir:
             wx.MessageBox(_("Select requirements folder first"), _("No Data"))
@@ -382,11 +401,17 @@ class MainFrame(wx.Frame):
         """Load requirements from ``path`` and update recent list."""
         repo = FileRequirementRepository()
         self.req_controller = RequirementsController(
-            self.config, self.model, path, repo
+            self.config,
+            self.model,
+            path,
+            repo,
         )
         lbl_repo = FileLabelRepository()
         self.labels_controller = LabelsController(
-            self.config, self.model, path, lbl_repo
+            self.config,
+            self.model,
+            path,
+            lbl_repo,
         )
         self.labels_controller.load_labels()
         derived_map = self.req_controller.load_directory()
@@ -539,7 +564,9 @@ class MainFrame(wx.Frame):
             revision=1,
         )
         link = DerivationLink(
-            source_id=source.id, source_revision=source.revision, suspect=False
+            source_id=source.id,
+            source_revision=source.revision,
+            suspect=False,
         )
         clone.derived_from = [*source.derived_from, link]
         clone.derivation = None

--- a/app/ui/navigation.py
+++ b/app/ui/navigation.py
@@ -65,7 +65,10 @@ class Navigation:
         open_item = file_menu.Append(wx.ID_OPEN, _("&Open Folder\tCtrl+O"))
         new_item = file_menu.Append(wx.ID_NEW, _("&New Requirement\tCtrl+N"))
         self.recent_menu = wx.Menu()
-        self.recent_menu_item = file_menu.AppendSubMenu(self.recent_menu, _("Open &Recent"))
+        self.recent_menu_item = file_menu.AppendSubMenu(
+            self.recent_menu,
+            _("Open &Recent"),
+        )
         settings_item = file_menu.Append(wx.ID_PREFERENCES, _("Settings"))
         labels_item = file_menu.Append(wx.ID_ANY, _("Manage Labels"))
         exit_item = file_menu.Append(wx.ID_EXIT, _("E&xit"))
@@ -88,7 +91,10 @@ class Navigation:
             self.frame.Bind(wx.EVT_MENU, self.on_toggle_column, item)
             self._column_items[item.GetId()] = field
         view_menu.AppendSubMenu(columns_menu, _("Columns"))
-        self.log_menu_item = view_menu.AppendCheckItem(wx.ID_ANY, _("Show Error Console"))
+        self.log_menu_item = view_menu.AppendCheckItem(
+            wx.ID_ANY,
+            _("Show Error Console"),
+        )
         self.frame.Bind(wx.EVT_MENU, self.on_toggle_log_console, self.log_menu_item)
         graph_item = view_menu.Append(wx.ID_ANY, _("Show Derivation Graph"))
         self.frame.Bind(wx.EVT_MENU, self.on_show_derivation_graph, graph_item)

--- a/app/ui/requirement_model.py
+++ b/app/ui/requirement_model.py
@@ -1,4 +1,5 @@
 """Model managing requirements data with filtering and sorting."""
+
 from __future__ import annotations
 
 from collections.abc import Sequence

--- a/app/ui/settings_dialog.py
+++ b/app/ui/settings_dialog.py
@@ -14,41 +14,40 @@ from .helpers import make_help_button
 LLM_HELP: dict[str, str] = {
     "base_url": _(
         "Базовый URL LLM API. Пример: https://api.openai.com/v1\n"
-        "Обязательное поле; определяет, куда отправляются запросы."
+        "Обязательное поле; определяет, куда отправляются запросы.",
     ),
     "model": _(
         "Имя модели LLM. Пример: gpt-4-turbo\n"
-        "Обязательное поле, определяет используемую модель."
+        "Обязательное поле, определяет используемую модель.",
     ),
     "api_key": _(
         "Ключ доступа к LLM. Пример: sk-XXXX\n"
-        "Обязателен, если сервис требует авторизации."
+        "Обязателен, если сервис требует авторизации.",
     ),
     "timeout_minutes": _(
         "Тайм-аут HTTP-запроса в минутах. Пример: 1\n"
-        "Необязательное поле; по умолчанию 60 секунд."
+        "Необязательное поле; по умолчанию 60 секунд.",
     ),
 }
 
 MCP_HELP: dict[str, str] = {
     "host": _(
         "Адрес хоста MCP-сервера. Пример: 127.0.0.1\n"
-        "Обязательное поле; определяет, где запускать сервер."
+        "Обязательное поле; определяет, где запускать сервер.",
     ),
     "port": _(
-        "Порт MCP-сервера. Пример: 8123\n"
-        "Обязательное поле."
+        "Порт MCP-сервера. Пример: 8123\nОбязательное поле.",
     ),
     "base_path": _(
         "Базовая папка с требованиями. Пример: /tmp/reqs\n"
-        "Обязательное поле; сервер обслуживает файлы из этой директории."
+        "Обязательное поле; сервер обслуживает файлы из этой директории.",
     ),
     "require_token": _(
-        "Если включено, сервер требует токен аутентификации."
+        "Если включено, сервер требует токен аутентификации.",
     ),
     "token": _(
         "Токен доступа для MCP. Пример: secret123\n"
-        "Обязателен, если включено 'Require token'."
+        "Обязателен, если включено 'Require token'.",
     ),
 }
 
@@ -113,7 +112,12 @@ class SettingsDialog(wx.Dialog):
         gen_sizer.Add(self._open_last, 0, wx.ALL, 5)
         gen_sizer.Add(self._remember_sort, 0, wx.ALL, 5)
         lang_sizer = wx.BoxSizer(wx.HORIZONTAL)
-        lang_sizer.Add(wx.StaticText(general, label=_("Language")), 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, 5)
+        lang_sizer.Add(
+            wx.StaticText(general, label=_("Language")),
+            0,
+            wx.ALIGN_CENTER_VERTICAL | wx.RIGHT,
+            5,
+        )
         lang_sizer.Add(self._language_choice, 1, wx.ALIGN_CENTER_VERTICAL)
         gen_sizer.Add(lang_sizer, 0, wx.ALL | wx.EXPAND, 5)
         general.SetSizer(gen_sizer)
@@ -124,7 +128,12 @@ class SettingsDialog(wx.Dialog):
         self._model = wx.TextCtrl(llm, value=model)
         self._api_key = wx.TextCtrl(llm, value=api_key, style=wx.TE_PASSWORD)
         self._max_retries = wx.SpinCtrl(llm, min=0, max=10, initial=max_retries)
-        self._max_output_tokens = wx.SpinCtrl(llm, min=0, max=500000, initial=max_output_tokens)
+        self._max_output_tokens = wx.SpinCtrl(
+            llm,
+            min=0,
+            max=500000,
+            initial=max_output_tokens,
+        )
         self._timeout = wx.SpinCtrl(llm, min=1, max=9999, initial=timeout_minutes)
         self._stream = wx.CheckBox(llm, label=_("Stream"))
         self._stream.SetValue(stream)
@@ -140,32 +149,82 @@ class SettingsDialog(wx.Dialog):
         llm_sizer = wx.BoxSizer(wx.VERTICAL)
         base_sz = wx.BoxSizer(wx.HORIZONTAL)
 
-        base_sz.Add(wx.StaticText(llm, label=_("API base")), 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, 5)
+        base_sz.Add(
+            wx.StaticText(llm, label=_("API base")),
+            0,
+            wx.ALIGN_CENTER_VERTICAL | wx.RIGHT,
+            5,
+        )
         base_sz.Add(self._base_url, 1, wx.ALIGN_CENTER_VERTICAL)
-        base_sz.Add(make_help_button(llm, LLM_HELP["base_url"]), 0, wx.ALIGN_CENTER_VERTICAL | wx.LEFT, 5)
+        base_sz.Add(
+            make_help_button(llm, LLM_HELP["base_url"]),
+            0,
+            wx.ALIGN_CENTER_VERTICAL | wx.LEFT,
+            5,
+        )
         llm_sizer.Add(base_sz, 0, wx.ALL | wx.EXPAND, 5)
         model_sz = wx.BoxSizer(wx.HORIZONTAL)
-        model_sz.Add(wx.StaticText(llm, label=_("Model")), 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, 5)
+        model_sz.Add(
+            wx.StaticText(llm, label=_("Model")),
+            0,
+            wx.ALIGN_CENTER_VERTICAL | wx.RIGHT,
+            5,
+        )
         model_sz.Add(self._model, 1, wx.ALIGN_CENTER_VERTICAL)
-        model_sz.Add(make_help_button(llm, LLM_HELP["model"]), 0, wx.ALIGN_CENTER_VERTICAL | wx.LEFT, 5)
+        model_sz.Add(
+            make_help_button(llm, LLM_HELP["model"]),
+            0,
+            wx.ALIGN_CENTER_VERTICAL | wx.LEFT,
+            5,
+        )
         llm_sizer.Add(model_sz, 0, wx.ALL | wx.EXPAND, 5)
         key_sz = wx.BoxSizer(wx.HORIZONTAL)
-        key_sz.Add(wx.StaticText(llm, label=_("API key")), 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, 5)
+        key_sz.Add(
+            wx.StaticText(llm, label=_("API key")),
+            0,
+            wx.ALIGN_CENTER_VERTICAL | wx.RIGHT,
+            5,
+        )
         key_sz.Add(self._api_key, 1, wx.ALIGN_CENTER_VERTICAL)
-        key_sz.Add(make_help_button(llm, LLM_HELP["api_key"]), 0, wx.ALIGN_CENTER_VERTICAL | wx.LEFT, 5)
+        key_sz.Add(
+            make_help_button(llm, LLM_HELP["api_key"]),
+            0,
+            wx.ALIGN_CENTER_VERTICAL | wx.LEFT,
+            5,
+        )
         llm_sizer.Add(key_sz, 0, wx.ALL | wx.EXPAND, 5)
         retries_sz = wx.BoxSizer(wx.HORIZONTAL)
-        retries_sz.Add(wx.StaticText(llm, label=_("Max retries")), 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, 5)
+        retries_sz.Add(
+            wx.StaticText(llm, label=_("Max retries")),
+            0,
+            wx.ALIGN_CENTER_VERTICAL | wx.RIGHT,
+            5,
+        )
         retries_sz.Add(self._max_retries, 1, wx.ALIGN_CENTER_VERTICAL)
         llm_sizer.Add(retries_sz, 0, wx.ALL | wx.EXPAND, 5)
         tokens_sz = wx.BoxSizer(wx.HORIZONTAL)
-        tokens_sz.Add(wx.StaticText(llm, label=_("Max output tokens")), 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, 5)
+        tokens_sz.Add(
+            wx.StaticText(llm, label=_("Max output tokens")),
+            0,
+            wx.ALIGN_CENTER_VERTICAL | wx.RIGHT,
+            5,
+        )
         tokens_sz.Add(self._max_output_tokens, 1, wx.ALIGN_CENTER_VERTICAL)
         llm_sizer.Add(tokens_sz, 0, wx.ALL | wx.EXPAND, 5)
         timeout_sz = wx.BoxSizer(wx.HORIZONTAL)
-        timeout_sz.Add(wx.StaticText(llm, label=_("Timeout (min)")), 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, 5)
+        timeout_sz.Add(
+            wx.StaticText(llm, label=_("Timeout (min)")),
+            0,
+            wx.ALIGN_CENTER_VERTICAL | wx.RIGHT,
+            5,
+        )
         timeout_sz.Add(self._timeout, 1, wx.ALIGN_CENTER_VERTICAL)
-        timeout_sz.Add(make_help_button(llm, LLM_HELP["timeout_minutes"]), 0, wx.ALIGN_CENTER_VERTICAL | wx.LEFT, 5)
+        timeout_sz.Add(
+            make_help_button(llm, LLM_HELP["timeout_minutes"]),
+            0,
+            wx.ALIGN_CENTER_VERTICAL | wx.LEFT,
+            5,
+        )
         llm_sizer.Add(timeout_sz, 0, wx.ALL | wx.EXPAND, 5)
         stream_sz = wx.BoxSizer(wx.HORIZONTAL)
         stream_sz.Add(self._stream, 0, wx.ALIGN_CENTER_VERTICAL)
@@ -200,7 +259,7 @@ class SettingsDialog(wx.Dialog):
         help_txt = wx.StaticText(
             mcp,
             label=_(
-                "MCP is a local server providing tools for requirement management used by agents and the LLM."
+                "MCP is a local server providing tools for requirement management used by agents and the LLM.",
             ),
         )
         help_txt.Wrap(300)
@@ -212,28 +271,73 @@ class SettingsDialog(wx.Dialog):
 
         mcp_sizer = wx.BoxSizer(wx.VERTICAL)
         host_sz = wx.BoxSizer(wx.HORIZONTAL)
-        host_sz.Add(wx.StaticText(mcp, label=_("Host")), 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, 5)
+        host_sz.Add(
+            wx.StaticText(mcp, label=_("Host")),
+            0,
+            wx.ALIGN_CENTER_VERTICAL | wx.RIGHT,
+            5,
+        )
         host_sz.Add(self._host, 1, wx.ALIGN_CENTER_VERTICAL)
-        host_sz.Add(make_help_button(mcp, MCP_HELP["host"]), 0, wx.ALIGN_CENTER_VERTICAL | wx.LEFT, 5)
+        host_sz.Add(
+            make_help_button(mcp, MCP_HELP["host"]),
+            0,
+            wx.ALIGN_CENTER_VERTICAL | wx.LEFT,
+            5,
+        )
         mcp_sizer.Add(host_sz, 0, wx.ALL | wx.EXPAND, 5)
         port_sz = wx.BoxSizer(wx.HORIZONTAL)
-        port_sz.Add(wx.StaticText(mcp, label=_("Port")), 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, 5)
+        port_sz.Add(
+            wx.StaticText(mcp, label=_("Port")),
+            0,
+            wx.ALIGN_CENTER_VERTICAL | wx.RIGHT,
+            5,
+        )
         port_sz.Add(self._port, 1, wx.ALIGN_CENTER_VERTICAL)
-        port_sz.Add(make_help_button(mcp, MCP_HELP["port"]), 0, wx.ALIGN_CENTER_VERTICAL | wx.LEFT, 5)
+        port_sz.Add(
+            make_help_button(mcp, MCP_HELP["port"]),
+            0,
+            wx.ALIGN_CENTER_VERTICAL | wx.LEFT,
+            5,
+        )
         mcp_sizer.Add(port_sz, 0, wx.ALL | wx.EXPAND, 5)
         base_sz = wx.BoxSizer(wx.HORIZONTAL)
-        base_sz.Add(wx.StaticText(mcp, label=_("Path")), 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, 5)
+        base_sz.Add(
+            wx.StaticText(mcp, label=_("Path")),
+            0,
+            wx.ALIGN_CENTER_VERTICAL | wx.RIGHT,
+            5,
+        )
         base_sz.Add(self._base_path, 1, wx.ALIGN_CENTER_VERTICAL)
-        base_sz.Add(make_help_button(mcp, MCP_HELP["base_path"]), 0, wx.ALIGN_CENTER_VERTICAL | wx.LEFT, 5)
+        base_sz.Add(
+            make_help_button(mcp, MCP_HELP["base_path"]),
+            0,
+            wx.ALIGN_CENTER_VERTICAL | wx.LEFT,
+            5,
+        )
         mcp_sizer.Add(base_sz, 0, wx.ALL | wx.EXPAND, 5)
         token_toggle_sz = wx.BoxSizer(wx.HORIZONTAL)
         token_toggle_sz.Add(self._require_token, 0, wx.ALIGN_CENTER_VERTICAL)
-        token_toggle_sz.Add(make_help_button(mcp, MCP_HELP["require_token"]), 0, wx.ALIGN_CENTER_VERTICAL | wx.LEFT, 5)
+        token_toggle_sz.Add(
+            make_help_button(mcp, MCP_HELP["require_token"]),
+            0,
+            wx.ALIGN_CENTER_VERTICAL | wx.LEFT,
+            5,
+        )
         mcp_sizer.Add(token_toggle_sz, 0, wx.ALL, 5)
         token_sz = wx.BoxSizer(wx.HORIZONTAL)
-        token_sz.Add(wx.StaticText(mcp, label=_("Token")), 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, 5)
+        token_sz.Add(
+            wx.StaticText(mcp, label=_("Token")),
+            0,
+            wx.ALIGN_CENTER_VERTICAL | wx.RIGHT,
+            5,
+        )
         token_sz.Add(self._token, 1, wx.ALIGN_CENTER_VERTICAL)
-        token_sz.Add(make_help_button(mcp, MCP_HELP["token"]), 0, wx.ALIGN_CENTER_VERTICAL | wx.LEFT, 5)
+        token_sz.Add(
+            make_help_button(mcp, MCP_HELP["token"]),
+            0,
+            wx.ALIGN_CENTER_VERTICAL | wx.LEFT,
+            5,
+        )
         mcp_sizer.Add(token_sz, 0, wx.ALL | wx.EXPAND, 5)
         btn_sz = wx.BoxSizer(wx.HORIZONTAL)
         btn_sz.Add(self._start, 0, wx.RIGHT, 5)
@@ -258,7 +362,10 @@ class SettingsDialog(wx.Dialog):
         self.SetSizerAndFit(dlg_sizer)
 
     # ------------------------------------------------------------------
-    def _on_toggle_token(self, _event: wx.Event) -> None:  # pragma: no cover - GUI event
+    def _on_toggle_token(
+        self,
+        _event: wx.Event,
+    ) -> None:  # pragma: no cover - GUI event
         self._token.Enable(self._require_token.GetValue())
 
     def _update_mcp_controls(self) -> None:
@@ -329,7 +436,9 @@ class SettingsDialog(wx.Dialog):
         )
 
     # ------------------------------------------------------------------
-    def get_values(self) -> tuple[
+    def get_values(
+        self,
+    ) -> tuple[
         bool,
         bool,
         str,
@@ -365,4 +474,3 @@ class SettingsDialog(wx.Dialog):
             self._require_token.GetValue(),
             self._token.GetValue(),
         )
-

--- a/app/util/__init__.py
+++ b/app/util/__init__.py
@@ -1,3 +1,1 @@
 """Utility helpers for CookaReq."""
-
-

--- a/app/util/hashing.py
+++ b/app/util/hashing.py
@@ -1,4 +1,5 @@
 """Utilities for hashing identifiers."""
+
 from __future__ import annotations
 
 from hashlib import sha256

--- a/app/util/paths.py
+++ b/app/util/paths.py
@@ -1,4 +1,5 @@
 """Helpers for dealing with filesystem paths."""
+
 from __future__ import annotations
 
 from pathlib import Path

--- a/app/util/time.py
+++ b/app/util/time.py
@@ -13,9 +13,7 @@ def utc_now_iso() -> str:
 def local_now_str() -> str:
     """Return local time in ``YYYY-MM-DD HH:MM:SS`` format."""
     return (
-        datetime.datetime.now(datetime.UTC)
-        .astimezone()
-        .strftime("%Y-%m-%d %H:%M:%S")
+        datetime.datetime.now(datetime.UTC).astimezone().strftime("%Y-%m-%d %H:%M:%S")
     )
 
 

--- a/build.py
+++ b/build.py
@@ -4,6 +4,7 @@ This script generates a one-folder distribution in the ``dist``
 folder. It requires PyInstaller to be installed in the active
 environment.
 """
+
 import os
 import sys
 from pathlib import Path

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ select = [
     "I",
     "W",
     "C4",
+    "COM",
     "A",
     "ARG",
     "SIM",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,7 +23,7 @@ def _mock_openrouter(monkeypatch, request):
     if request.node.get_closest_marker("real_llm"):
         if not os.getenv("COOKAREQ_RUN_REAL_LLM_TESTS"):
             pytest.skip(
-                "Set COOKAREQ_RUN_REAL_LLM_TESTS=1 to run tests hitting real LLM"
+                "Set COOKAREQ_RUN_REAL_LLM_TESTS=1 to run tests hitting real LLM",
             )
         return
     from tests.llm_utils import make_openai_mock
@@ -93,5 +93,6 @@ def pytest_terminal_summary(terminalreporter, exitstatus):
     skipped = len(terminalreporter.stats.get("skipped", []))
     duration = time.time() - terminalreporter.config._start_time
     terminalreporter.write_sep(
-        "=", f"{passed} passed, {failed} failed, {skipped} skipped in {duration:.2f}s"
+        "=",
+        f"{passed} passed, {failed} failed, {skipped} skipped in {duration:.2f}s",
     )

--- a/tests/gui/test_app_icon.py
+++ b/tests/gui/test_app_icon.py
@@ -16,4 +16,3 @@ def test_main_frame_loads_multiple_icon_sizes(wx_app):
         assert bundle.GetIconCount() >= 2
     finally:
         frame.Destroy()
-

--- a/tests/gui/test_editor_panel.py
+++ b/tests/gui/test_editor_panel.py
@@ -15,6 +15,7 @@ def _make_panel():
     wx = pytest.importorskip("wx")
     frame = wx.Frame(None)
     from app.ui.editor_panel import EditorPanel
+
     return EditorPanel(frame)
 
 
@@ -137,12 +138,14 @@ def test_enum_localization_roundtrip(wx_app):
             "status": "approved",
             "priority": "high",
             "verification": "test",
-        }
+        },
     )
     assert panel.enums["type"].GetStringSelection() == locale.TYPE["constraint"]
     assert panel.enums["status"].GetStringSelection() == locale.STATUS["approved"]
     assert panel.enums["priority"].GetStringSelection() == locale.PRIORITY["high"]
-    assert panel.enums["verification"].GetStringSelection() == locale.VERIFICATION["test"]
+    assert (
+        panel.enums["verification"].GetStringSelection() == locale.VERIFICATION["test"]
+    )
 
     panel.enums["type"].SetStringSelection(locale.TYPE["interface"])
     panel.enums["status"].SetStringSelection(locale.STATUS["baselined"])

--- a/tests/gui/test_editor_panel_gui.py
+++ b/tests/gui/test_editor_panel_gui.py
@@ -14,6 +14,7 @@ def _make_panel():
     wx = pytest.importorskip("wx")
     frame = wx.Frame(None)
     from app.ui.editor_panel import EditorPanel
+
     return EditorPanel(frame)
 
 
@@ -54,7 +55,9 @@ def test_editor_add_attachment_included(wx_app):
     panel.add_attachment("file.txt", "note")
     panel.fields["id"].SetValue("1")
     data = panel.get_data()
-    assert [asdict(a) for a in data.attachments] == [{"path": "file.txt", "note": "note"}]
+    assert [asdict(a) for a in data.attachments] == [
+        {"path": "file.txt", "note": "note"},
+    ]
 
 
 def test_id_field_highlight_on_duplicate(tmp_path, wx_app):
@@ -163,6 +166,7 @@ def test_editor_save_and_delete_roundtrip(tmp_path, wx_app):
     assert panel.mtime is None
     assert not saved_path.exists()
 
+
 def test_editor_loads_links(tmp_path, wx_app):
     panel = _make_panel()
     data = {
@@ -199,6 +203,7 @@ def test_multiline_fields_resize_dynamically(wx_app):
     shrunk = ctrl.GetSize().height
     assert shrunk < grown
     assert shrunk >= line_h * 2
+
 
 def test_rationale_autosizes_without_affecting_statement(wx_app):
     panel = _make_panel()

--- a/tests/gui/test_labels_dialog.py
+++ b/tests/gui/test_labels_dialog.py
@@ -52,7 +52,9 @@ def test_labels_dialog_adds_presets(wx_app):
     dlg = LabelsDialog(None, [])
     dlg._on_add_preset_set("basic")
     labels = dlg.get_labels()
-    assert {label.name for label in labels} == {label.name for label in PRESET_SETS["basic"]}
+    assert {label.name for label in labels} == {
+        label.name for label in PRESET_SETS["basic"]
+    }
     # calling again should not duplicate
     dlg._on_add_preset_set("basic")
     assert len(dlg.get_labels()) == len(PRESET_SETS["basic"])
@@ -63,7 +65,10 @@ def test_labels_dialog_deletes_selected(wx_app):
     wx = pytest.importorskip("wx")
     from app.ui.labels_dialog import LabelsDialog
 
-    dlg = LabelsDialog(None, [Label("a", "#111111"), Label("b", "#222222"), Label("c", "#333333")])
+    dlg = LabelsDialog(
+        None,
+        [Label("a", "#111111"), Label("b", "#222222"), Label("c", "#333333")],
+    )
     dlg.list.SetItemState(0, wx.LIST_STATE_SELECTED, wx.LIST_STATE_SELECTED)
     dlg.list.SetItemState(2, wx.LIST_STATE_SELECTED, wx.LIST_STATE_SELECTED)
     dlg._on_delete_selected(None)
@@ -145,6 +150,7 @@ def _prepare_frame(monkeypatch, tmp_path):
 
     import app.ui.list_panel as list_panel
     import app.ui.main_frame as main_frame
+
     importlib.reload(list_panel)
     importlib.reload(main_frame)
 
@@ -175,10 +181,10 @@ def test_main_frame_manage_labels_saves(monkeypatch, tmp_path, wx_app):
 
     captured: list[tuple[str, list[str]]] = []
     frame.editor.update_labels_list = lambda labels: captured.append(
-        ("editor", [label.name for label in labels])
+        ("editor", [label.name for label in labels]),
     )
     frame.panel.update_labels_list = lambda labels: captured.append(
-        ("panel", [label.name for label in labels])
+        ("panel", [label.name for label in labels]),
     )
 
     evt = wx.CommandEvent(wx.EVT_MENU.typeId, frame.manage_labels_id)
@@ -218,6 +224,7 @@ def test_main_frame_manage_labels_deletes_used(monkeypatch, tmp_path, wx_app):
 
     monkeypatch.setattr(main_frame_mod, "LabelsDialog", DummyLabelsDialog)
     from app import confirm as confirm_mod
+
     confirm_mod.set_confirm(fake_confirm)
 
     evt = wx.CommandEvent(wx.EVT_MENU.typeId, frame.manage_labels_id)
@@ -225,6 +232,7 @@ def test_main_frame_manage_labels_deletes_used(monkeypatch, tmp_path, wx_app):
 
     assert calls
     from app.core import store
+
     data, _ = store.load(tmp_path / "1.json")
     assert data["labels"] == []
     req = frame.model.get_all()[0]

--- a/tests/gui/test_labels_sync.py
+++ b/tests/gui/test_labels_sync.py
@@ -30,7 +30,10 @@ def test_sync_labels_preserves_unused(monkeypatch, tmp_path, wx_app):
     label_store.save_labels(tmp_path, PRESET_SETS["basic"])
     _create_requirement(tmp_path)
     from app.ui.main_frame import MainFrame
+
     frame = MainFrame(None)
     frame._load_directory(tmp_path)
-    assert {label.name for label in frame.labels} == {label.name for label in PRESET_SETS["basic"]}
+    assert {label.name for label in frame.labels} == {
+        label.name for label in PRESET_SETS["basic"]
+    }
     frame.Destroy()

--- a/tests/gui/test_language_switch.py
+++ b/tests/gui/test_language_switch.py
@@ -10,6 +10,7 @@ pytestmark = pytest.mark.gui
 def test_switch_to_russian_updates_ui(monkeypatch, wx_app):
     wx = pytest.importorskip("wx")
     import app.ui.main_frame as main_frame
+
     importlib.reload(main_frame)
 
     frame = main_frame.MainFrame(None)
@@ -26,8 +27,10 @@ def test_switch_to_russian_updates_ui(monkeypatch, wx_app):
     class DummySettingsDialog:
         def __init__(self, *args, **kwargs):
             pass
+
         def ShowModal(self):
             return wx.ID_OK
+
         def get_values(self):
             return (
                 frame.auto_open_last,
@@ -46,6 +49,7 @@ def test_switch_to_russian_updates_ui(monkeypatch, wx_app):
                 frame.mcp_settings.require_token,
                 frame.mcp_settings.token,
             )
+
         def Destroy(self):
             pass
 
@@ -56,5 +60,6 @@ def test_switch_to_russian_updates_ui(monkeypatch, wx_app):
 
     frame.Destroy()
     from app import i18n
+
     # restore default language for subsequent tests
     i18n.install(main_mod.APP_NAME, main_mod.LOCALE_DIR, ["en"])

--- a/tests/gui/test_list_panel.py
+++ b/tests/gui/test_list_panel.py
@@ -18,16 +18,22 @@ def _build_wx_stub():
             self._bindings = {}
             self._shown = True
             self._tooltip = None
+
         def GetParent(self):
             return self._parent
+
         def Bind(self, event, handler):
             self._bindings[event] = handler
+
         def Show(self, show=True):
             self._shown = bool(show)
+
         def Hide(self):
             self._shown = False
+
         def IsShown(self):
             return self._shown
+
         def SetToolTip(self, tip):
             self._tooltip = tip
 
@@ -39,8 +45,10 @@ def _build_wx_stub():
         def __init__(self, parent=None):
             super().__init__(parent)
             self._sizer = None
+
         def SetSizer(self, sizer):
             self._sizer = sizer
+
         def GetSizer(self):
             return self._sizer
 
@@ -48,8 +56,10 @@ def _build_wx_stub():
         def __init__(self, parent=None):
             super().__init__(parent)
             self._value = ""
+
         def SetValue(self, value):
             self._value = value
+
         def GetValue(self):
             return self._value
 
@@ -63,8 +73,10 @@ def _build_wx_stub():
         def __init__(self, parent=None, label=""):
             super().__init__(parent)
             self._value = False
+
         def SetValue(self, value):
             self._value = bool(value)
+
         def GetValue(self):
             return self._value
 
@@ -72,6 +84,7 @@ def _build_wx_stub():
         def __init__(self, parent=None, label=""):
             super().__init__(parent)
             self._label = label
+
         def GetLabel(self):
             return self._label
 
@@ -104,32 +117,44 @@ def _build_wx_stub():
         def __init__(self, width, height):
             self._w = width
             self._h = height
+
         def GetWidth(self):
             return self._w
+
         def GetHeight(self):
             return self._h
 
     class MemoryDC:
         def __init__(self):
             self._bmp = None
+
         def SelectObject(self, bmp):
             self._bmp = bmp
+
         def SetFont(self, font):
             pass
+
         def SetBackground(self, brush):
             pass
+
         def Clear(self):
             pass
+
         def SetBrush(self, brush):
             pass
+
         def SetPen(self, pen):
             pass
+
         def DrawRectangle(self, x, y, w, h):
             pass
+
         def SetTextForeground(self, colour):
             pass
+
         def DrawText(self, text, x, y):
             pass
+
         def GetTextExtent(self, text):
             return (len(text) * 6, 10)
 
@@ -137,12 +162,16 @@ def _build_wx_stub():
         def __init__(self, parent=None, title=""):
             super().__init__(parent)
             self._title = title
+
         def CreateButtonSizer(self, flags):
             return BoxSizer(0)
+
         def SetSizerAndFit(self, sizer):
             self._sizer = sizer
+
         def ShowModal(self):
             return 0
+
         def Destroy(self):
             pass
 
@@ -151,10 +180,13 @@ def _build_wx_stub():
             super().__init__(parent)
             self._choices = choices or []
             self._checked: set[int] = set()
+
         def GetCount(self):
             return len(self._choices)
+
         def IsChecked(self, idx):
             return idx in self._checked
+
         def Check(self, idx, check=True):
             if check:
                 self._checked.add(idx)
@@ -176,10 +208,12 @@ def _build_wx_stub():
             self._col_images = {}
             self._item_images = []
             self._cells = {}
+
         def InsertColumn(self, col, heading):
             if col >= len(self._cols):
                 self._cols.extend([None] * (col - len(self._cols) + 1))
             self._cols[col] = heading
+
         def ClearAll(self):
             self._items.clear()
             self._data.clear()
@@ -187,51 +221,73 @@ def _build_wx_stub():
             self._col_images.clear()
             self._item_images.clear()
             self._cells.clear()
+
         def DeleteAllItems(self):
             self._items.clear()
             self._data.clear()
             self._col_images.clear()
             self._item_images.clear()
             self._cells.clear()
+
         def GetItemCount(self):
             return len(self._items)
+
         def GetColumnCount(self):
             return len(self._cols)
+
         def InsertItem(self, index, text, image=-1):
             self._items.insert(index, text)
             self._data.insert(index, 0)
             self._item_images.insert(index, image)
             return index
+
         InsertStringItem = InsertItem
+
         def SetItem(self, index, col, text, image=-1):
             if col == 0:
                 self._items[index] = text
             self._cells[(index, col)] = text
+
         SetStringItem = SetItem
+
         def SetItemData(self, index, data):
             self._data[index] = data
+
         def GetItemData(self, index):
             return self._data[index]
+
         def HitTest(self, pt):
             return -1, 0
+
         def HitTestSubItem(self, pt):
             return -1, 0, -1
+
         def SetItemColumnImage(self, index, col, img):
             self._col_images[(index, col)] = img
+
         def SetItemImage(self, index, img):
             if index >= len(self._item_images):
                 self._item_images.extend([-1] * (index - len(self._item_images) + 1))
             self._item_images[index] = img
+
         def GetItem(self, index, col=0):
             text = self._items[index] if col == 0 else self._cells.get((index, col), "")
-            img = self._item_images[index] if col == 0 else self._col_images.get((index, col), -1)
+            img = (
+                self._item_images[index]
+                if col == 0
+                else self._col_images.get((index, col), -1)
+            )
             return types.SimpleNamespace(GetText=lambda: text, GetImage=lambda: img)
+
         def GetFont(self):
             return Font()
+
         def GetBackgroundColour(self):
             return Colour("#ffffff")
+
         def SetImageList(self, il, which):
             self._imagelist = il
+
         def GetImageList(self, which):
             return self._imagelist
 
@@ -241,26 +297,35 @@ def _build_wx_stub():
             self._col = 0
             self._text = ""
             self._renderer = None
+
         def SetId(self, value):
             self._id = value
+
         def GetId(self):
             return self._id
+
         def SetColumn(self, value):
             self._col = value
+
         def GetColumn(self):
             return self._col
+
         def SetText(self, text):
             self._text = text
+
         def GetText(self):
             return self._text
+
         def SetCustomRenderer(self, rend):
             self._renderer = rend
+
         def GetCustomRenderer(self):
             return self._renderer
 
     class UltimateListCtrl(_BaseList):
         def __init__(self, parent=None, agw_style=0, **kwargs):
             super().__init__(parent)
+
         def SetItem(self, item):
             pass
 
@@ -273,31 +338,43 @@ def _build_wx_stub():
             self._w = width
             self._h = height
             self._images = []
+
         def Add(self, bmp):
             self._images.append(bmp)
             return len(self._images) - 1
+
         def GetSize(self):
             return self._w, self._h
+
         def GetImageCount(self):
             return len(self._images)
+
         def GetBitmap(self, idx):
             return self._images[idx]
 
     class BoxSizer:
         def __init__(self, orient):
             self._children = []
+
         def Add(self, window, proportion, flag, border):
             self._children.append(window)
+
         def GetChildren(self):
-            return [types.SimpleNamespace(GetWindow=lambda w=child: w) for child in self._children]
+            return [
+                types.SimpleNamespace(GetWindow=lambda w=child: w)
+                for child in self._children
+            ]
 
     class Config:
         def read_int(self, key, default):
             return default
+
         def write_int(self, key, value):
             pass
+
         def read(self, key, default=""):
             return default
+
         def write(self, key, value):
             pass
 
@@ -344,6 +421,7 @@ def _build_wx_stub():
         NullBitmap=object(),
         BLACK=Colour(0, 0, 0),
     )
+
     class ColumnSorterMixin:
         def __init__(self, *args, **kwargs):
             ctrl = self.GetListCtrl()
@@ -424,16 +502,20 @@ def test_column_click_sorts(monkeypatch):
 
     list_panel_module = importlib.import_module("app.ui.list_panel")
     importlib.reload(list_panel_module)
-    requirement_model_cls = importlib.import_module("app.ui.requirement_model").RequirementModel
+    requirement_model_cls = importlib.import_module(
+        "app.ui.requirement_model",
+    ).RequirementModel
     list_panel_cls = list_panel_module.ListPanel
 
     frame = wx_stub.Panel(None)
     panel = list_panel_cls(frame, model=requirement_model_cls())
     panel.set_columns(["id"])
-    panel.set_requirements([
-        _req(2, "B"),
-        _req(1, "A"),
-    ])
+    panel.set_requirements(
+        [
+            _req(2, "B"),
+            _req(1, "A"),
+        ],
+    )
 
     panel._on_col_click(types.SimpleNamespace(GetColumn=lambda: 0))
     assert [r.id for r in panel.model.get_visible()] == [1, 2]
@@ -455,16 +537,20 @@ def test_column_click_after_set_columns_triggers_sort(monkeypatch):
 
     list_panel_module = importlib.import_module("app.ui.list_panel")
     importlib.reload(list_panel_module)
-    requirement_model_cls = importlib.import_module("app.ui.requirement_model").RequirementModel
+    requirement_model_cls = importlib.import_module(
+        "app.ui.requirement_model",
+    ).RequirementModel
     list_panel_cls = list_panel_module.ListPanel
 
     frame = wx_stub.Panel(None)
     panel = list_panel_cls(frame, model=requirement_model_cls())
     panel.set_columns(["id"])
-    panel.set_requirements([
-        _req(2, "B"),
-        _req(1, "A"),
-    ])
+    panel.set_requirements(
+        [
+            _req(2, "B"),
+            _req(1, "A"),
+        ],
+    )
 
     handler = panel.list.get_bound_handler(wx_stub.EVT_LIST_COL_CLICK)
     handler(types.SimpleNamespace(GetColumn=lambda: 1))
@@ -481,15 +567,19 @@ def test_search_and_label_filters(monkeypatch):
 
     list_panel_module = importlib.import_module("app.ui.list_panel")
     importlib.reload(list_panel_module)
-    requirement_model_cls = importlib.import_module("app.ui.requirement_model").RequirementModel
+    requirement_model_cls = importlib.import_module(
+        "app.ui.requirement_model",
+    ).RequirementModel
     list_panel_cls = list_panel_module.ListPanel
 
     frame = wx_stub.Panel(None)
     panel = list_panel_cls(frame, model=requirement_model_cls())
-    panel.set_requirements([
-        _req(1, "Login", labels=["ui"]),
-        _req(2, "Export", labels=["report"]),
-    ])
+    panel.set_requirements(
+        [
+            _req(1, "Login", labels=["ui"]),
+            _req(2, "Export", labels=["report"]),
+        ],
+    )
 
     panel.set_label_filter(["ui"])
     assert [r.id for r in panel.model.get_visible()] == [1]
@@ -503,7 +593,6 @@ def test_search_and_label_filters(monkeypatch):
     assert panel.model.get_visible() == []
 
 
-
 def test_apply_filters(monkeypatch):
     wx_stub, mixins, ulc = _build_wx_stub()
     agw = types.SimpleNamespace(ultimatelistctrl=ulc)
@@ -514,15 +603,19 @@ def test_apply_filters(monkeypatch):
 
     list_panel_module = importlib.import_module("app.ui.list_panel")
     importlib.reload(list_panel_module)
-    requirement_model_cls = importlib.import_module("app.ui.requirement_model").RequirementModel
+    requirement_model_cls = importlib.import_module(
+        "app.ui.requirement_model",
+    ).RequirementModel
     list_panel_cls = list_panel_module.ListPanel
 
     frame = wx_stub.Panel(None)
     panel = list_panel_cls(frame, model=requirement_model_cls())
-    panel.set_requirements([
-        _req(1, "Login", labels=["ui"], owner="alice"),
-        _req(2, "Export", labels=["report"], owner="bob"),
-    ])
+    panel.set_requirements(
+        [
+            _req(1, "Login", labels=["ui"], owner="alice"),
+            _req(2, "Export", labels=["report"], owner="bob"),
+        ],
+    )
 
     panel.apply_filters({"labels": ["ui"]})
     assert [r.id for r in panel.model.get_visible()] == [1]
@@ -541,7 +634,9 @@ def test_reset_button_visibility(monkeypatch):
 
     list_panel_module = importlib.import_module("app.ui.list_panel")
     importlib.reload(list_panel_module)
-    requirement_model_cls = importlib.import_module("app.ui.requirement_model").RequirementModel
+    requirement_model_cls = importlib.import_module(
+        "app.ui.requirement_model",
+    ).RequirementModel
     list_panel_cls = list_panel_module.ListPanel
 
     frame = wx_stub.Panel(None)
@@ -563,15 +658,19 @@ def test_apply_status_filter(monkeypatch):
 
     list_panel_module = importlib.import_module("app.ui.list_panel")
     importlib.reload(list_panel_module)
-    requirement_model_cls = importlib.import_module("app.ui.requirement_model").RequirementModel
+    requirement_model_cls = importlib.import_module(
+        "app.ui.requirement_model",
+    ).RequirementModel
     list_panel_cls = list_panel_module.ListPanel
 
     frame = wx_stub.Panel(None)
     panel = list_panel_cls(frame, model=requirement_model_cls())
-    panel.set_requirements([
-        _req(1, "A", status=Status.DRAFT),
-        _req(2, "B", status=Status.APPROVED),
-    ])
+    panel.set_requirements(
+        [
+            _req(1, "A", status=Status.DRAFT),
+            _req(2, "B", status=Status.APPROVED),
+        ],
+    )
 
     panel.apply_filters({"status": "approved"})
     assert [r.id for r in panel.model.get_visible()] == [2]
@@ -589,15 +688,19 @@ def test_labels_column_uses_imagelist(monkeypatch):
 
     list_panel_module = importlib.import_module("app.ui.list_panel")
     importlib.reload(list_panel_module)
-    requirement_model_cls = importlib.import_module("app.ui.requirement_model").RequirementModel
+    requirement_model_cls = importlib.import_module(
+        "app.ui.requirement_model",
+    ).RequirementModel
     list_panel_cls = list_panel_module.ListPanel
 
     frame = wx_stub.Panel(None)
     panel = list_panel_cls(frame, model=requirement_model_cls())
     panel.set_columns(["labels"])
-    panel.set_requirements([
-        _req(1, "A", labels=["ui", "backend"]),
-    ])
+    panel.set_requirements(
+        [
+            _req(1, "A", labels=["ui", "backend"]),
+        ],
+    )
     labels_col = panel.columns.index("labels") + 1
     # В колонке labels должен появиться image-id, а колонка Title остаётся без картинки
     assert panel.list._col_images[(0, labels_col)] >= 0
@@ -614,16 +717,20 @@ def test_sort_by_labels(monkeypatch):
 
     list_panel_module = importlib.import_module("app.ui.list_panel")
     importlib.reload(list_panel_module)
-    requirement_model_cls = importlib.import_module("app.ui.requirement_model").RequirementModel
+    requirement_model_cls = importlib.import_module(
+        "app.ui.requirement_model",
+    ).RequirementModel
     list_panel_cls = list_panel_module.ListPanel
 
     frame = wx_stub.Panel(None)
     panel = list_panel_cls(frame, model=requirement_model_cls())
     panel.set_columns(["labels"])
-    panel.set_requirements([
-        _req(1, "A", labels=["beta"]),
-        _req(2, "B", labels=["alpha"]),
-    ])
+    panel.set_requirements(
+        [
+            _req(1, "A", labels=["beta"]),
+            _req(2, "B", labels=["alpha"]),
+        ],
+    )
 
     panel.sort(1, True)
     assert [r.id for r in panel.model.get_visible()] == [2, 1]
@@ -639,16 +746,20 @@ def test_sort_by_multiple_labels(monkeypatch):
 
     list_panel_module = importlib.import_module("app.ui.list_panel")
     importlib.reload(list_panel_module)
-    requirement_model_cls = importlib.import_module("app.ui.requirement_model").RequirementModel
+    requirement_model_cls = importlib.import_module(
+        "app.ui.requirement_model",
+    ).RequirementModel
     list_panel_cls = list_panel_module.ListPanel
 
     frame = wx_stub.Panel(None)
     panel = list_panel_cls(frame, model=requirement_model_cls())
     panel.set_columns(["labels"])
-    panel.set_requirements([
-        _req(1, "A", labels=["alpha", "zeta"]),
-        _req(2, "B", labels=["alpha", "beta"]),
-    ])
+    panel.set_requirements(
+        [
+            _req(1, "A", labels=["alpha", "zeta"]),
+            _req(2, "B", labels=["alpha", "beta"]),
+        ],
+    )
 
     panel.sort(1, True)
     assert [r.id for r in panel.model.get_visible()] == [2, 1]
@@ -664,7 +775,9 @@ def test_bulk_edit_updates_requirements(monkeypatch):
 
     list_panel_module = importlib.import_module("app.ui.list_panel")
     importlib.reload(list_panel_module)
-    requirement_model_cls = importlib.import_module("app.ui.requirement_model").RequirementModel
+    requirement_model_cls = importlib.import_module(
+        "app.ui.requirement_model",
+    ).RequirementModel
     list_panel_cls = list_panel_module.ListPanel
 
     frame = wx_stub.Panel(None)
@@ -691,17 +804,25 @@ def test_sort_method_and_callback(monkeypatch):
 
     list_panel_module = importlib.import_module("app.ui.list_panel")
     importlib.reload(list_panel_module)
-    requirement_model_cls = importlib.import_module("app.ui.requirement_model").RequirementModel
+    requirement_model_cls = importlib.import_module(
+        "app.ui.requirement_model",
+    ).RequirementModel
     list_panel_cls = list_panel_module.ListPanel
 
     frame = wx_stub.Panel(None)
     calls = []
-    panel = list_panel_cls(frame, model=requirement_model_cls(), on_sort_changed=lambda c, a: calls.append((c, a)))
+    panel = list_panel_cls(
+        frame,
+        model=requirement_model_cls(),
+        on_sort_changed=lambda c, a: calls.append((c, a)),
+    )
     panel.set_columns(["id"])
-    panel.set_requirements([
-        _req(2, "B"),
-        _req(1, "A"),
-    ])
+    panel.set_requirements(
+        [
+            _req(2, "B"),
+            _req(1, "A"),
+        ],
+    )
 
     panel.sort(1, True)
     assert [r.id for r in panel.model.get_visible()] == [1, 2]
@@ -722,7 +843,9 @@ def test_reorder_columns(monkeypatch):
 
     list_panel_module = importlib.import_module("app.ui.list_panel")
     importlib.reload(list_panel_module)
-    requirement_model_cls = importlib.import_module("app.ui.requirement_model").RequirementModel
+    requirement_model_cls = importlib.import_module(
+        "app.ui.requirement_model",
+    ).RequirementModel
     list_panel_cls = list_panel_module.ListPanel
 
     frame = wx_stub.Panel(None)

--- a/tests/gui/test_list_panel_gui.py
+++ b/tests/gui/test_list_panel_gui.py
@@ -35,9 +35,11 @@ def _req(req_id: int, title: str, **kwargs) -> Requirement:
 def test_list_panel_real_widgets(wx_app):
     wx = pytest.importorskip("wx")
     import app.ui.list_panel as list_panel
+
     importlib.reload(list_panel)
     frame = wx.Frame(None)
     from app.ui.requirement_model import RequirementModel
+
     panel = list_panel.ListPanel(frame, model=RequirementModel())
 
     frame.SetSizer(wx.BoxSizer(wx.VERTICAL))
@@ -61,9 +63,11 @@ def test_list_panel_real_widgets(wx_app):
 def test_reset_button_visibility_gui(wx_app):
     wx = pytest.importorskip("wx")
     import app.ui.list_panel as list_panel
+
     importlib.reload(list_panel)
     frame = wx.Frame(None)
     from app.ui.requirement_model import RequirementModel
+
     panel = list_panel.ListPanel(frame, model=RequirementModel())
     panel.set_search_query("T")
     wx_app.Yield()
@@ -77,6 +81,7 @@ def test_reset_button_visibility_gui(wx_app):
 def test_list_panel_context_menu_calls_handlers(monkeypatch, wx_app):
     wx = pytest.importorskip("wx")
     import app.ui.list_panel as list_panel
+
     importlib.reload(list_panel)
     frame = wx.Frame(None)
     called: dict[str, int] = {}
@@ -88,7 +93,13 @@ def test_list_panel_context_menu_calls_handlers(monkeypatch, wx_app):
         called["delete"] = req_id
 
     from app.ui.requirement_model import RequirementModel
-    panel = list_panel.ListPanel(frame, model=RequirementModel(), on_clone=on_clone, on_delete=on_delete)
+
+    panel = list_panel.ListPanel(
+        frame,
+        model=RequirementModel(),
+        on_clone=on_clone,
+        on_delete=on_delete,
+    )
     panel.set_columns(["version"])
     reqs = [_req(1, "T", version="1")]
     panel.set_requirements(reqs)
@@ -119,9 +130,11 @@ def test_list_panel_context_menu_calls_handlers(monkeypatch, wx_app):
 def test_list_panel_context_menu_via_event(monkeypatch, wx_app):
     wx = pytest.importorskip("wx")
     import app.ui.list_panel as list_panel
+
     importlib.reload(list_panel)
     frame = wx.Frame(None)
     from app.ui.requirement_model import RequirementModel
+
     panel = list_panel.ListPanel(frame, model=RequirementModel())
     panel.set_columns(["version"])
     panel.set_requirements([_req(1, "T", version="1")])
@@ -152,9 +165,11 @@ def test_list_panel_context_menu_via_event(monkeypatch, wx_app):
 def test_bulk_edit_updates_selected_items(monkeypatch, wx_app):
     wx = pytest.importorskip("wx")
     import app.ui.list_panel as list_panel
+
     importlib.reload(list_panel)
     frame = wx.Frame(None)
     from app.ui.requirement_model import RequirementModel
+
     panel = list_panel.ListPanel(frame, model=RequirementModel())
     panel.set_columns(["version", "type"])
     reqs = [
@@ -172,20 +187,29 @@ def test_bulk_edit_updates_selected_items(monkeypatch, wx_app):
     panel._on_edit_field(1)
     panel._on_edit_field(2)
     assert [r.version for r in reqs] == ["2", "2"]
-    assert [r.type for r in reqs] == [RequirementType.CONSTRAINT, RequirementType.CONSTRAINT]
+    assert [r.type for r in reqs] == [
+        RequirementType.CONSTRAINT,
+        RequirementType.CONSTRAINT,
+    ]
     frame.Destroy()
 
 
 def test_recalc_derived_map_updates_count(wx_app):
     wx = pytest.importorskip("wx")
     import app.ui.list_panel as list_panel
+
     importlib.reload(list_panel)
     frame = wx.Frame(None)
     from app.ui.requirement_model import RequirementModel
+
     panel = list_panel.ListPanel(frame, model=RequirementModel())
     panel.set_columns(["derived_count"])
     req1 = _req(1, "S")
-    req2 = _req(2, "D", derived_from=[DerivationLink(source_id=1, source_revision=1, suspect=False)])
+    req2 = _req(
+        2,
+        "D",
+        derived_from=[DerivationLink(source_id=1, source_revision=1, suspect=False)],
+    )
     panel.set_requirements([req1, req2])
     assert panel.list.GetItem(0, 1).GetText() == "1"
     req2.derived_from = []
@@ -197,14 +221,14 @@ def test_recalc_derived_map_updates_count(wx_app):
 def test_reorder_columns_gui(wx_app):
     wx = pytest.importorskip("wx")
     import app.ui.list_panel as list_panel
+
     importlib.reload(list_panel)
     frame = wx.Frame(None)
     from app.ui.requirement_model import RequirementModel
+
     panel = list_panel.ListPanel(frame, model=RequirementModel())
     panel.set_columns(["id", "status"])
     panel.reorder_columns(1, 2)
     assert panel.columns == ["status", "id"]
     assert panel.list.GetColumn(1).GetText() == "status"
     frame.Destroy()
-
-

--- a/tests/gui/test_main.py
+++ b/tests/gui/test_main.py
@@ -14,19 +14,23 @@ def test_main_runs(monkeypatch):
     class DummyApp:
         def __init__(self):
             self.loop_ran = False
+
         def MainLoop(self):
             self.loop_ran = True
 
     dummy_app = DummyApp()
+
     class DummyLocale:
         def __init__(self, lang):
             self.lang = lang
+
         def AddCatalog(self, name):
             pass
 
     class DummyConfig:
         def __init__(self, **kwargs):
             self.app_name = kwargs.get("appName")
+
         def Read(self, key):
             return ""
 
@@ -49,12 +53,18 @@ def test_main_runs(monkeypatch):
         def __init__(self, parent):
             self.parent = parent
             DummyFrame.instances.append(self)
+
         def Show(self):
             DummyFrame.shown = True
 
-    monkeypatch.setitem(sys.modules, "app.ui.main_frame", types.SimpleNamespace(MainFrame=DummyFrame))
+    monkeypatch.setitem(
+        sys.modules,
+        "app.ui.main_frame",
+        types.SimpleNamespace(MainFrame=DummyFrame),
+    )
 
     import app.main as main_module
+
     importlib.reload(main_module)
 
     main_module.main()

--- a/tests/gui/test_main_frame_gui.py
+++ b/tests/gui/test_main_frame_gui.py
@@ -16,11 +16,14 @@ def test_main_frame_open_folder(monkeypatch, tmp_path, wx_app):
     class DummyDirDialog:
         def __init__(self, parent, message):
             called["init"] = True
+
         def ShowModal(self):
             called["show"] = True
             return wx.ID_OK
+
         def GetPath(self):
             return str(tmp_path)
+
         def Destroy(self):
             called["destroy"] = True
 
@@ -28,6 +31,7 @@ def test_main_frame_open_folder(monkeypatch, tmp_path, wx_app):
 
     import app.ui.list_panel as list_panel
     import app.ui.main_frame as main_frame
+
     importlib.reload(list_panel)
     importlib.reload(main_frame)
 
@@ -42,6 +46,7 @@ def test_main_frame_open_folder(monkeypatch, tmp_path, wx_app):
 
     frame.Destroy()
 
+
 def test_main_frame_run_command_menu(monkeypatch, wx_app):
     wx = pytest.importorskip("wx")
 
@@ -50,8 +55,10 @@ def test_main_frame_run_command_menu(monkeypatch, wx_app):
     class DummyDialog:
         def __init__(self, parent, *, agent, history_path=None):
             called["init"] = True
+
         def ShowModal(self):
             called["show"] = True
+
         def Destroy(self):
             called["destroy"] = True
 
@@ -60,6 +67,7 @@ def test_main_frame_run_command_menu(monkeypatch, wx_app):
             called["agent"] = True
 
     import app.ui.main_frame as main_frame
+
     importlib.reload(main_frame)
     monkeypatch.setattr(main_frame, "CommandDialog", DummyDialog)
     monkeypatch.setattr(main_frame, "LocalAgent", DummyAgent)
@@ -78,6 +86,7 @@ def test_main_frame_run_command_history_persists(monkeypatch, tmp_path, wx_app):
     import json
 
     import app.ui.command_dialog as cmd
+
     importlib.reload(cmd)
     history_file = tmp_path / "history.json"
     monkeypatch.setattr(cmd, "_default_history_path", lambda: history_file)
@@ -85,6 +94,7 @@ def test_main_frame_run_command_history_persists(monkeypatch, tmp_path, wx_app):
     class DummyAgent:
         def __init__(self, settings=None, confirm=None):
             pass
+
         def run_command(self, text):
             return {"ok": 1}
 
@@ -95,6 +105,7 @@ def test_main_frame_run_command_history_persists(monkeypatch, tmp_path, wx_app):
             return wx.ID_OK
 
     import app.ui.main_frame as main_frame
+
     importlib.reload(main_frame)
     monkeypatch.setattr(main_frame, "LocalAgent", DummyAgent)
     monkeypatch.setattr(main_frame, "CommandDialog", AutoDialog)
@@ -123,24 +134,16 @@ def test_log_handler_not_duplicated(tmp_path, wx_app):
             logger.removeHandler(h)
 
     frame1 = main_frame.MainFrame(None)
-    assert (
-        sum(isinstance(h, main_frame.WxLogHandler) for h in logger.handlers) == 1
-    )
+    assert sum(isinstance(h, main_frame.WxLogHandler) for h in logger.handlers) == 1
     frame1.Close()
     wx_app.Yield()
-    assert (
-        sum(isinstance(h, main_frame.WxLogHandler) for h in logger.handlers) == 0
-    )
+    assert sum(isinstance(h, main_frame.WxLogHandler) for h in logger.handlers) == 0
 
     frame2 = main_frame.MainFrame(None)
-    assert (
-        sum(isinstance(h, main_frame.WxLogHandler) for h in logger.handlers) == 1
-    )
+    assert sum(isinstance(h, main_frame.WxLogHandler) for h in logger.handlers) == 1
     frame2.Close()
     wx_app.Yield()
-    assert (
-        sum(isinstance(h, main_frame.WxLogHandler) for h in logger.handlers) == 0
-    )
+    assert sum(isinstance(h, main_frame.WxLogHandler) for h in logger.handlers) == 0
 
     # wx_app fixture handles cleanup
 
@@ -196,6 +199,7 @@ def test_main_frame_loads_requirements(monkeypatch, tmp_path, wx_app):
 
     import app.ui.list_panel as list_panel
     import app.ui.main_frame as main_frame
+
     importlib.reload(list_panel)
     importlib.reload(main_frame)
 
@@ -247,6 +251,7 @@ def test_main_frame_select_opens_editor(monkeypatch, tmp_path, wx_app):
 
     import app.ui.list_panel as list_panel
     import app.ui.main_frame as main_frame
+
     importlib.reload(list_panel)
     importlib.reload(main_frame)
 
@@ -300,6 +305,7 @@ def _prepare_frame(monkeypatch, tmp_path):
 
     import app.ui.list_panel as list_panel
     import app.ui.main_frame as main_frame
+
     importlib.reload(list_panel)
     importlib.reload(main_frame)
 

--- a/tests/gui/test_main_frame_gui_size.py
+++ b/tests/gui/test_main_frame_gui_size.py
@@ -50,7 +50,14 @@ def test_main_frame_editor_multiline_fields_have_size(tmp_path, monkeypatch, wx_
     frame.panel.list.Select(0)
     wx_app.Yield()
 
-    for name in ["statement", "acceptance", "conditions", "trace_up", "trace_down", "source"]:
+    for name in [
+        "statement",
+        "acceptance",
+        "conditions",
+        "trace_up",
+        "trace_down",
+        "source",
+    ]:
         assert frame.editor.fields[name].GetSize().GetHeight() > 0
 
     frame.Destroy()

--- a/tests/gui/test_main_frame_llm_integration.py
+++ b/tests/gui/test_main_frame_llm_integration.py
@@ -13,12 +13,21 @@ from tests.llm_utils import make_openai_mock, settings_with_llm
 
 pytestmark = [pytest.mark.gui, pytest.mark.integration]
 
-def test_main_frame_creates_requirement_via_llm(tmp_path: Path, monkeypatch, wx_app, mcp_server) -> None:
+
+def test_main_frame_creates_requirement_via_llm(
+    tmp_path: Path,
+    monkeypatch,
+    wx_app,
+    mcp_server,
+) -> None:
     wx = pytest.importorskip("wx")
     port = mcp_server
     mcp_app.state.base_path = str(tmp_path)
     settings = settings_with_llm(tmp_path)
-    config = main_frame.ConfigManager(app_name="CookaReqTest", path=tmp_path / "cfg.ini")
+    config = main_frame.ConfigManager(
+        app_name="CookaReqTest",
+        path=tmp_path / "cfg.ini",
+    )
     config.set_llm_settings(settings.llm)
     config.set_mcp_settings(
         MCPSettings(
@@ -27,7 +36,7 @@ def test_main_frame_creates_requirement_via_llm(tmp_path: Path, monkeypatch, wx_
             base_path=str(tmp_path),
             require_token=False,
             token="",
-        )
+        ),
     )
     history_file = tmp_path / "history.json"
     monkeypatch.setattr(cmd, "_default_history_path", lambda: history_file)
@@ -55,10 +64,10 @@ def test_main_frame_creates_requirement_via_llm(tmp_path: Path, monkeypatch, wx_
                             "priority": "medium",
                             "source": "spec",
                             "verification": "analysis",
-                        }
+                        },
                     },
-                )
-            }
+                ),
+            },
         ),
     )
 
@@ -84,7 +93,10 @@ def test_main_frame_creates_requirement_via_llm(tmp_path: Path, monkeypatch, wx_
 
 def test_run_command_without_base_url(monkeypatch, tmp_path: Path, wx_app) -> None:
     wx = pytest.importorskip("wx")
-    config = main_frame.ConfigManager(app_name="CookaReqTest", path=tmp_path / "cfg.ini")
+    config = main_frame.ConfigManager(
+        app_name="CookaReqTest",
+        path=tmp_path / "cfg.ini",
+    )
     config.set_llm_settings(LLMSettings(base_url="", model="foo", api_key=None))
     frame = main_frame.MainFrame(None, config=config)
     called: dict[str, str] = {}

--- a/tests/gui/test_recent_dirs.py
+++ b/tests/gui/test_recent_dirs.py
@@ -6,10 +6,12 @@ import pytest
 
 pytestmark = pytest.mark.gui
 
+
 def test_recent_dirs_history(tmp_path, wx_app):
     pytest.importorskip("wx")
     import app.ui.list_panel as list_panel
     import app.ui.main_frame as main_frame
+
     importlib.reload(list_panel)
     importlib.reload(main_frame)
     frame = main_frame.MainFrame(None)
@@ -18,10 +20,16 @@ def test_recent_dirs_history(tmp_path, wx_app):
     for d in dirs:
         d.mkdir()
         frame._load_directory(d)
-    assert frame.recent_dirs == [str(dirs[i]) for i in (5,4,3,2,1)]
+    assert frame.recent_dirs == [str(dirs[i]) for i in (5, 4, 3, 2, 1)]
 
     frame._load_directory(dirs[4])
-    assert frame.recent_dirs == [str(dirs[4]), str(dirs[5]), str(dirs[3]), str(dirs[2]), str(dirs[1])]
+    assert frame.recent_dirs == [
+        str(dirs[4]),
+        str(dirs[5]),
+        str(dirs[3]),
+        str(dirs[2]),
+        str(dirs[1]),
+    ]
 
     items = [i.GetItemLabelText() for i in frame._recent_menu.GetMenuItems()]
     assert items == frame.recent_dirs

--- a/tests/gui/test_settings_dialog.py
+++ b/tests/gui/test_settings_dialog.py
@@ -157,7 +157,10 @@ def test_mcp_check_status(monkeypatch, wx_app):
     dummy = DummyMCP()
     monkeypatch.setattr("app.ui.settings_dialog.MCPController", lambda: dummy)
     messages: list[tuple[str, str]] = []
-    monkeypatch.setattr("wx.MessageBox", lambda msg, caption, *a, **k: messages.append((msg, caption)))
+    monkeypatch.setattr(
+        "wx.MessageBox",
+        lambda msg, caption, *a, **k: messages.append((msg, caption)),
+    )
 
     dlg = SettingsDialog(
         None,
@@ -215,7 +218,10 @@ def test_llm_agent_checks(monkeypatch, wx_app):
         def check_tools(self):
             return {"ok": True}
 
-    monkeypatch.setattr("app.ui.settings_dialog.LLMClient", lambda *, settings: DummyLLM(settings=settings))
+    monkeypatch.setattr(
+        "app.ui.settings_dialog.LLMClient",
+        lambda *, settings: DummyLLM(settings=settings),
+    )
     monkeypatch.setattr(
         "app.ui.settings_dialog.MCPClient",
         lambda *, settings, confirm: DummyMCP(settings=settings),

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -34,6 +34,7 @@ def sample() -> dict:
 
 def run_cli(argv: list[str]):
     from app.cli.main import main
+
     return main(argv)
 
 
@@ -147,6 +148,7 @@ def test_cli_settings_flag(tmp_path, monkeypatch, capsys):
         return AppSettings()
 
     import app.cli.main as cli_mod
+
     monkeypatch.setattr(cli_mod, "load_app_settings", fake_loader)
     monkeypatch.setattr(cli_mod, "AppSettings", AppSettings)
 

--- a/tests/integration/test_health_endpoint.py
+++ b/tests/integration/test_health_endpoint.py
@@ -1,7 +1,9 @@
 """Tests for health endpoint."""
+
 import pytest
 
 pytestmark = pytest.mark.integration
+
 
 def test_health_endpoint_returns_ok():
     from fastapi.testclient import TestClient

--- a/tests/integration/test_llm_client.py
+++ b/tests/integration/test_llm_client.py
@@ -21,10 +21,17 @@ def test_missing_api_key_ignores_env(monkeypatch):
     captured: dict[str, str | None] = {}
 
     class FakeOpenAI:
-        def __init__(self, *, base_url, api_key, timeout, max_retries):  # pragma: no cover - simple capture
+        def __init__(
+            self,
+            *,
+            base_url,
+            api_key,
+            timeout,
+            max_retries,
+        ):  # pragma: no cover - simple capture
             captured["api_key"] = api_key
             self.chat = SimpleNamespace(
-                completions=SimpleNamespace(create=lambda **kwargs: SimpleNamespace())
+                completions=SimpleNamespace(create=lambda **kwargs: SimpleNamespace()),
             )
 
     monkeypatch.setattr("openai.OpenAI", FakeOpenAI)
@@ -36,7 +43,8 @@ def test_missing_api_key_ignores_env(monkeypatch):
 def test_check_llm(tmp_path: Path, monkeypatch) -> None:
     settings = settings_with_llm(tmp_path)
     monkeypatch.setattr(
-        "openai.OpenAI", make_openai_mock({"ping": ("noop", {})})
+        "openai.OpenAI",
+        make_openai_mock({"ping": ("noop", {})}),
     )
     client = LLMClient(settings.llm)
     log_file = tmp_path / "llm.jsonl"

--- a/tests/integration/test_local_agent.py
+++ b/tests/integration/test_local_agent.py
@@ -36,7 +36,6 @@ class DummyLLM:
         return "some_tool", {}
 
 
-
 def test_check_llm_and_check_tools_propagate_errors():
     agent = LocalAgent(llm=FailingLLM(), mcp=FailingMCP())
     with pytest.raises(RuntimeError, match="llm failure"):

--- a/tests/integration/test_mcp_client.py
+++ b/tests/integration/test_mcp_client.py
@@ -23,7 +23,12 @@ def test_check_tools_success(tmp_path: Path) -> None:
     try:
         _wait_until_ready(port)
         settings = settings_with_mcp(
-            "127.0.0.1", port, str(tmp_path), "", tmp_path=tmp_path, fmt="toml"
+            "127.0.0.1",
+            port,
+            str(tmp_path),
+            "",
+            tmp_path=tmp_path,
+            fmt="toml",
         )
         client = MCPClient(settings.mcp, confirm=lambda _m: True)
         log_file = tmp_path / "log.jsonl"
@@ -55,7 +60,11 @@ def test_check_tools_unauthorized(tmp_path: Path) -> None:
     try:
         _wait_until_ready(port)
         settings = settings_with_mcp(
-            "127.0.0.1", port, str(tmp_path), "wrong", tmp_path=tmp_path
+            "127.0.0.1",
+            port,
+            str(tmp_path),
+            "wrong",
+            tmp_path=tmp_path,
         )
         client = MCPClient(settings.mcp, confirm=lambda _m: True)
         result = client.check_tools()
@@ -65,7 +74,13 @@ def test_check_tools_unauthorized(tmp_path: Path) -> None:
 
 
 def test_call_tool_delete_requires_confirmation(monkeypatch) -> None:
-    settings = MCPSettings(host="127.0.0.1", port=0, base_path="", require_token=False, token="")
+    settings = MCPSettings(
+        host="127.0.0.1",
+        port=0,
+        base_path="",
+        require_token=False,
+        token="",
+    )
 
     called = {"msg": None}
 
@@ -87,13 +102,23 @@ def test_call_tool_delete_requires_confirmation(monkeypatch) -> None:
 
 
 def test_call_tool_delete_confirm_yes(monkeypatch) -> None:
-    settings = MCPSettings(host="127.0.0.1", port=0, base_path="", require_token=False, token="")
+    settings = MCPSettings(
+        host="127.0.0.1",
+        port=0,
+        base_path="",
+        require_token=False,
+        token="",
+    )
 
     client = MCPClient(settings, confirm=lambda _m: True)
 
     events: list[tuple[str, dict | None]] = []
 
-    def fake_log(event: str, payload=None, start_time=None) -> None:  # pragma: no cover - helper
+    def fake_log(
+        event: str,
+        payload=None,
+        start_time=None,
+    ) -> None:  # pragma: no cover - helper
         events.append((event, payload))
 
     monkeypatch.setattr("app.mcp.client.log_event", fake_log)

--- a/tests/integration/test_mcp_controller.py
+++ b/tests/integration/test_mcp_controller.py
@@ -4,6 +4,7 @@ import pytest
 
 pytestmark = pytest.mark.integration
 
+
 def test_controller_check(monkeypatch):
     from app.mcp.controller import MCPController, MCPStatus
     from app.settings import MCPSettings
@@ -39,7 +40,11 @@ def test_controller_check(monkeypatch):
 
     ctrl = MCPController()
     settings = MCPSettings(
-        host="localhost", port=8123, base_path="/tmp", require_token=True, token="abc"
+        host="localhost",
+        port=8123,
+        base_path="/tmp",
+        require_token=True,
+        token="abc",
     )
     res = ctrl.check(settings)
     assert res.status is MCPStatus.READY
@@ -75,10 +80,13 @@ def test_controller_start_stop(monkeypatch):
 
     monkeypatch.setattr(
         "app.mcp.controller.start_server",
-        lambda host, port, base_path, token: calls.append(("start", host, port, base_path, token)),
+        lambda host, port, base_path, token: calls.append(
+            ("start", host, port, base_path, token),
+        ),
     )
     monkeypatch.setattr(
-        "app.mcp.controller.stop_server", lambda: calls.append(("stop",))
+        "app.mcp.controller.stop_server",
+        lambda: calls.append(("stop",)),
     )
 
     ctrl = MCPController()

--- a/tests/integration/test_mcp_http_tools.py
+++ b/tests/integration/test_mcp_http_tools.py
@@ -39,7 +39,12 @@ def _prepare(tmp_path: Path) -> None:
 def _call_tool(port: int, name: str, arguments: dict | None = None):
     conn = HTTPConnection("127.0.0.1", port)
     payload = json.dumps({"name": name, "arguments": arguments or {}})
-    conn.request("POST", "/mcp", body=payload, headers={"Content-Type": "application/json"})
+    conn.request(
+        "POST",
+        "/mcp",
+        body=payload,
+        headers={"Content-Type": "application/json"},
+    )
     resp = conn.getresponse()
     body = json.loads(resp.read().decode())
     conn.close()
@@ -59,6 +64,7 @@ def test_list_requirements_via_http(tmp_path: Path) -> None:
         assert ids == {1, 2}
     finally:
         stop_server()
+
 
 def test_get_requirement_via_http(tmp_path: Path) -> None:
     _prepare(tmp_path)
@@ -130,7 +136,11 @@ def test_patch_requirement_via_http(tmp_path: Path) -> None:
         status, body = _call_tool(
             port,
             "patch_requirement",
-            {"req_id": 1, "patch": [{"op": "replace", "path": "/title", "value": "A2"}], "rev": 1},
+            {
+                "req_id": 1,
+                "patch": [{"op": "replace", "path": "/title", "value": "A2"}],
+                "rev": 1,
+            },
         )
         assert status == 200
         assert body["title"] == "A2"
@@ -162,9 +172,15 @@ def test_link_requirements_via_http(tmp_path: Path) -> None:
     start_server(port=port, base_path=str(tmp_path))
     try:
         _wait_until_ready(port)
-        status, body = _call_tool(port, "link_requirements", {"source_id": 1, "derived_id": 2, "link_type": "derived_from", "rev": 1})
+        status, body = _call_tool(
+            port,
+            "link_requirements",
+            {"source_id": 1, "derived_id": 2, "link_type": "derived_from", "rev": 1},
+        )
         assert status == 200
         assert body["revision"] == 2
-        assert body["derived_from"] == [{"source_id": 1, "source_revision": 1, "suspect": False}]
+        assert body["derived_from"] == [
+            {"source_id": 1, "source_revision": 1, "suspect": False},
+        ]
     finally:
         stop_server()

--- a/tests/integration/test_mcp_llm_integration.py
+++ b/tests/integration/test_mcp_llm_integration.py
@@ -15,11 +15,19 @@ from tests.llm_utils import make_openai_mock, settings_with_mcp
 pytestmark = pytest.mark.integration
 
 
-def test_create_and_delete_requirement_via_llm(tmp_path: Path, monkeypatch, mcp_server) -> None:
+def test_create_and_delete_requirement_via_llm(
+    tmp_path: Path,
+    monkeypatch,
+    mcp_server,
+) -> None:
     port = mcp_server
     mcp_app.state.base_path = str(tmp_path)
     settings = settings_with_mcp(
-        "127.0.0.1", port, str(tmp_path), "", tmp_path=tmp_path
+        "127.0.0.1",
+        port,
+        str(tmp_path),
+        "",
+        tmp_path=tmp_path,
     )
     responses = {}
     monkeypatch.setattr("openai.OpenAI", make_openai_mock(responses))
@@ -49,7 +57,7 @@ def test_create_and_delete_requirement_via_llm(tmp_path: Path, monkeypatch, mcp_
                     "source": "spec",
                     "verification": "analysis",
                     "labels": ["llm", "automation"],
-                }
+                },
             },
         )
         client.run_command(text_create)
@@ -58,7 +66,9 @@ def test_create_and_delete_requirement_via_llm(tmp_path: Path, monkeypatch, mcp_
         assert data["title"] == "LLM test"
         assert data["owner"] == "alice"
         rev = data["revision"]
-        text_delete = f"Delete requirement 10 with revision {rev}. I confirm the deletion."
+        text_delete = (
+            f"Delete requirement 10 with revision {rev}. I confirm the deletion."
+        )
         responses[text_delete] = (
             "delete_requirement",
             {"req_id": 10, "rev": rev},

--- a/tests/integration/test_mcp_text_commands.py
+++ b/tests/integration/test_mcp_text_commands.py
@@ -19,13 +19,17 @@ def test_run_command_list_logs(tmp_path: Path, monkeypatch, mcp_server) -> None:
     port = mcp_server
     mcp_app.state.base_path = str(tmp_path)
     settings = settings_with_mcp(
-        "127.0.0.1", port, str(tmp_path), "", tmp_path=tmp_path
+        "127.0.0.1",
+        port,
+        str(tmp_path),
+        "",
+        tmp_path=tmp_path,
     )
     # Мокаем OpenAI, чтобы исключить внешние вызовы.
     monkeypatch.setattr(
         "openai.OpenAI",
         make_openai_mock(
-            {"list requirements per page 1": ("list_requirements", {"per_page": 1})}
+            {"list requirements per page 1": ("list_requirements", {"per_page": 1})},
         ),
     )
     client = LocalAgent(settings=settings, confirm=lambda _m: True)
@@ -45,12 +49,15 @@ def test_run_command_list_logs(tmp_path: Path, monkeypatch, mcp_server) -> None:
     assert {"LLM_REQUEST", "LLM_RESPONSE", "TOOL_CALL", "TOOL_RESULT", "DONE"} <= events
 
 
-
 def test_run_command_error_logs(tmp_path: Path, monkeypatch, mcp_server) -> None:
     port = mcp_server
     mcp_app.state.base_path = str(tmp_path)
     settings = settings_with_mcp(
-        "127.0.0.1", port, str(tmp_path), "", tmp_path=tmp_path
+        "127.0.0.1",
+        port,
+        str(tmp_path),
+        "",
+        tmp_path=tmp_path,
     )
     # Мокаем OpenAI, чтобы исключить внешние вызовы.
     monkeypatch.setattr(
@@ -71,4 +78,10 @@ def test_run_command_error_logs(tmp_path: Path, monkeypatch, mcp_server) -> None
     assert "error" in result
     entries = [json.loads(line) for line in log_file.read_text().splitlines()]
     events = {e.get("event") for e in entries}
-    assert {"LLM_REQUEST", "LLM_RESPONSE", "TOOL_CALL", "TOOL_RESULT", "ERROR"} <= events
+    assert {
+        "LLM_REQUEST",
+        "LLM_RESPONSE",
+        "TOOL_CALL",
+        "TOOL_RESULT",
+        "ERROR",
+    } <= events

--- a/tests/integration/test_tool_logging.py
+++ b/tests/integration/test_tool_logging.py
@@ -13,6 +13,7 @@ from app.mcp.utils import log_tool
 
 pytestmark = pytest.mark.integration
 
+
 def test_tool_logging(tmp_path: Path) -> None:
     log_file = tmp_path / "server.jsonl"
     handler = JsonlHandler(str(log_file))

--- a/tests/llm_utils.py
+++ b/tests/llm_utils.py
@@ -42,12 +42,12 @@ def make_openai_mock(responses: dict[str, tuple[str, dict] | Exception]):
                                         function=SimpleNamespace(
                                             name=name,
                                             arguments=json.dumps(args),
-                                        )
-                                    )
-                                ]
-                            )
-                        )
-                    ]
+                                        ),
+                                    ),
+                                ],
+                            ),
+                        ),
+                    ],
                 )
             return SimpleNamespace()
 
@@ -73,7 +73,7 @@ def settings_with_llm(tmp_path: Path, *, api_key: str = "dummy") -> AppSettings:
             "max_output_tokens": 0,
             "timeout_minutes": 60,
             "stream": False,
-        }
+        },
     }
     path = tmp_path / "settings.json"
     path.write_text(json.dumps(data))
@@ -118,13 +118,13 @@ def settings_with_mcp(
     if fmt == "toml":
         toml = f"""
 [llm]
-base_url = \"{settings['llm']['base_url']}\"
-model = \"{settings['llm']['model']}\"
-api_key = \"{settings['llm']['api_key']}\"
-max_retries = {settings['llm']['max_retries']}
-max_output_tokens = {settings['llm']['max_output_tokens']}
-timeout_minutes = {settings['llm']['timeout_minutes']}
-stream = {str(settings['llm']['stream']).lower()}
+base_url = \"{settings["llm"]["base_url"]}\"
+model = \"{settings["llm"]["model"]}\"
+api_key = \"{settings["llm"]["api_key"]}\"
+max_retries = {settings["llm"]["max_retries"]}
+max_output_tokens = {settings["llm"]["max_output_tokens"]}
+timeout_minutes = {settings["llm"]["timeout_minutes"]}
+stream = {str(settings["llm"]["stream"]).lower()}
 
 [mcp]
 host = \"{host}\"

--- a/tests/slow/test_pydocstyle.py
+++ b/tests/slow/test_pydocstyle.py
@@ -5,6 +5,7 @@ import pytest
 
 pytestmark = pytest.mark.slow
 
+
 def test_pydocstyle_conformance():
     """Ensure docstring conventions are respected."""
     cmd = [sys.executable, "-m", "pydocstyle", "app"]

--- a/tests/unit/test_config_manager.py
+++ b/tests/unit/test_config_manager.py
@@ -93,7 +93,13 @@ def test_app_settings_round_trip(tmp_path, wx_app):
             timeout_minutes=42,
             stream=False,
         ),
-        mcp=MCPSettings(host="1.2.3.4", port=9999, base_path="/m", require_token=True, token="t"),
+        mcp=MCPSettings(
+            host="1.2.3.4",
+            port=9999,
+            base_path="/m",
+            require_token=True,
+            token="t",
+        ),
         ui=UISettings(
             columns=["id", "title"],
             recent_dirs=[str(tmp_path / "a"), str(tmp_path / "b")],

--- a/tests/unit/test_derived_requirements.py
+++ b/tests/unit/test_derived_requirements.py
@@ -13,7 +13,6 @@ from app.core.store import filename_for, load, save
 pytestmark = pytest.mark.unit
 
 
-
 def _base(req_id: int) -> dict:
     return {
         "id": req_id,
@@ -68,7 +67,9 @@ def test_suspect_mark_on_source_revision_change(tmp_path: Path) -> None:
 def test_search_filters_is_and_has_derived() -> None:
     req1 = requirement_from_dict(_base(1))
     derived_data = _base(2)
-    derived_data["derived_from"] = [{"source_id": 1, "source_revision": 1, "suspect": False}]
+    derived_data["derived_from"] = [
+        {"source_id": 1, "source_revision": 1, "suspect": False},
+    ]
     req2 = requirement_from_dict(derived_data)
     reqs: list[Requirement] = [req1, req2]
 

--- a/tests/unit/test_i18n.py
+++ b/tests/unit/test_i18n.py
@@ -29,7 +29,8 @@ def test_install_selects_locale_and_falls_back(tmp_path, monkeypatch):
     fr_dir = tmp_path / "fr" / "LC_MESSAGES"
     fr_dir.mkdir(parents=True)
     (fr_dir / "app.po").write_text(
-        'msgid "hello"\nmsgstr "bonjour"\n', encoding="utf-8"
+        'msgid "hello"\nmsgstr "bonjour"\n',
+        encoding="utf-8",
     )
 
     monkeypatch.setattr(i18n, "_translations", {})

--- a/tests/unit/test_i18n_escape.py
+++ b/tests/unit/test_i18n_escape.py
@@ -6,11 +6,16 @@ from app import i18n
 
 pytestmark = pytest.mark.unit
 
+
 def test_parse_po_unescape(tmp_path):
     po = tmp_path / "sample.po"
-    po.write_text('msgid "Line\\nBreak\\tTab"\nmsgstr "Перевод\\nСтрока\\tТаб"\n', encoding="utf-8")
+    po.write_text(
+        'msgid "Line\\nBreak\\tTab"\nmsgstr "Перевод\\nСтрока\\tТаб"\n',
+        encoding="utf-8",
+    )
     data = i18n._parse_po(po)
     assert data["Line\nBreak\tTab"] == "Перевод\nСтрока\tТаб"
+
 
 def test_flush_missing_escape(tmp_path):
     i18n._missing.clear()

--- a/tests/unit/test_model.py
+++ b/tests/unit/test_model.py
@@ -53,7 +53,7 @@ def test_requirement_derivation_conversion():
         "source": "spec",
         "verification": "analysis",
         "derived_from": [
-            {"source_id": 2, "source_revision": 3, "suspect": True}
+            {"source_id": 2, "source_revision": 3, "suspect": True},
         ],
         "derivation": {
             "rationale": "r",

--- a/tests/unit/test_requirement_ops.py
+++ b/tests/unit/test_requirement_ops.py
@@ -43,7 +43,12 @@ def test_create_patch_delete(tmp_path: Path):
     assert path.exists()
 
     # patch allowed field
-    patch_requirement(tmp_path, 1, [{"op": "replace", "path": "/title", "value": "New"}], rev=1)
+    patch_requirement(
+        tmp_path,
+        1,
+        [{"op": "replace", "path": "/title", "value": "New"}],
+        rev=1,
+    )
     data, _ = load(path)
     assert data["title"] == "New"
     assert data["revision"] == 2
@@ -52,11 +57,21 @@ def test_create_patch_delete(tmp_path: Path):
     assert data["notes"] == "note"
 
     # conflicting revision
-    err = patch_requirement(tmp_path, 1, [{"op": "replace", "path": "/title", "value": "Other"}], rev=1)
+    err = patch_requirement(
+        tmp_path,
+        1,
+        [{"op": "replace", "path": "/title", "value": "Other"}],
+        rev=1,
+    )
     assert err["error"]["code"] == ErrorCode.CONFLICT
 
     # forbidden fields
-    err = patch_requirement(tmp_path, 1, [{"op": "replace", "path": "/id", "value": 5}], rev=2)
+    err = patch_requirement(
+        tmp_path,
+        1,
+        [{"op": "replace", "path": "/id", "value": 5}],
+        rev=2,
+    )
     assert err["error"]["code"] == ErrorCode.VALIDATION_ERROR
 
     # delete with wrong revision
@@ -75,18 +90,37 @@ def test_link_requirements(tmp_path: Path):
     create_requirement(tmp_path, _base_req(2))
 
     # link
-    link_requirements(tmp_path, source_id=1, derived_id=2, link_type="derived_from", rev=1)
+    link_requirements(
+        tmp_path,
+        source_id=1,
+        derived_id=2,
+        link_type="derived_from",
+        rev=1,
+    )
     path = tmp_path / filename_for(2)
     data, _ = load(path)
     assert data["revision"] == 2
-    assert data["derived_from"] == [{"source_id": 1, "source_revision": 1, "suspect": False}]
+    assert data["derived_from"] == [
+        {"source_id": 1, "source_revision": 1, "suspect": False},
+    ]
 
     # outdated rev
-    err = link_requirements(tmp_path, source_id=1, derived_id=2, link_type="derived_from", rev=1)
+    err = link_requirements(
+        tmp_path,
+        source_id=1,
+        derived_id=2,
+        link_type="derived_from",
+        rev=1,
+    )
     assert err["error"]["code"] == ErrorCode.CONFLICT
 
     # patching derived_from should be prohibited
-    err = patch_requirement(tmp_path, 2, [{"op": "replace", "path": "/derived_from", "value": []}], rev=2)
+    err = patch_requirement(
+        tmp_path,
+        2,
+        [{"op": "replace", "path": "/derived_from", "value": []}],
+        rev=2,
+    )
     assert err["error"]["code"] == ErrorCode.VALIDATION_ERROR
 
 
@@ -113,7 +147,12 @@ def test_create_requirement_errors(tmp_path: Path, monkeypatch) -> None:
 
 def test_patch_requirement_errors(tmp_path: Path, monkeypatch) -> None:
     # not found
-    err = patch_requirement(tmp_path, 1, [{"op": "replace", "path": "/title", "value": "X"}], rev=1)
+    err = patch_requirement(
+        tmp_path,
+        1,
+        [{"op": "replace", "path": "/title", "value": "X"}],
+        rev=1,
+    )
     assert err["error"]["code"] == ErrorCode.NOT_FOUND
 
     create_requirement(tmp_path, _base_req(1))
@@ -126,7 +165,12 @@ def test_patch_requirement_errors(tmp_path: Path, monkeypatch) -> None:
         raise RuntimeError("boom")
 
     monkeypatch.setattr("app.core.requirements.save_requirement", boom)
-    err = patch_requirement(tmp_path, 1, [{"op": "replace", "path": "/title", "value": "X"}], rev=1)
+    err = patch_requirement(
+        tmp_path,
+        1,
+        [{"op": "replace", "path": "/title", "value": "X"}],
+        rev=1,
+    )
     assert err["error"]["code"] == ErrorCode.INTERNAL
 
 
@@ -147,12 +191,24 @@ def test_delete_requirement_errors(tmp_path: Path, monkeypatch) -> None:
 def test_link_requirements_errors(tmp_path: Path, monkeypatch) -> None:
     # missing source
     create_requirement(tmp_path, _base_req(2))
-    err = link_requirements(tmp_path, source_id=1, derived_id=2, link_type="derived_from", rev=1)
+    err = link_requirements(
+        tmp_path,
+        source_id=1,
+        derived_id=2,
+        link_type="derived_from",
+        rev=1,
+    )
     assert err["error"]["code"] == ErrorCode.NOT_FOUND
 
     # missing derived
     create_requirement(tmp_path, _base_req(1))
-    err = link_requirements(tmp_path, source_id=1, derived_id=3, link_type="derived_from", rev=1)
+    err = link_requirements(
+        tmp_path,
+        source_id=1,
+        derived_id=3,
+        link_type="derived_from",
+        rev=1,
+    )
     assert err["error"]["code"] == ErrorCode.NOT_FOUND
 
     def val_err(*args, **kwargs):
@@ -160,7 +216,13 @@ def test_link_requirements_errors(tmp_path: Path, monkeypatch) -> None:
 
     orig = tools_write.requirement_from_dict
     monkeypatch.setattr(tools_write, "requirement_from_dict", val_err)
-    err = link_requirements(tmp_path, source_id=1, derived_id=2, link_type="derived_from", rev=1)
+    err = link_requirements(
+        tmp_path,
+        source_id=1,
+        derived_id=2,
+        link_type="derived_from",
+        rev=1,
+    )
     assert err["error"]["code"] == ErrorCode.VALIDATION_ERROR
 
     monkeypatch.setattr(tools_write, "requirement_from_dict", orig)
@@ -169,10 +231,22 @@ def test_link_requirements_errors(tmp_path: Path, monkeypatch) -> None:
         raise RuntimeError("boom")
 
     monkeypatch.setattr("app.core.requirements.save_requirement", boom)
-    err = link_requirements(tmp_path, source_id=1, derived_id=2, link_type="derived_from", rev=1)
+    err = link_requirements(
+        tmp_path,
+        source_id=1,
+        derived_id=2,
+        link_type="derived_from",
+        rev=1,
+    )
     assert err["error"]["code"] == ErrorCode.INTERNAL
 
-    err = link_requirements(tmp_path, source_id=1, derived_id=2, link_type="bogus", rev=1)
+    err = link_requirements(
+        tmp_path,
+        source_id=1,
+        derived_id=2,
+        link_type="bogus",
+        rev=1,
+    )
     assert err["error"]["code"] == ErrorCode.VALIDATION_ERROR
 
 
@@ -187,12 +261,16 @@ def test_link_requirements_types(tmp_path: Path) -> None:
 
     link_requirements(tmp_path, source_id=3, derived_id=4, link_type="verifies", rev=1)
     data, _ = load(tmp_path / filename_for(4))
-    assert data["links"]["verifies"] == [{"source_id": 3, "source_revision": 1, "suspect": False}]
+    assert data["links"]["verifies"] == [
+        {"source_id": 3, "source_revision": 1, "suspect": False},
+    ]
     assert data["revision"] == 2
 
     link_requirements(tmp_path, source_id=5, derived_id=6, link_type="relates", rev=1)
     data, _ = load(tmp_path / filename_for(6))
-    assert data["links"]["relates"] == [{"source_id": 5, "source_revision": 1, "suspect": False}]
+    assert data["links"]["relates"] == [
+        {"source_id": 5, "source_revision": 1, "suspect": False},
+    ]
     assert data["revision"] == 2
 
 
@@ -201,7 +279,10 @@ def test_patch_parent_and_links_forbidden(tmp_path: Path) -> None:
     create_requirement(tmp_path, _base_req(2))
     link_requirements(tmp_path, source_id=1, derived_id=2, link_type="parent", rev=1)
     err = patch_requirement(
-        tmp_path, 2, [{"op": "replace", "path": "/parent", "value": None}], rev=2
+        tmp_path,
+        2,
+        [{"op": "replace", "path": "/parent", "value": None}],
+        rev=2,
     )
     assert err["error"]["code"] == ErrorCode.VALIDATION_ERROR
 
@@ -209,6 +290,9 @@ def test_patch_parent_and_links_forbidden(tmp_path: Path) -> None:
     create_requirement(tmp_path, _base_req(4))
     link_requirements(tmp_path, source_id=3, derived_id=4, link_type="verifies", rev=1)
     err = patch_requirement(
-        tmp_path, 4, [{"op": "replace", "path": "/links", "value": {}}], rev=2
+        tmp_path,
+        4,
+        [{"op": "replace", "path": "/links", "value": {}}],
+        rev=2,
     )
     assert err["error"]["code"] == ErrorCode.VALIDATION_ERROR

--- a/tests/unit/test_schema.py
+++ b/tests/unit/test_schema.py
@@ -43,7 +43,7 @@ def test_validate_rejects_bad_enum():
 def test_derived_from_and_derivation_valid():
     data = make_valid()
     data["derived_from"] = [
-        {"source_id": 2, "source_revision": 1, "suspect": True}
+        {"source_id": 2, "source_revision": 1, "suspect": True},
     ]
     data["derivation"] = {
         "rationale": "r",

--- a/tests/unit/test_telemetry.py
+++ b/tests/unit/test_telemetry.py
@@ -41,7 +41,10 @@ def test_sanitize_redacts_nested_sensitive_keys() -> None:
     assert sanitized["list"][1]["Authorization"] == REDACTED
 
 
-def test_log_event_records_size_and_duration_and_sanitizes_payload(tmp_path: Path, monkeypatch) -> None:
+def test_log_event_records_size_and_duration_and_sanitizes_payload(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
     log_file = tmp_path / "telemetry.jsonl"
     handler = JsonlHandler(str(log_file))
     logger.addHandler(handler)
@@ -66,7 +69,9 @@ def test_log_event_records_size_and_duration_and_sanitizes_payload(tmp_path: Pat
         "nested": {"password": REDACTED},
         "list": [{"api_key": REDACTED}],
     }
-    expected_size = len(json.dumps(sanitized_payload, ensure_ascii=False).encode("utf-8"))
+    expected_size = len(
+        json.dumps(sanitized_payload, ensure_ascii=False).encode("utf-8"),
+    )
     assert entry["payload"] == sanitized_payload
     log_text = json.dumps(entry)
     assert "secret" not in log_text

--- a/tests/unit/test_validate.py
+++ b/tests/unit/test_validate.py
@@ -70,7 +70,11 @@ def test_missing_source_id(tmp_path):
 
 
 def test_cycle_detection(tmp_path):
-    write_req(tmp_path, 1, derived_from=[{"source_id": 2, "source_revision": 1, "suspect": False}])
+    write_req(
+        tmp_path,
+        1,
+        derived_from=[{"source_id": 2, "source_revision": 1, "suspect": False}],
+    )
     data = make_valid()
     data["id"] = 2
     data["derived_from"] = [{"source_id": 1, "source_revision": 1, "suspect": False}]


### PR DESCRIPTION
## Summary
- enforce trailing commas by enabling Ruff `COM` rules
- format codebase to comply with new style

## Testing
- `python3 -m ruff check`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c6ac3bf9608320ae7424cc7d658a8f