### PR TITLE
Add vulture-based dead code check

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ If Ruff is missing, install it separately:
 
 ```bash
 python3 -m pip install ruff
+python3 -m pip install vulture
 ```
 
 Check that every module has a docstring:
@@ -102,6 +103,12 @@ Run Ruff to catch basic errors:
 
 ```bash
 ruff check app tests
+```
+
+Find dead code:
+
+```bash
+vulture app --min-confidence 80
 ```
 
 ## License

--- a/app/ui/editor_panel.py
+++ b/app/ui/editor_panel.py
@@ -461,7 +461,6 @@ class EditorPanel(ScrolledPanel):
         }
         self.current_path: Path | None = None
         self.mtime: float | None = None
-        self._app = wx.GetApp()
         self._refresh_labels_display()
         self._refresh_attachments()
         self._refresh_parent_display()
@@ -990,9 +989,6 @@ class EditorPanel(ScrolledPanel):
             else:
                 list_ctrl.Delete(idx)
         self._refresh_links_visibility(attr)
-
-    def _on_add_link(self, _event: wx.CommandEvent) -> None:
-        self._on_add_link_generic("derived_from")
 
     def _on_set_parent(self, _event: wx.CommandEvent) -> None:
         value = self.parent_id.GetValue().strip()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-dev = ["pytest", "polib", "pydocstyle", "ruff"]
+dev = ["pytest", "polib", "pydocstyle", "ruff", "vulture"]
 
 [tool.pydocstyle]
 select = ["D100", "D101", "D102", "D103", "D104", "D107"]

--- a/tests/slow/test_vulture.py
+++ b/tests/slow/test_vulture.py
@@ -1,0 +1,14 @@
+import subprocess
+import sys
+
+import pytest
+
+pytestmark = pytest.mark.slow
+
+
+def test_vulture_finds_no_dead_code():
+    """Ensure repository has no obvious dead code."""
+    cmd = [sys.executable, "-m", "vulture", "app", "--min-confidence", "80"]
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert result.stdout.strip() == ""


### PR DESCRIPTION
## Summary
- Document installation and usage of vulture for dead code detection
- Include vulture in development dependencies and add regression test
- Drop unused helpers in editor_panel to satisfy vulture

## Testing
- `python3 -m vulture app --min-confidence 80`
- `python3 -m ruff check app tests`
- `python3 -m pydocstyle app`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c6b52aa5e08320aedb316167db5eb5