### PR TITLE
feat(cli): add link and trace commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ CookaReq (Cook a requirement) is a wibecoded desktop application built with wxPy
 - Persistent interface state: window size, columns, sorting, recent folders
 - Command dialog for interacting with the built-in LocalAgent (LLM + MCP)
 - Settings dialog for configuring LLM, MCP and UI options
-- Manage label presets and choose colours for custom tags
+- Manage label presets and choose colours for custom labels
 - Command-line utility for batch operations and health checks
 - MCP server exposing requirement tools for external agents
 - Interface localization via text `.po` files
@@ -27,7 +27,7 @@ Additional windows and dialogs:
 
 - **Command dialog** — run LocalAgent commands that combine LLM reasoning with MCP tools.
 - **Settings dialog** — edit LLM/MCP/UI configuration stored in a JSON or TOML file.
-- **Labels dialog** — manage label presets; the **label selection dialog** picks tags from predefined sets with generated colours.
+- **Labels dialog** — manage label presets; the **label selection dialog** picks labels from predefined sets with generated colours.
 - **Filter dialog** — build complex search queries across fields, labels and statuses.
 - **Derivation graph** — visualise "derived-from" links using `networkx` and Graphviz.
 - **Navigation** — jump between linked requirements.
@@ -51,6 +51,8 @@ Available commands:
 - `delete <dir> <id>` — remove a requirement by id
 - `show <dir> <id>` — display the full contents of a requirement as JSON
 - `check` — verify LLM and MCP connectivity according to loaded settings
+- `link <dir> <rid> <parents...>` — link a requirement to ancestors
+- `trace <dir> [--format csv|html] [-o FILE]` — export child-parent links
 
 The `add` and `edit` commands validate the input file before saving. If the JSON is malformed or does not match the requirement schema, an error message is printed and no changes are written to disk. The `check` command uses the same LocalAgent as the GUI to test LLM and MCP access.
 

--- a/app/core/doc_store.py
+++ b/app/core/doc_store.py
@@ -4,7 +4,7 @@ import json
 import re
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
-from typing import Any
+from typing import Any, Iterable, Mapping
 
 
 @dataclass
@@ -83,6 +83,58 @@ def save_document(directory: str | Path, doc: Document) -> Path:
     return path
 
 
+def load_documents(root: str | Path) -> dict[str, Document]:
+    """Load all document configurations under ``root``.
+
+    Returns mapping of document prefix to :class:`Document` instance.
+    Missing directories yield an empty mapping.
+    """
+
+    root_path = Path(root)
+    docs: dict[str, Document] = {}
+    if not root_path.is_dir():
+        return docs
+    for path in root_path.iterdir():
+        doc_file = path / "document.json"
+        if doc_file.is_file():
+            doc = load_document(path)
+            docs[doc.prefix] = doc
+    return docs
+
+
+def is_ancestor(
+    child_prefix: str, ancestor_prefix: str, docs: Mapping[str, Document]
+) -> bool:
+    """Return ``True`` if ``ancestor_prefix`` is an ancestor of ``child_prefix``."""
+
+    current = docs.get(child_prefix)
+    while current and current.parent:
+        if current.parent == ancestor_prefix:
+            return True
+        current = docs.get(current.parent)
+    return False
+
+
+def collect_labels(prefix: str, docs: Mapping[str, Document]) -> tuple[set[str], bool]:
+    """Return allowed label keys and freeform flag for ``prefix``.
+
+    The result aggregates label definitions from ``prefix`` and all its
+    ancestors, with ``allow_freeform`` set when any document in the chain
+    permits free-form labels.
+    """
+
+    allowed: set[str] = set()
+    allow_freeform = False
+    current = docs.get(prefix)
+    while current:
+        allowed.update(ld.key for ld in current.labels.defs)
+        allow_freeform = allow_freeform or current.labels.allow_freeform
+        if not current.parent:
+            break
+        current = docs.get(current.parent)
+    return allowed, allow_freeform
+
+
 def rid_for(doc: Document, item_id: int) -> str:
     """Return requirement identifier for ``item_id`` within ``doc``."""
 
@@ -147,3 +199,17 @@ def next_item_id(directory: str | Path, doc: Document) -> int:
 
     ids = list_item_ids(directory, doc)
     return max(ids, default=0) + 1
