### PR TITLE
feat: allow requirement deletion

### DIFF
--- a/tests/unit/test_cli_doc.py
+++ b/tests/unit/test_cli_doc.py
@@ -34,3 +34,98 @@ def test_doc_create_and_list(tmp_path, capsys):
     doc_hlr = load_document(Path(tmp_path) / "HLR")
     assert doc_hlr.parent == "SYS"
     assert doc_hlr.digits == 2
+
+
+def test_doc_delete_removes_subtree(tmp_path, capsys):
+    repo = FileRequirementRepository()
+
+    args = argparse.Namespace(
+        directory=str(tmp_path), prefix="SYS", title="System", digits=3, parent=None
+    )
+    commands.cmd_doc_create(args, repo)
+    _ = capsys.readouterr()
+
+    args2 = argparse.Namespace(
+        directory=str(tmp_path), prefix="HLR", title="High", digits=2, parent="SYS"
+    )
+    commands.cmd_doc_create(args2, repo)
+    _ = capsys.readouterr()
+
+    args3 = argparse.Namespace(
+        directory=str(tmp_path), prefix="LLR", title="Low", digits=2, parent="HLR"
+    )
+    commands.cmd_doc_create(args3, repo)
+    _ = capsys.readouterr()
+
+    del_args = argparse.Namespace(directory=str(tmp_path), prefix="HLR")
+    commands.cmd_doc_delete(del_args, repo)
+    out = capsys.readouterr().out.splitlines()
+    assert out == ["HLR"]
+    assert not (Path(tmp_path) / "HLR").exists()
+    assert not (Path(tmp_path) / "LLR").exists()
+
+    commands.cmd_doc_delete(del_args, repo)
+    out2 = capsys.readouterr().out
+    assert out2 == "document not found: HLR\n"
+
+
+def test_doc_delete_dry_run_lists_subtree(tmp_path, capsys):
+    repo = FileRequirementRepository()
+
+    args_sys = argparse.Namespace(
+        directory=str(tmp_path), prefix="SYS", title="System", digits=3, parent=None
+    )
+    commands.cmd_doc_create(args_sys, repo)
+    _ = capsys.readouterr()
+
+    args_hlr = argparse.Namespace(
+        directory=str(tmp_path), prefix="HLR", title="High", digits=2, parent="SYS"
+    )
+    commands.cmd_doc_create(args_hlr, repo)
+    _ = capsys.readouterr()
+
+    item1 = argparse.Namespace(
+        directory=str(tmp_path), prefix="SYS", title="S", text="", labels=None
+    )
+    commands.cmd_item_add(item1, repo)
+    _ = capsys.readouterr()
+
+    item2 = argparse.Namespace(
+        directory=str(tmp_path), prefix="HLR", title="H", text="", labels=None
+    )
+    commands.cmd_item_add(item2, repo)
+    _ = capsys.readouterr()
+
+    del_args = argparse.Namespace(directory=str(tmp_path), prefix="SYS", dry_run=True)
+    commands.cmd_doc_delete(del_args, repo)
+    out = capsys.readouterr().out.splitlines()
+    assert out == ["SYS", "HLR", "SYS001", "HLR01"]
+    assert (Path(tmp_path) / "SYS").exists()
+    assert (Path(tmp_path) / "HLR").exists()
+
+
+def test_doc_delete_requires_confirmation(tmp_path, capsys):
+    repo = FileRequirementRepository()
+
+    args = argparse.Namespace(
+        directory=str(tmp_path), prefix="SYS", title="System", digits=3, parent=None
+    )
+    commands.cmd_doc_create(args, repo)
+    _ = capsys.readouterr()
+
+    from app.confirm import set_confirm
+
+    messages: list[str] = []
+
+    def fake_confirm(msg: str) -> bool:
+        messages.append(msg)
+        return False
+
+    set_confirm(fake_confirm)
+
+    del_args = argparse.Namespace(directory=str(tmp_path), prefix="SYS")
+    commands.cmd_doc_delete(del_args, repo)
+    out = capsys.readouterr().out.strip()
+    assert out == "aborted"
+    assert (Path(tmp_path) / "SYS").exists()
+    assert messages and "SYS" in messages[0]

