### PR TITLE
feat: enforce security linting

### DIFF
--- a/app/core/labels.py
+++ b/app/core/labels.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from hashlib import sha1
+from hashlib import sha256
 
 
 @dataclass(slots=True)
@@ -16,7 +16,7 @@ class Label:
 
 def _color_from_name(name: str) -> str:
     """Generate a stable pastel color from ``name``."""
-    digest = sha1(name.encode("utf-8")).hexdigest()
+    digest = sha256(name.encode("utf-8")).hexdigest()
     r = (int(digest[0:2], 16) + 0xAA) // 2
     g = (int(digest[2:4], 16) + 0xAA) // 2
     b = (int(digest[4:6], 16) + 0xAA) // 2

--- a/app/ui/editor_panel.py
+++ b/app/ui/editor_panel.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Any, Callable
@@ -26,6 +27,8 @@ from . import locale
 from .enums import ENUMS
 from .helpers import HelpStaticBox, make_help_button, show_help
 from .label_selection_dialog import LabelSelectionDialog
+
+logger = logging.getLogger(__name__)
 
 
 class EditorPanel(ScrolledPanel):
@@ -607,7 +610,7 @@ class EditorPanel(ScrolledPanel):
                     req = req_ops.get_requirement(self.directory, src_id)
                     title = req.title or ""
                 except Exception:  # pragma: no cover - lookup errors
-                    pass
+                    logger.exception("Failed to load requirement %s", src_id)
             idx = list_ctrl.InsertItem(list_ctrl.GetItemCount(), str(src_id))
             list_ctrl.SetItem(idx, 1, title)
 
@@ -964,7 +967,7 @@ class EditorPanel(ScrolledPanel):
                 revision = req.revision or 1
                 title = req.title or ""
             except Exception:  # pragma: no cover - lookup errors
-                pass
+                logger.exception("Failed to load requirement %s", src_id)
         links_list.append(
             {"source_id": src_id, "source_revision": revision, "suspect": False},
         )
@@ -1005,7 +1008,7 @@ class EditorPanel(ScrolledPanel):
                 req = req_ops.get_requirement(self.directory, src_id)
                 revision = req.revision or 1
             except Exception:
-                pass
+                logger.exception("Failed to load requirement %s", src_id)
         self.parent = {
             "source_id": src_id,
             "source_revision": revision,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,12 +54,13 @@ select = [
     "Q",
     "SLF",
     "TRY",
+    "S",
 ]
 
 ignore = ["RUF001", "RUF003", "TRY003"]
 
 [tool.ruff.lint.per-file-ignores]
-"tests/**/*" = ["ARG001", "ARG002", "ARG003", "ARG004", "ARG005", "N802", "SLF001"]
+"tests/**/*" = ["ARG001", "ARG002", "ARG003", "ARG004", "ARG005", "N802", "SLF001", "S"]
 "app/ui/helpers.py" = ["N802", "N803"]
 "app/ui/list_panel.py" = ["N802"]
 "app/ui/labels_dialog.py" = ["N802"]


### PR DESCRIPTION
## Summary
- enable Ruff security rules
- replace SHA-1 with SHA-256 for label colors
- log lookup failures instead of silently passing

## Testing
- `python3 -m ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6ad707e68832086847be022ee5679