+
+
+def iter_links(root: str | Path) -> Iterable[tuple[str, str]]:
+    """Yield pairs of (child_rid, parent_rid) for all links under ``root``."""
+
+    docs = load_documents(root)
+    for prefix in sorted(docs):
+        doc = docs[prefix]
+        directory = Path(root) / prefix
+        for item_id in sorted(list_item_ids(directory, doc)):
+            data, _ = load_item(directory, doc, item_id)
+            rid = rid_for(doc, item_id)
+            for parent in sorted(data.get("links", [])):
+                yield rid, parent

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,10 +1,9 @@
 [pytest]
 xvfb_width = 1280
 xvfb_height = 800
-# Tests are temporarily disabled during a major refactor
+# Xvfb settings for GUI tests; remove temporary exclusions and run all tests
 xvfb_colordepth = 24
-# addopts = -q -m "__disabled__"
-norecursedirs = tests
+addopts = -m "not slow"
 markers =
     unit: unit tests
     integration: integration tests (MCP/LLM/CLI)

--- a/tests/unit/test_cli_item.py
+++ b/tests/unit/test_cli_item.py
@@ -23,7 +23,7 @@ def test_item_add_and_move(tmp_path, capsys):
         prefix="SYS",
         title="Login",
         text="User shall login",
-        tags=None,
+        labels=None,
     )
     commands.cmd_item_add(add_args, repo)
     rid = capsys.readouterr().out.strip()

--- a/tests/unit/test_cli_item_add_labels.py
+++ b/tests/unit/test_cli_item_add_labels.py
@@ -1,0 +1,57 @@
+import argparse
+import json
+from pathlib import Path
+
+import pytest
+
+from app.cli import commands
+from app.core.doc_store import Document, DocumentLabels, LabelDef, save_document
+from app.core.repository import FileRequirementRepository
+
+
+@pytest.mark.unit
+def test_item_add_rejects_unknown_label(tmp_path, capsys):
+    repo = FileRequirementRepository()
+    doc_sys = Document(prefix="SYS", title="System", digits=3)
+    save_document(tmp_path / "SYS", doc_sys)
+    doc_hlr = Document(prefix="HLR", title="High", digits=2, parent="SYS")
+    save_document(tmp_path / "HLR", doc_hlr)
+    args = argparse.Namespace(
+        directory=str(tmp_path),
+        prefix="HLR",
+        title="T",
+        text="X",
+        labels="unknown",
+    )
+    commands.cmd_item_add(args, repo)
+    out = capsys.readouterr().out
+    assert "unknown label: unknown" in out
+    items_dir = Path(tmp_path) / "HLR" / "items"
+    assert not items_dir.exists() or not any(items_dir.iterdir())
+
+
+@pytest.mark.unit
+def test_item_add_accepts_inherited_label(tmp_path, capsys):
+    repo = FileRequirementRepository()
+    doc_sys = Document(
+        prefix="SYS",
+        title="System",
+        digits=3,
+        labels=DocumentLabels(defs=[LabelDef("ui", "UI")]),
+    )
+    save_document(tmp_path / "SYS", doc_sys)
+    doc_hlr = Document(prefix="HLR", title="High", digits=2, parent="SYS")
+    save_document(tmp_path / "HLR", doc_hlr)
+    args = argparse.Namespace(
+        directory=str(tmp_path),
+        prefix="HLR",
+        title="T",
+        text="X",
+        labels="ui",
+    )
+    commands.cmd_item_add(args, repo)
+    out = capsys.readouterr().out.strip()
+    assert out == "HLR01"
+    path = Path(tmp_path) / "HLR" / "items" / "HLR01.json"
+    data = json.loads(path.read_text(encoding="utf-8"))
+    assert data["labels"] == ["ui"]