--- a/tests/unit/test_doc_store.py
+++ b/tests/unit/test_doc_store.py
@@ -5,6 +5,7 @@ import pytest
 
 from app.core.doc_store import (
     Document,
+    delete_document,
     next_item_id,
     parse_rid,
     load_document,
@@ -13,6 +14,10 @@ from app.core.doc_store import (
     rid_for,
     save_document,
     save_item,
+    delete_item,
+    load_documents,
+    plan_delete_document,
+    plan_delete_item,
 )
 
 pytestmark = pytest.mark.unit
@@ -53,3 +58,77 @@ def test_parse_rid_and_next_id(tmp_path: Path):
 
     save_item(doc_dir, doc, {"id": 1, "title": "T", "text": "X"})
     assert next_item_id(doc_dir, doc) == 2
+
+
+def test_delete_item_removes_links(tmp_path: Path):
+    sys_doc = Document(prefix="SYS", title="System", digits=3)
+    hlr_doc = Document(prefix="HLR", title="High", digits=2, parent="SYS")
+    save_document(tmp_path / "SYS", sys_doc)
+    save_document(tmp_path / "HLR", hlr_doc)
+    save_item(tmp_path / "SYS", sys_doc, {"id": 1, "title": "S", "text": ""})
+    save_item(
+        tmp_path / "HLR",
+        hlr_doc,
+        {"id": 1, "title": "H", "text": "", "links": ["SYS001"]},
+    )
+    docs = load_documents(tmp_path)
+    assert delete_item(tmp_path, "SYS001", docs) is True
+    # parent file removed
+    assert not (tmp_path / "SYS" / "items" / "SYS001.json").exists()
+    # link cleaned
+    data, _ = load_item(tmp_path / "HLR", hlr_doc, 1)
+    assert data.get("links") == []
+
+
+def test_delete_document_recursively(tmp_path: Path):
+    sys_doc = Document(prefix="SYS", title="System", digits=3)
+    hlr_doc = Document(prefix="HLR", title="High", digits=2, parent="SYS")
+    llr_doc = Document(prefix="LLR", title="Low", digits=2, parent="HLR")
+    save_document(tmp_path / "SYS", sys_doc)
+    save_document(tmp_path / "HLR", hlr_doc)
+    save_document(tmp_path / "LLR", llr_doc)
+    save_item(tmp_path / "SYS", sys_doc, {"id": 1, "title": "S", "text": ""})
+    save_item(tmp_path / "HLR", hlr_doc, {"id": 1, "title": "H", "text": "", "links": ["SYS001"]})
+    save_item(tmp_path / "LLR", llr_doc, {"id": 1, "title": "L", "text": "", "links": ["HLR01"]})
+    docs = load_documents(tmp_path)
+    assert delete_document(tmp_path, "HLR", docs) is True
+    assert not (tmp_path / "HLR").exists()
+    assert not (tmp_path / "LLR").exists()
+    assert (tmp_path / "SYS").is_dir()
+
+
+def test_plan_delete_item_lists_references(tmp_path: Path):
+    sys_doc = Document(prefix="SYS", title="System", digits=3)
+    hlr_doc = Document(prefix="HLR", title="High", digits=2, parent="SYS")
+    save_document(tmp_path / "SYS", sys_doc)
+    save_document(tmp_path / "HLR", hlr_doc)
+    save_item(tmp_path / "SYS", sys_doc, {"id": 1, "title": "S", "text": ""})
+    save_item(
+        tmp_path / "HLR",
+        hlr_doc,
+        {"id": 1, "title": "H", "text": "", "links": ["SYS001"]},
+    )
+    docs = load_documents(tmp_path)
+    exists, refs = plan_delete_item(tmp_path, "SYS001", docs)
+    assert exists is True
+    assert refs == ["HLR01"]
+    # nothing removed
+    assert (tmp_path / "SYS" / "items" / "SYS001.json").exists()
+    data, _ = load_item(tmp_path / "HLR", hlr_doc, 1)
+    assert data.get("links") == ["SYS001"]
+
+
+def test_plan_delete_document_lists_subtree(tmp_path: Path):
+    sys_doc = Document(prefix="SYS", title="System", digits=3)
+    hlr_doc = Document(prefix="HLR", title="High", digits=2, parent="SYS")
+    save_document(tmp_path / "SYS", sys_doc)
+    save_document(tmp_path / "HLR", hlr_doc)
+    save_item(tmp_path / "SYS", sys_doc, {"id": 1, "title": "S", "text": ""})
+    save_item(tmp_path / "HLR", hlr_doc, {"id": 1, "title": "H", "text": ""})
+    docs = load_documents(tmp_path)
+    doc_list, item_list = plan_delete_document(tmp_path, "SYS", docs)
+    assert set(doc_list) == {"SYS", "HLR"}
+    assert set(item_list) == {"SYS001", "HLR01"}
+    # filesystem intact
+    assert (tmp_path / "SYS").exists()
+    assert (tmp_path / "HLR").exists()


### PR DESCRIPTION
## Summary
- support deleting requirement items with link cleanup
- expose `item delete` CLI subcommand
- ensure documents controller uses new deletion logic
- recursively delete documents and their items
- expose `doc delete` CLI subcommand
- preview document and item deletions via `--dry-run` without modifying files
- confirm document and item deletions before removal

## Testing
- `pytest tests/unit/test_doc_store.py::test_plan_delete_item_lists_references -q`
- `pytest tests/unit/test_doc_store.py::test_plan_delete_document_lists_subtree -q`
- `pytest tests/unit/test_cli_doc.py::test_doc_delete_dry_run_lists_subtree -q`
- `pytest tests/unit/test_cli_item.py::test_item_delete_dry_run_lists_links -q`
- `pytest tests/unit/test_cli_doc.py::test_doc_delete_requires_confirmation -q`
- `pytest tests/unit/test_cli_item.py::test_item_delete_requires_confirmation -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c704a11c988320bba7ab3cc0c0d99d