### PR TITLE
Move labels column to index 0

### DIFF
--- a/app/ui/list_panel.py
+++ b/app/ui/list_panel.py
@@ -176,6 +176,9 @@ class ListPanel(wx.Panel, ColumnSorterMixin):
     def _set_label_image(self, index: int, col: int, labels: list[str]) -> None:
         if not labels:
             self.list.SetItem(index, col, "")
+            if hasattr(self.list, "SetItemImage") and col == 0:
+                with suppress(Exception):
+                    self.list.SetItemImage(index, -1)
             return
         key = tuple(labels)
         img_id = self._label_images.get(key)
@@ -184,11 +187,18 @@ class ListPanel(wx.Panel, ColumnSorterMixin):
             self._ensure_image_list_size(bmp.GetWidth(), bmp.GetHeight())
             img_id = self._image_list.Add(bmp)
             self._label_images[key] = img_id
-        self.list.SetItem(index, col, "")
-        self.list.SetItemColumnImage(index, col, img_id)
-        if hasattr(self.list, "SetItemImage"):
-            with suppress(Exception):
-                self.list.SetItemImage(index, -1)
+        if col == 0:
+            # Column 0 uses the main item image slot
+            self.list.SetItem(index, col, "")
+            if hasattr(self.list, "SetItemImage"):
+                with suppress(Exception):
+                    self.list.SetItemImage(index, img_id)
+        else:
+            self.list.SetItem(index, col, "")
+            self.list.SetItemColumnImage(index, col, img_id)
+            if hasattr(self.list, "SetItemImage"):
+                with suppress(Exception):
+                    self.list.SetItemImage(index, -1)
 
     def _setup_columns(self) -> None:
         """Configure list control columns based on selected fields.

--- a/app/ui/list_panel.py
+++ b/app/ui/list_panel.py
@@ -193,11 +193,11 @@ class ListPanel(wx.Panel, ColumnSorterMixin):
     def _setup_columns(self) -> None:
         """Configure list control columns based on selected fields.
 
-        ``wx.ListCtrl`` на Windows всегда резервирует место под иконку в
-        первой физической колонке. Чтобы убрать отступ у текста в ``Title``,
-        мы размещаем ``labels`` на позиции 0. Альтернативный обходной путь —
-        добавить скрытую служебную колонку перед ``Title``.
-        """  # noqa: RUF002
+        On Windows ``wx.ListCtrl`` always reserves space for an image in the
+        first physical column. Placing ``labels`` at index 0 removes the extra
+        padding before ``Title``. Another workaround is to insert a hidden
+        dummy column before ``Title``.
+        """
         self.list.ClearAll()
         self._field_order: list[str] = []
         include_labels = "labels" in self.columns

--- a/tests/gui/test_list_panel.py
+++ b/tests/gui/test_list_panel.py
@@ -702,7 +702,7 @@ def test_labels_column_uses_imagelist(monkeypatch):
         ],
     )
     labels_col = panel._field_order.index("labels")
-    # В колонке labels должен появиться image-id, а колонка Title остаётся без картинки
+    # labels column should get an image id while Title stays without one
     assert panel.list._col_images[(0, labels_col)] >= 0
     assert panel.list._item_images[0] == -1
 

--- a/tests/gui/test_list_panel.py
+++ b/tests/gui/test_list_panel.py
@@ -696,15 +696,18 @@ def test_labels_column_uses_imagelist(monkeypatch):
     frame = wx_stub.Panel(None)
     panel = list_panel_cls(frame, model=requirement_model_cls())
     panel.set_columns(["labels"])
-    panel.set_requirements(
-        [
-            _req(1, "A", labels=["ui", "backend"]),
-        ],
-    )
+    panel.set_requirements([
+        _req(1, "A", labels=["ui", "backend"]),
+    ])
     labels_col = panel._field_order.index("labels")
-    # labels column should get an image id while Title stays without one
-    assert panel.list._col_images[(0, labels_col)] >= 0
-    assert panel.list._item_images[0] == -1
+    title_col = panel._field_order.index("title")
+    # labels column uses main image slot when placed at index 0
+    if labels_col == 0:
+        assert panel.list._item_images[0] >= 0
+        assert panel.list._col_images.get((0, title_col), -1) == -1
+    else:
+        assert panel.list._col_images[(0, labels_col)] >= 0
+        assert panel.list._item_images[0] == -1
 
 
 def test_sort_by_labels(monkeypatch):

--- a/tests/gui/test_list_panel.py
+++ b/tests/gui/test_list_panel.py
@@ -701,7 +701,7 @@ def test_labels_column_uses_imagelist(monkeypatch):
             _req(1, "A", labels=["ui", "backend"]),
         ],
     )
-    labels_col = panel.columns.index("labels") + 1
+    labels_col = panel._field_order.index("labels")
     # В колонке labels должен появиться image-id, а колонка Title остаётся без картинки
     assert panel.list._col_images[(0, labels_col)] >= 0
     assert panel.list._item_images[0] == -1
@@ -732,7 +732,7 @@ def test_sort_by_labels(monkeypatch):
         ],
     )
 
-    panel.sort(1, True)
+    panel.sort(0, True)
     assert [r.id for r in panel.model.get_visible()] == [2, 1]
 
 
@@ -761,7 +761,7 @@ def test_sort_by_multiple_labels(monkeypatch):
         ],
     )
 
-    panel.sort(1, True)
+    panel.sort(0, True)
     assert [r.id for r in panel.model.get_visible()] == [2, 1]
 
 


### PR DESCRIPTION
## Summary
- make `labels` the first physical column in `ListPanel` so `Title` no longer reserves image space on Windows
- document hidden dummy-column workaround and track column-to-field mapping with `_field_order`
- adjust tests for new column indices

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6b803421083208f7178d489abd42e