--- a/tests/unit/test_cli_link.py
+++ b/tests/unit/test_cli_link.py
@@ -1,0 +1,84 @@
+import argparse
+import json
+from pathlib import Path
+
+import pytest
+
+from app.cli import commands
+from app.core.doc_store import Document, save_document, save_item
+from app.core.repository import FileRequirementRepository
+
+
+@pytest.mark.unit
+def test_link_add(tmp_path, capsys):
+    repo = FileRequirementRepository()
+
+    doc_sys = Document(prefix="SYS", title="System", digits=3)
+    save_document(tmp_path / "SYS", doc_sys)
+    doc_hlr = Document(prefix="HLR", title="High", digits=2, parent="SYS")
+    save_document(tmp_path / "HLR", doc_hlr)
+
+    save_item(tmp_path / "SYS", doc_sys, {"id": 1, "title": "S", "text": "", "labels": [], "links": []})
+    save_item(tmp_path / "HLR", doc_hlr, {"id": 1, "title": "H", "text": "", "labels": [], "links": []})
+
+    args = argparse.Namespace(
+        directory=str(tmp_path), rid="HLR01", parents=["SYS001"], replace=False
+    )
+    commands.cmd_link(args, repo)
+    out = capsys.readouterr().out.strip()
+    assert out == "HLR01"
+
+    path = Path(tmp_path) / "HLR" / "items" / "HLR01.json"
+    data = json.loads(path.read_text(encoding="utf-8"))
+    assert data["links"] == ["SYS001"]
+
+
+@pytest.mark.unit
+def test_link_rejects_self_link(tmp_path, capsys):
+    repo = FileRequirementRepository()
+
+    doc_sys = Document(prefix="SYS", title="System", digits=3)
+    save_document(tmp_path / "SYS", doc_sys)
+
+    save_item(
+        tmp_path / "SYS",
+        doc_sys,
+        {"id": 1, "title": "S", "text": "", "labels": [], "links": []},
+    )
+
+    args = argparse.Namespace(
+        directory=str(tmp_path), rid="SYS001", parents=["SYS001"], replace=False
+    )
+    commands.cmd_link(args, repo)
+    out = capsys.readouterr().out.strip()
+    assert out == "invalid link target: SYS001"
+
+    path = Path(tmp_path) / "SYS" / "items" / "SYS001.json"
+    data = json.loads(path.read_text(encoding="utf-8"))
+    assert data["links"] == []
+
+
+@pytest.mark.unit
+def test_link_rejects_non_ancestor(tmp_path, capsys):
+    repo = FileRequirementRepository()
+
+    doc_sys = Document(prefix="SYS", title="System", digits=3)
+    save_document(tmp_path / "SYS", doc_sys)
+    doc_hlr = Document(prefix="HLR", title="High", digits=2, parent="SYS")
+    save_document(tmp_path / "HLR", doc_hlr)
+    doc_llr = Document(prefix="LLR", title="Low", digits=2, parent="HLR")
+    save_document(tmp_path / "LLR", doc_llr)
+
+    save_item(tmp_path / "HLR", doc_hlr, {"id": 1, "title": "H", "text": "", "labels": [], "links": []})
+    save_item(tmp_path / "LLR", doc_llr, {"id": 1, "title": "L", "text": "", "labels": [], "links": []})
+
+    args = argparse.Namespace(
+        directory=str(tmp_path), rid="HLR01", parents=["LLR01"], replace=False
+    )
+    commands.cmd_link(args, repo)
+    out = capsys.readouterr().out.strip()
+    assert out == "invalid link target: LLR01"
+
+    path = Path(tmp_path) / "HLR" / "items" / "HLR01.json"
+    data = json.loads(path.read_text(encoding="utf-8"))
+    assert data.get("links") == []

