### PR TITLE
Add time utility unit tests and enforce timestamp validation

### DIFF
--- a/app/util/time.py
+++ b/app/util/time.py
@@ -18,14 +18,26 @@ def local_now_str() -> str:
 
 
 def normalize_timestamp(value: str | None) -> str:
-    """Normalize ``value`` to second precision while preserving date-only strings."""
+    """Normalize ``value`` to second precision.
+
+    Empty input returns an empty string. Valid ISO date strings are preserved as is,
+    while datetime strings are converted to ``YYYY-MM-DD HH:MM:SS`` format with
+    microseconds discarded. Invalid values raise :class:`ValueError`.
+    """
+
     if not value:
         return ""
+
     if ":" not in value:
-        return value.split(".", 1)[0]
+        base = value.split(".", 1)[0]
+        try:
+            datetime.date.fromisoformat(base)
+        except ValueError as exc:
+            raise ValueError(f"Invalid date: {value}") from exc
+        return base
+
     try:
         dt = datetime.datetime.fromisoformat(value)
-    except ValueError:
-        base = value.split(".", 1)[0]
-        return base.replace("T", " ")
+    except ValueError as exc:
+        raise ValueError(f"Invalid datetime: {value}") from exc
     return dt.strftime("%Y-%m-%d %H:%M:%S")

--- a/tests/unit/test_time_utils.py
+++ b/tests/unit/test_time_utils.py
@@ -1,0 +1,49 @@
+"""Tests for time utilities."""
+
+import re
+
+import pytest
+
+from app.util.time import local_now_str, normalize_timestamp, utc_now_iso
+
+pytestmark = pytest.mark.unit
+
+
+def test_utc_now_iso_format():
+    value = utc_now_iso()
+    assert re.fullmatch(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\+00:00", value)
+
+
+def test_local_now_str_format():
+    value = local_now_str()
+    assert re.fullmatch(r"\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}", value)
+
+
+@pytest.mark.parametrize(
+    "raw, expected",
+    [
+        (None, ""),
+        ("", ""),
+        ("2024-01-02T03:04:05.123456+00:00", "2024-01-02 03:04:05"),
+        ("2024-01-02T03:04:05.123456", "2024-01-02 03:04:05"),
+        ("2024-01-02 03:04:05.123456", "2024-01-02 03:04:05"),
+        ("2024-01-02", "2024-01-02"),
+    ],
+)
+def test_normalize_timestamp_valid(raw, expected):
+    assert normalize_timestamp(raw) == expected
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "2024-13-02T03:04:05",
+        "2024-13-02 03:04:05",
+        "2024-13-02",
+        "2024-02-30",
+        "not-a-date",
+    ],
+)
+def test_normalize_timestamp_invalid(raw):
+    with pytest.raises(ValueError):
+        normalize_timestamp(raw)


### PR DESCRIPTION
## Summary
- enforce strict validation in `normalize_timestamp` so malformed dates raise `ValueError`
- split unit tests into valid and invalid cases for timestamp normalization

## Testing
- `ruff check app/util/time.py tests/unit/test_time_utils.py --fix`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c6b0012cec8320bb5527d443a08b4e