--- a/tests/unit/test_cli_trace.py
+++ b/tests/unit/test_cli_trace.py
@@ -1,0 +1,101 @@
+import argparse
+
+import pytest
+
+from app.cli import commands
+from app.core.doc_store import Document, save_document, save_item
+from app.core.repository import FileRequirementRepository
+
+
+@pytest.mark.unit
+def test_trace_export(tmp_path, capsys):
+    repo = FileRequirementRepository()
+
+    doc_sys = Document(prefix="SYS", title="System", digits=3)
+    save_document(tmp_path / "SYS", doc_sys)
+    doc_hlr = Document(prefix="HLR", title="High", digits=2, parent="SYS")
+    save_document(tmp_path / "HLR", doc_hlr)
+
+    save_item(tmp_path / "SYS", doc_sys, {"id": 1, "title": "S", "text": "", "labels": [], "links": []})
+    save_item(
+        tmp_path / "HLR",
+        doc_hlr,
+        {"id": 1, "title": "H", "text": "", "labels": [], "links": ["SYS001"]},
+    )
+
+    args = argparse.Namespace(directory=str(tmp_path), format="plain", output=None)
+    commands.cmd_trace(args, repo)
+    out = capsys.readouterr().out.strip().splitlines()
+    assert out == ["HLR01 SYS001"]
+
+
+@pytest.mark.unit
+def test_trace_export_csv(tmp_path, capsys):
+    repo = FileRequirementRepository()
+
+    doc_sys = Document(prefix="SYS", title="System", digits=3)
+    save_document(tmp_path / "SYS", doc_sys)
+    doc_hlr = Document(prefix="HLR", title="High", digits=2, parent="SYS")
+    save_document(tmp_path / "HLR", doc_hlr)
+
+    save_item(tmp_path / "SYS", doc_sys, {"id": 1, "title": "S", "text": "", "labels": [], "links": []})
+    save_item(
+        tmp_path / "HLR",
+        doc_hlr,
+        {"id": 1, "title": "H", "text": "", "labels": [], "links": ["SYS001"]},
+    )
+
+    args = argparse.Namespace(directory=str(tmp_path), format="csv", output=None)
+    commands.cmd_trace(args, repo)
+    out = capsys.readouterr().out.strip().splitlines()
+    assert out == ["child,parent", "HLR01,SYS001"]
+
+
+@pytest.mark.unit
+def test_trace_export_html(tmp_path, capsys):
+    repo = FileRequirementRepository()
+
+    doc_sys = Document(prefix="SYS", title="System", digits=3)
+    save_document(tmp_path / "SYS", doc_sys)
+    doc_hlr = Document(prefix="HLR", title="High", digits=2, parent="SYS")
+    save_document(tmp_path / "HLR", doc_hlr)
+
+    save_item(tmp_path / "SYS", doc_sys, {"id": 1, "title": "S", "text": "", "labels": [], "links": []})
+    save_item(
+        tmp_path / "HLR",
+        doc_hlr,
+        {"id": 1, "title": "H", "text": "", "labels": [], "links": ["SYS001"]},
+    )
+
+    args = argparse.Namespace(directory=str(tmp_path), format="html", output=None)
+    commands.cmd_trace(args, repo)
+    out = capsys.readouterr().out
+    assert "<!DOCTYPE html>" in out
+    assert "<style>" in out
+    assert "<tr><td>HLR01</td><td>SYS001</td></tr>" in out
+
+
+@pytest.mark.unit
+def test_trace_output_file(tmp_path, capsys):
+    repo = FileRequirementRepository()
+
+    doc_sys = Document(prefix="SYS", title="System", digits=3)
+    save_document(tmp_path / "SYS", doc_sys)
+    doc_hlr = Document(prefix="HLR", title="High", digits=2, parent="SYS")
+    save_document(tmp_path / "HLR", doc_hlr)
+
+    save_item(tmp_path / "SYS", doc_sys, {"id": 1, "title": "S", "text": "", "labels": [], "links": []})
+    save_item(
+        tmp_path / "HLR",
+        doc_hlr,
+        {"id": 1, "title": "H", "text": "", "labels": [], "links": ["SYS001"]},
+    )
+
+    out_file = tmp_path / "trace.html"
+    args = argparse.Namespace(directory=str(tmp_path), format="html", output=str(out_file))
+    commands.cmd_trace(args, repo)
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    data = out_file.read_text()
+    assert "<style>" in data
+    assert "<tr><td>HLR01</td><td>SYS001</td></tr>" in data

--- a/tests/unit/test_migrate_to_docs.py
+++ b/tests/unit/test_migrate_to_docs.py
@@ -29,7 +29,7 @@ def test_migrate_to_docs_basic(tmp_path: Path):
     write_req(tmp_path / "CR-001.json", r1)
     write_req(tmp_path / "CR-002.json", r2)
 
-    migrate_to_docs(tmp_path, rules="tag:doc=SYS->SYS; tag:doc=HLR->HLR", default="SYS")
+    migrate_to_docs(tmp_path, rules="label:doc=SYS->SYS; label:doc=HLR->HLR", default="SYS")
 
     # original files removed
     assert not (tmp_path / "CR-001.json").exists()
@@ -45,10 +45,10 @@ def test_migrate_to_docs_basic(tmp_path: Path):
     assert sys_data["id"] == 1
     assert sys_data["title"] == "One"
     assert sys_data["text"] == "First"
-    assert sys_data["tags"] == ["alpha"]
+    assert sys_data["labels"] == ["alpha"]
 
     assert hlr_data["id"] == 2
-    assert hlr_data["tags"] == ["beta"]
+    assert hlr_data["labels"] == ["beta"]
 
     doc = json.loads((tmp_path / "SYS" / "document.json").read_text(encoding="utf-8"))
     assert doc["prefix"] == "SYS"


### PR DESCRIPTION
## Summary
- add link command to connect requirement items across document hierarchy
- export child-parent trace pairs via new `trace` CLI command and `iter_links` utility
- validate labels when adding items, aggregating allowed labels across ancestor documents
- re-enable test suite and avoid clobbering `_` translator in CLI
- clarify link rules and architecture based on Doorstop review
- prevent linking a requirement to itself and cover invalid link targets with tests
- rename `--tags` option to `--labels`, propagate terminology to migration utility and docs
- support CSV and HTML output formats for the `trace` command
- allow writing `trace` output to a file and embed minimal CSS for HTML results

## Testing
- `pytest tests/unit/test_cli_trace.py::test_trace_output_file -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6d7c669588320a600d336a952fbcb