### PR TITLE
Refactor requirement linking model

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,11 +121,11 @@ items/<RID>.json
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "CookaReq Item",
   "type": "object",
-  "required": ["id", "title", "text"],
+  "required": ["id", "title", "statement"],
   "properties": {
     "id":         { "type": "integer", "minimum": 1 },
     "title":      { "type": "string", "minLength": 1 },
-    "text":       { "type": "string", "minLength": 1 },
+    "statement":  { "type": "string", "minLength": 1 },
     "level":      { "type": ["string", "null"], "pattern": "^[0-9]+(\\.[0-9]+)*$" },
     "active":     { "type": "boolean", "default": true },
     "normative":  { "type": "boolean", "default": true },
@@ -272,7 +272,7 @@ cookareq migrate to-docs \
   --rules "label:doc=SYS->SYS; label:doc=HLR->HLR; label:doc=LLR->LLR" \
   --default SYS
 
-Шаги: создать каталоги/document.json, разнести элементы, пересчитать имена файлов, преобразовать trace_up→links (RID), собрать/раскидать labels.
+Шаги: создать каталоги/document.json, разнести элементы, пересчитать имена файлов, перенести ссылки в поле links (RID), собрать/раскидать labels.
 
 
 

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Each requirement item (`items/<RID>.json`) includes:
 
 - `id` *(int)* — numeric identifier unique within the document
 - `title` *(str)* — short name
-- `text` *(str)* — requirement statement
+- `statement` *(str)* — requirement statement
 - `type` *(str)* — `requirement`, `constraint`, `interface`
 - `status` *(str)* — `draft`, `in_review`, `approved`, `baselined`, `retired`
 - `owner` *(str)* — responsible person
@@ -124,9 +124,7 @@ Each requirement item (`items/<RID>.json`) includes:
 - `source` *(str)* — origin of the requirement
 - `verification` *(str)* — method of verification
 - `labels` *(list[str])* — labels including inherited ones
- - `derived_from` *(list[obj])* — upstream requirements `{rid, revision, suspect}`
- - `derived_to` *(list[obj])* — downstream requirements `{rid, revision, suspect}`
- - `links` *(list[str])* — linked higher-level requirement IDs
+- `links` *(list[str])* — linked higher-level requirement IDs
 - `attachments` *(list[obj])* — attachments `{path, note}`
 - `revision` *(int)* — revision number (starting at 1)
 - `notes` *(str)* — additional comments

--- a/app/cli/commands.py
+++ b/app/cli/commands.py
@@ -148,7 +148,7 @@ def cmd_item_add(args: argparse.Namespace) -> None:
     data = {
         "id": item_id,
         "title": args.title,
-        "text": args.text,
+        "statement": args.statement,
         "labels": labels,
         "links": [],
     }
@@ -205,7 +205,7 @@ def add_item_arguments(p: argparse.ArgumentParser) -> None:
     add_p.add_argument("directory", help=_("requirements root"))
     add_p.add_argument("prefix", help=_("document prefix"))
     add_p.add_argument("--title", required=True, help=_("item title"))
-    add_p.add_argument("--text", required=True, help=_("item text"))
+    add_p.add_argument("--statement", required=True, help=_("item statement"))
     add_p.add_argument("--labels", dest="labels", help=_("comma-separated labels"))
     add_p.set_defaults(func=cmd_item_add)
 

--- a/app/locale/en/LC_MESSAGES/CookaReq.po
+++ b/app/locale/en/LC_MESSAGES/CookaReq.po
@@ -211,11 +211,6 @@ msgstr "Test"
 msgid "Title"
 msgstr "Title"
 
-msgid "Trace down"
-msgstr "Trace down"
-
-msgid "Trace up"
-msgstr "Trace up"
 
 msgid "Unique integer identifier"
 msgstr "Unique integer identifier"
@@ -571,16 +566,6 @@ msgstr ""
 "shows why this requirement exists and simplifies impact analysis when "
 "parents change. Use it to prove coverage of system objectives."
 
-msgid ""
-"References to lower-level derived requirements, design elements or test "
-"cases. Downward traceability reveals how the requirement will be implemented "
-"and verified. It supports audits and helps detect missing implementation "
-"pieces."
-msgstr ""
-"References to lower-level derived requirements, design elements or test "
-"cases. Downward traceability reveals how the requirement will be implemented "
-"and verified. It supports audits and helps detect missing implementation "
-"pieces."
 
 msgid ""
 "Sequential version number for change control. Increase it whenever the "

--- a/app/locale/ru/LC_MESSAGES/CookaReq.po
+++ b/app/locale/ru/LC_MESSAGES/CookaReq.po
@@ -118,11 +118,6 @@ msgstr "Критерии приемки требования"
 msgid "Conditions"
 msgstr "Условия и режимы"
 
-msgid "Trace up"
-msgstr "Трассировка вверх"
-
-msgid "Trace down"
-msgstr "Трассировка вниз"
 
 msgid "Requirement version"
 msgstr "Версия требования"
@@ -576,16 +571,6 @@ msgstr ""
 "облегчает анализ последствий при изменении родительских элементов. "
 "Используйте её, чтобы подтвердить покрытие целей системы."
 
-msgid ""
-"References to lower-level derived requirements, design elements or test "
-"cases. Downward traceability reveals how the requirement will be implemented "
-"and verified. It supports audits and helps detect missing implementation "
-"pieces."
-msgstr ""
-"Ссылки на нижестоящие производные требования, элементы проектирования или "
-"тесты. Трассировка вниз показывает, как требование будет реализовано и "
-"проверено. Она поддерживает аудит и помогает выявлять отсутствующие части "
-"реализации."
 
 msgid ""
 "Sequential version number for change control. Increase it whenever the "

--- a/app/ui/controllers/documents.py
+++ b/app/ui/controllers/documents.py
@@ -36,25 +36,25 @@ class DocumentsController:
         self.documents = load_documents(self.root)
         return self.documents
 
-    def load_items(self, prefix: str) -> dict[int, list[int]]:
+    def load_items(self, prefix: str) -> dict[str, list[int]]:
         """Load items for document ``prefix`` into the model.
 
-        Returns a mapping of source requirement id to list of derived ids.
+        Returns a mapping of parent requirement RID to list of linked item ids.
         """
         doc = self.documents.get(prefix)
         if not doc:
             self.model.set_requirements([])
             return {}
         directory = self.root / prefix
-        items = []
+        items: list[Requirement] = []
         derived_map: dict[str, list[int]] = {}
         for item_id in sorted(list_item_ids(directory, doc)):
             data, _mtime = load_item(directory, doc, item_id)
             rid = rid_for(doc, item_id)
             req = requirement_from_dict(data, doc_prefix=doc.prefix, rid=rid)
             items.append(req)
-            for link in getattr(req, "derived_from", []):
-                derived_map.setdefault(link.rid, []).append(req.id)
+            for parent in getattr(req, "links", []):
+                derived_map.setdefault(parent, []).append(req.id)
         self.model.set_requirements(items)
         return derived_map
 

--- a/app/ui/filter_dialog.py
+++ b/app/ui/filter_dialog.py
@@ -101,10 +101,6 @@ class FilterDialog(wx.Dialog):
         self.has_derived.SetValue(values.get("has_derived", False))
         sizer.Add(self.has_derived, 0, wx.ALL, 5)
 
-        self.suspect_only = wx.CheckBox(self, label=_("Suspect only"))
-        self.suspect_only.SetValue(values.get("suspect_only", False))
-        sizer.Add(self.suspect_only, 0, wx.ALL, 5)
-
         btns = wx.BoxSizer(wx.HORIZONTAL)
         btns.AddStretchSpacer()
         self.clear_btn = wx.Button(self, label=_("Clear filters"))
@@ -140,7 +136,6 @@ class FilterDialog(wx.Dialog):
             ),
             "is_derived": self.is_derived.GetValue(),
             "has_derived": self.has_derived.GetValue(),
-            "suspect_only": self.suspect_only.GetValue(),
             "field_queries": field_queries,
         }
 
@@ -155,4 +150,3 @@ class FilterDialog(wx.Dialog):
         self.status_choice.SetSelection(0)
         self.is_derived.SetValue(False)
         self.has_derived.SetValue(False)
-        self.suspect_only.SetValue(False)

--- a/app/ui/locale.py
+++ b/app/ui/locale.py
@@ -18,8 +18,6 @@ FIELD_LABELS = {
     "statement": _("Requirement text"),
     "acceptance": _("Acceptance criteria"),
     "conditions": _("Conditions"),
-    "trace_up": _("Trace up"),
-    "trace_down": _("Trace down"),
     "version": _("Requirement version"),
     "modified_at": _("Modified at"),
     "owner": _("Owner"),

--- a/app/ui/requirement_model.py
+++ b/app/ui/requirement_model.py
@@ -24,7 +24,6 @@ class RequirementModel:
         self._field_queries: dict[str, str] = {}
         self._is_derived: bool = False
         self._has_derived: bool = False
-        self._suspect_only: bool = False
         self._status: str | None = None
         self._sort_field: str | None = None
         self._sort_ascending: bool = True
@@ -99,11 +98,6 @@ class RequirementModel:
         self._has_derived = value
         self._refresh()
 
-    def set_suspect_only(self, value: bool) -> None:
-        """Restrict to requirements marked as suspect."""
-
-        self._suspect_only = value
-        self._refresh()
 
     def set_status(self, status: str | None) -> None:
         """Filter requirements by status code."""
@@ -136,7 +130,6 @@ class RequirementModel:
             match_all=self._labels_match_all,
             is_derived=self._is_derived,
             has_derived=self._has_derived,
-            suspect_only=self._suspect_only,
         )
         self._apply_sort()
 

--- a/requirements/HLR/items/HLR001.json
+++ b/requirements/HLR/items/HLR001.json
@@ -1,9 +1,6 @@
 {
-  "derived_from": [
-    {
-      "rid": "SYS001",
-      "revision": 1
-    }
+  "links": [
+    "SYS001"
   ],
   "id": 1,
   "labels": [
@@ -13,12 +10,6 @@
   "priority": "low",
   "revision": 1,
   "source": "architecture",
-  "derived_to": [
-    {
-      "rid": "LLR001",
-      "revision": 1
-    }
-  ],
   "statement": "Система должна предоставлять графический интерфейс с главным окном, списком требований и панелями редактора с русской локализацией.",
   "status": "approved",
   "title": "Графический интерфейс пользователя",

--- a/requirements/HLR/items/HLR002.json
+++ b/requirements/HLR/items/HLR002.json
@@ -1,9 +1,6 @@
 {
-  "derived_from": [
-    {
-      "rid": "SYS002",
-      "revision": 1
-    }
+  "links": [
+    "SYS002"
   ],
   "id": 2,
   "labels": [
@@ -13,12 +10,6 @@
   "priority": "medium",
   "revision": 1,
   "source": "architecture",
-  "derived_to": [
-    {
-      "rid": "LLR002",
-      "revision": 1
-    }
-  ],
   "statement": "Система должна обеспечивать фильтрацию и полнотекстовый поиск требований по меткам и полям.",
   "status": "approved",
   "title": "Поиск требований",

--- a/requirements/HLR/items/HLR003.json
+++ b/requirements/HLR/items/HLR003.json
@@ -1,9 +1,6 @@
 {
-  "derived_from": [
-    {
-      "rid": "SYS003",
-      "revision": 1
-    }
+  "links": [
+    "SYS003"
   ],
   "id": 3,
   "labels": [

--- a/requirements/LLR/items/LLR001.json
+++ b/requirements/LLR/items/LLR001.json
@@ -1,9 +1,6 @@
 {
-  "derived_from": [
-    {
-      "rid": "HLR001",
-      "revision": 1
-    }
+  "links": [
+    "HLR001"
   ],
   "id": 1,
   "labels": [

--- a/requirements/LLR/items/LLR002.json
+++ b/requirements/LLR/items/LLR002.json
@@ -1,9 +1,6 @@
 {
-  "derived_from": [
-    {
-      "rid": "HLR002",
-      "revision": 1
-    }
+  "links": [
+    "HLR002"
   ],
   "id": 2,
   "labels": [

--- a/requirements/SYS/items/SYS001.json
+++ b/requirements/SYS/items/SYS001.json
@@ -7,12 +7,6 @@
   "priority": "medium",
   "revision": 1,
   "source": "architecture",
-  "derived_to": [
-    {
-      "rid": "HLR001",
-      "revision": 1
-    }
-  ],
   "statement": "Система должна сохранять каждое требование в JSON-файл, имя которого совпадает с его идентификатором.",
   "status": "approved",
   "title": "Именование по идентификатору",

--- a/requirements/SYS/items/SYS002.json
+++ b/requirements/SYS/items/SYS002.json
@@ -7,12 +7,6 @@
   "priority": "medium",
   "revision": 1,
   "source": "architecture",
-  "derived_to": [
-    {
-      "rid": "HLR002",
-      "revision": 1
-    }
-  ],
   "statement": "Система должна представлять каждое требование как dataclass с типизированными полями для статуса, приоритета и способа верификации.",
   "status": "approved",
   "title": "Структурированная модель данных",

--- a/requirements/SYS/items/SYS003.json
+++ b/requirements/SYS/items/SYS003.json
@@ -7,12 +7,6 @@
   "priority": "medium",
   "revision": 1,
   "source": "architecture",
-  "derived_to": [
-    {
-      "rid": "HLR003",
-      "revision": 1
-    }
-  ],
   "statement": "Система должна предоставлять CLI для перечисления, добавления, правки и отображения требований, хранящихся в каталоге.",
   "status": "approved",
   "title": "Командный интерфейс",

--- a/tests/gui/test_filter_dialog.py
+++ b/tests/gui/test_filter_dialog.py
@@ -16,7 +16,6 @@ def _make_dialog(wx_app):
         "status": "draft",
         "is_derived": True,
         "has_derived": True,
-        "suspect_only": True,
     }
     return FilterDialog(None, labels=labels, values=values)
 
@@ -31,7 +30,6 @@ def test_clear_button_resets_all_filters(wx_app):
         "status": None,
         "is_derived": False,
         "has_derived": False,
-        "suspect_only": False,
         "field_queries": {},
     }
     dlg.Destroy()

--- a/tests/gui/test_link_column_width.py
+++ b/tests/gui/test_link_column_width.py
@@ -28,14 +28,14 @@ def test_title_column_expands_to_available_width(wx_app, monkeypatch):
     frame.Show()
     wx.GetApp().Yield()
 
-    panel.derived_id.SetValue("1")
-    panel._on_add_link_generic("derived_from")
+    panel.links_id.SetValue("1")
+    panel._on_add_link_generic("links")
 
-    panel.derived_list.SendSizeEvent()
+    panel.links_list.SendSizeEvent()
     wx.GetApp().Yield()
 
-    total = panel.derived_list.GetClientSize().width
-    id_width = panel.derived_list.GetColumnWidth(0)
-    title_width = panel.derived_list.GetColumnWidth(1)
+    total = panel.links_list.GetClientSize().width
+    id_width = panel.links_list.GetColumnWidth(0)
+    title_width = panel.links_list.GetColumnWidth(1)
     assert title_width >= total - id_width - 2
     frame.Destroy()

--- a/tests/gui/test_link_titles.py
+++ b/tests/gui/test_link_titles.py
@@ -24,9 +24,9 @@ def test_added_link_shows_id_and_title(wx_app, monkeypatch):
         verification=Verification.ANALYSIS,
     )
 
-    panel.derived_id.SetValue("123")
-    panel._on_add_link_generic("derived_from")
+    panel.links_id.SetValue("123")
+    panel._on_add_link_generic("links")
 
-    assert panel.derived_list.GetItemText(0, 0) == "123"
-    assert panel.derived_list.GetItemText(0, 1) == ""
+    assert panel.links_list.GetItemText(0, 0) == "123"
+    assert panel.links_list.GetItemText(0, 1) == ""
     frame.Destroy()

--- a/tests/gui/test_links_visibility.py
+++ b/tests/gui/test_links_visibility.py
@@ -9,7 +9,7 @@ pytestmark = pytest.mark.gui
 def test_links_list_becomes_visible(wx_app, monkeypatch):
     frame = wx.Frame(None)
     panel = EditorPanel(frame)
-    assert not panel.derived_list.IsShown()
+    assert not panel.links_list.IsShown()
 
     called = {}
 
@@ -17,9 +17,9 @@ def test_links_list_becomes_visible(wx_app, monkeypatch):
         called["called"] = True
 
     monkeypatch.setattr(panel, "FitInside", fake_fitinside)
-    panel.derived_id.SetValue("123")
-    panel._on_add_link_generic("derived_from")
+    panel.links_id.SetValue("123")
+    panel._on_add_link_generic("links")
 
-    assert panel.derived_list.IsShown()
+    assert panel.links_list.IsShown()
     assert called.get("called")
     frame.Destroy()

--- a/tests/gui/test_list_panel_gui.py
+++ b/tests/gui/test_list_panel_gui.py
@@ -5,7 +5,6 @@ import importlib
 import pytest
 
 from app.core.model import (
-    DerivationLink,
     Priority,
     Requirement,
     RequirementType,
@@ -205,14 +204,10 @@ def test_recalc_derived_map_updates_count(wx_app):
     panel = list_panel.ListPanel(frame, model=RequirementModel())
     panel.set_columns(["derived_count"])
     req1 = _req(1, "S")
-    req2 = _req(
-        2,
-        "D",
-        derived_from=[DerivationLink(rid="1", revision=1, suspect=False)],
-    )
+    req2 = _req(2, "D", links=["1"])
     panel.set_requirements([req1, req2])
     assert panel.list.GetItem(0, 1).GetText() == "1"
-    req2.derived_from = []
+    req2.links = []
     panel.recalc_derived_map([req1, req2])
     assert panel.list.GetItem(0, 1).GetText() == "0"
     frame.Destroy()

--- a/tests/unit/test_cli_doc.py
+++ b/tests/unit/test_cli_doc.py
@@ -78,13 +78,13 @@ def test_doc_delete_dry_run_lists_subtree(tmp_path, capsys):
     _ = capsys.readouterr()
 
     item1 = argparse.Namespace(
-        directory=str(tmp_path), prefix="SYS", title="S", text="", labels=None
+        directory=str(tmp_path), prefix="SYS", title="S", statement="", labels=None
     )
     commands.cmd_item_add(item1)
     _ = capsys.readouterr()
 
     item2 = argparse.Namespace(
-        directory=str(tmp_path), prefix="HLR", title="H", text="", labels=None
+        directory=str(tmp_path), prefix="HLR", title="H", statement="", labels=None
     )
     commands.cmd_item_add(item2)
     _ = capsys.readouterr()

--- a/tests/unit/test_cli_item.py
+++ b/tests/unit/test_cli_item.py
@@ -19,7 +19,7 @@ def test_item_add_and_move(tmp_path, capsys):
         directory=str(tmp_path),
         prefix="SYS",
         title="Login",
-        text="User shall login",
+        statement="User shall login",
         labels=None,
     )
     commands.cmd_item_add(add_args)
@@ -29,7 +29,7 @@ def test_item_add_and_move(tmp_path, capsys):
     path = Path(tmp_path) / "SYS" / "items" / "SYS001.json"
     data = json.loads(path.read_text(encoding="utf-8"))
     assert data["title"] == "Login"
-    assert data["text"] == "User shall login"
+    assert data["statement"] == "User shall login"
 
     move_args = argparse.Namespace(
         directory=str(tmp_path), rid="SYS001", new_prefix="HLR"
@@ -55,11 +55,11 @@ def test_item_delete_removes_links(tmp_path, capsys):
     save_document(tmp_path / "HLR", doc_hlr)
 
     add_args = argparse.Namespace(
-        directory=str(tmp_path), prefix="SYS", title="S", text="", labels=None
+        directory=str(tmp_path), prefix="SYS", title="S", statement="", labels=None
     )
     commands.cmd_item_add(add_args)
     add_args2 = argparse.Namespace(
-        directory=str(tmp_path), prefix="HLR", title="H", text="", labels=None
+        directory=str(tmp_path), prefix="HLR", title="H", statement="", labels=None
     )
     commands.cmd_item_add(add_args2)
     # link child to parent
@@ -87,11 +87,11 @@ def test_item_delete_dry_run_lists_links(tmp_path, capsys):
     save_document(tmp_path / "HLR", doc_hlr)
 
     add_args = argparse.Namespace(
-        directory=str(tmp_path), prefix="SYS", title="S", text="", labels=None
+        directory=str(tmp_path), prefix="SYS", title="S", statement="", labels=None
     )
     commands.cmd_item_add(add_args)
     add_args2 = argparse.Namespace(
-        directory=str(tmp_path), prefix="HLR", title="H", text="", labels=None
+        directory=str(tmp_path), prefix="HLR", title="H", statement="", labels=None
     )
     commands.cmd_item_add(add_args2)
     link_args = argparse.Namespace(
@@ -115,7 +115,7 @@ def test_item_delete_requires_confirmation(tmp_path, capsys):
     save_document(tmp_path / "SYS", doc_sys)
 
     add_args = argparse.Namespace(
-        directory=str(tmp_path), prefix="SYS", title="S", text="", labels=None
+        directory=str(tmp_path), prefix="SYS", title="S", statement="", labels=None
     )
     commands.cmd_item_add(add_args)
     _ = capsys.readouterr()

--- a/tests/unit/test_cli_item_add_labels.py
+++ b/tests/unit/test_cli_item_add_labels.py
@@ -18,7 +18,7 @@ def test_item_add_rejects_unknown_label(tmp_path, capsys):
         directory=str(tmp_path),
         prefix="HLR",
         title="T",
-        text="X",
+        statement="X",
         labels="unknown",
     )
     commands.cmd_item_add(args)
@@ -43,7 +43,7 @@ def test_item_add_accepts_inherited_label(tmp_path, capsys):
         directory=str(tmp_path),
         prefix="HLR",
         title="T",
-        text="X",
+        statement="X",
         labels="ui",
     )
     commands.cmd_item_add(args)

--- a/tests/unit/test_cli_link.py
+++ b/tests/unit/test_cli_link.py
@@ -15,8 +15,8 @@ def test_link_add(tmp_path, capsys):
     doc_hlr = Document(prefix="HLR", title="High", digits=2, parent="SYS")
     save_document(tmp_path / "HLR", doc_hlr)
 
-    save_item(tmp_path / "SYS", doc_sys, {"id": 1, "title": "S", "text": "", "labels": [], "links": []})
-    save_item(tmp_path / "HLR", doc_hlr, {"id": 1, "title": "H", "text": "", "labels": [], "links": []})
+    save_item(tmp_path / "SYS", doc_sys, {"id": 1, "title": "S", "statement": "", "labels": [], "links": []})
+    save_item(tmp_path / "HLR", doc_hlr, {"id": 1, "title": "H", "statement": "", "labels": [], "links": []})
 
     args = argparse.Namespace(
         directory=str(tmp_path), rid="HLR01", parents=["SYS001"], replace=False
@@ -38,7 +38,7 @@ def test_link_rejects_self_link(tmp_path, capsys):
     save_item(
         tmp_path / "SYS",
         doc_sys,
-        {"id": 1, "title": "S", "text": "", "labels": [], "links": []},
+        {"id": 1, "title": "S", "statement": "", "labels": [], "links": []},
     )
 
     args = argparse.Namespace(
@@ -62,8 +62,8 @@ def test_link_rejects_non_ancestor(tmp_path, capsys):
     doc_llr = Document(prefix="LLR", title="Low", digits=2, parent="HLR")
     save_document(tmp_path / "LLR", doc_llr)
 
-    save_item(tmp_path / "HLR", doc_hlr, {"id": 1, "title": "H", "text": "", "labels": [], "links": []})
-    save_item(tmp_path / "LLR", doc_llr, {"id": 1, "title": "L", "text": "", "labels": [], "links": []})
+    save_item(tmp_path / "HLR", doc_hlr, {"id": 1, "title": "H", "statement": "", "labels": [], "links": []})
+    save_item(tmp_path / "LLR", doc_llr, {"id": 1, "title": "L", "statement": "", "labels": [], "links": []})
 
     args = argparse.Namespace(
         directory=str(tmp_path), rid="HLR01", parents=["LLR01"], replace=False

--- a/tests/unit/test_cli_trace.py
+++ b/tests/unit/test_cli_trace.py
@@ -15,11 +15,11 @@ def _prepare(root):
     save_document(root / "SYS", doc_sys)
     doc_hlr = Document(prefix="HLR", title="High", digits=2, parent="SYS")
     save_document(root / "HLR", doc_hlr)
-    save_item(root / "SYS", doc_sys, {"id": 1, "title": "S", "text": "", "labels": [], "links": []})
+    save_item(root / "SYS", doc_sys, {"id": 1, "title": "S", "statement": "", "labels": [], "links": []})
     save_item(
         root / "HLR",
         doc_hlr,
-        {"id": 1, "title": "H", "text": "", "labels": [], "links": ["SYS001"]},
+        {"id": 1, "title": "H", "statement": "", "labels": [], "links": ["SYS001"]},
     )
 
 

--- a/tests/unit/test_doc_store.py
+++ b/tests/unit/test_doc_store.py
@@ -31,8 +31,8 @@ def test_document_store_roundtrip(tmp_path: Path):
     assert loaded.prefix == "SYS"
     assert loaded.digits == 3
 
-    item1 = {"id": 1, "title": "One", "text": "First"}
-    item2 = {"id": 2, "title": "Two", "text": "Second"}
+    item1 = {"id": 1, "title": "One", "statement": "First"}
+    item2 = {"id": 2, "title": "Two", "statement": "Second"}
     save_item(doc_dir, doc, item1)
     save_item(doc_dir, doc, item2)
 
@@ -44,7 +44,7 @@ def test_document_store_roundtrip(tmp_path: Path):
 
     data, _ = load_item(doc_dir, doc, 2)
     assert data["title"] == "Two"
-    assert data["text"] == "Second"
+    assert data["statement"] == "Second"
 
 
 def test_parse_rid_and_next_id(tmp_path: Path):
@@ -55,7 +55,7 @@ def test_parse_rid_and_next_id(tmp_path: Path):
     assert parse_rid("HLR01") == ("HLR", 1)
     assert next_item_id(doc_dir, doc) == 1
 
-    save_item(doc_dir, doc, {"id": 1, "title": "T", "text": "X"})
+    save_item(doc_dir, doc, {"id": 1, "title": "T", "statement": "X"})
     assert next_item_id(doc_dir, doc) == 2
 
 
@@ -64,11 +64,11 @@ def test_delete_item_removes_links(tmp_path: Path):
     hlr_doc = Document(prefix="HLR", title="High", digits=2, parent="SYS")
     save_document(tmp_path / "SYS", sys_doc)
     save_document(tmp_path / "HLR", hlr_doc)
-    save_item(tmp_path / "SYS", sys_doc, {"id": 1, "title": "S", "text": ""})
+    save_item(tmp_path / "SYS", sys_doc, {"id": 1, "title": "S", "statement": ""})
     save_item(
         tmp_path / "HLR",
         hlr_doc,
-        {"id": 1, "title": "H", "text": "", "links": ["SYS001"]},
+        {"id": 1, "title": "H", "statement": "", "links": ["SYS001"]},
     )
     docs = load_documents(tmp_path)
     assert delete_item(tmp_path, "SYS001", docs) is True
@@ -86,9 +86,9 @@ def test_delete_document_recursively(tmp_path: Path):
     save_document(tmp_path / "SYS", sys_doc)
     save_document(tmp_path / "HLR", hlr_doc)
     save_document(tmp_path / "LLR", llr_doc)
-    save_item(tmp_path / "SYS", sys_doc, {"id": 1, "title": "S", "text": ""})
-    save_item(tmp_path / "HLR", hlr_doc, {"id": 1, "title": "H", "text": "", "links": ["SYS001"]})
-    save_item(tmp_path / "LLR", llr_doc, {"id": 1, "title": "L", "text": "", "links": ["HLR01"]})
+    save_item(tmp_path / "SYS", sys_doc, {"id": 1, "title": "S", "statement": ""})
+    save_item(tmp_path / "HLR", hlr_doc, {"id": 1, "title": "H", "statement": "", "links": ["SYS001"]})
+    save_item(tmp_path / "LLR", llr_doc, {"id": 1, "title": "L", "statement": "", "links": ["HLR01"]})
     docs = load_documents(tmp_path)
     assert delete_document(tmp_path, "HLR", docs) is True
     assert not (tmp_path / "HLR").exists()
@@ -101,11 +101,11 @@ def test_plan_delete_item_lists_references(tmp_path: Path):
     hlr_doc = Document(prefix="HLR", title="High", digits=2, parent="SYS")
     save_document(tmp_path / "SYS", sys_doc)
     save_document(tmp_path / "HLR", hlr_doc)
-    save_item(tmp_path / "SYS", sys_doc, {"id": 1, "title": "S", "text": ""})
+    save_item(tmp_path / "SYS", sys_doc, {"id": 1, "title": "S", "statement": ""})
     save_item(
         tmp_path / "HLR",
         hlr_doc,
-        {"id": 1, "title": "H", "text": "", "links": ["SYS001"]},
+        {"id": 1, "title": "H", "statement": "", "links": ["SYS001"]},
     )
     docs = load_documents(tmp_path)
     exists, refs = plan_delete_item(tmp_path, "SYS001", docs)
@@ -122,8 +122,8 @@ def test_plan_delete_document_lists_subtree(tmp_path: Path):
     hlr_doc = Document(prefix="HLR", title="High", digits=2, parent="SYS")
     save_document(tmp_path / "SYS", sys_doc)
     save_document(tmp_path / "HLR", hlr_doc)
-    save_item(tmp_path / "SYS", sys_doc, {"id": 1, "title": "S", "text": ""})
-    save_item(tmp_path / "HLR", hlr_doc, {"id": 1, "title": "H", "text": ""})
+    save_item(tmp_path / "SYS", sys_doc, {"id": 1, "title": "S", "statement": ""})
+    save_item(tmp_path / "HLR", hlr_doc, {"id": 1, "title": "H", "statement": ""})
     docs = load_documents(tmp_path)
     doc_list, item_list = plan_delete_document(tmp_path, "SYS", docs)
     assert set(doc_list) == {"SYS", "HLR"}

--- a/tests/unit/test_migrate_to_docs.py
+++ b/tests/unit/test_migrate_to_docs.py
@@ -44,7 +44,7 @@ def test_migrate_to_docs_basic(tmp_path: Path):
 
     assert sys_data["id"] == 1
     assert sys_data["title"] == "One"
-    assert sys_data["text"] == "First"
+    assert sys_data["statement"] == "First"
     assert sys_data["labels"] == ["alpha"]
 
     assert hlr_data["id"] == 2

--- a/tests/unit/test_model.py
+++ b/tests/unit/test_model.py
@@ -33,40 +33,8 @@ def test_requirement_defaults():
     assert req.approved_at is None
     assert req.notes == ""
     assert req.conditions == ""
-    assert req.trace_up == ""
-    assert req.trace_down == ""
     assert req.version == ""
     assert req.modified_at == ""
-    assert req.derived_from == []
-    assert req.derived_to == []
-    assert req.derivation is None
-
-
-def test_requirement_derivation_conversion():
-    data = {
-        "id": 1,
-        "title": "Title",
-        "statement": "Statement",
-        "type": "requirement",
-        "status": "draft",
-        "owner": "user",
-        "priority": "medium",
-        "source": "spec",
-        "verification": "analysis",
-        "derived_from": [
-            {"rid": "2", "revision": 3, "suspect": True},
-        ],
-        "derivation": {
-            "rationale": "r",
-            "assumptions": ["a1", "a2"],
-        },
-    }
-    req = requirement_from_dict(data)
-    assert req.derived_from[0].rid == "2"
-    assert req.derived_from[0].suspect is True
-    roundtrip = requirement_to_dict(req)
-    assert roundtrip["derived_from"][0]["revision"] == 3
-    assert roundtrip["derivation"]["assumptions"] == ["a1", "a2"]
 
 
 def test_requirement_prefix_and_rid():

--- a/tests/unit/test_search.py
+++ b/tests/unit/test_search.py
@@ -3,7 +3,6 @@
 import pytest
 
 from app.core.model import (
-    DerivationLink,
     Priority,
     Requirement,
     RequirementType,
@@ -60,7 +59,7 @@ def sample_requirements():
             source="spec",
             verification=Verification.ANALYSIS,
             labels=["ui"],
-            derived_from=[DerivationLink(rid="2", revision=1, suspect=True)],
+            links=["2"],
         ),
     ]
 
@@ -115,17 +114,13 @@ def test_search_match_any():
 def test_filter_is_and_has_derived():
     reqs = sample_requirements()
     assert [r.id for r in filter_is_derived(reqs)] == [3]
-    assert [r.id for r in filter_is_derived(reqs, suspect_only=True)] == [3]
     assert [r.id for r in filter_has_derived(reqs, reqs)] == [2]
-    assert [r.id for r in filter_has_derived(reqs, reqs, suspect_only=True)] == [2]
 
 
 def test_search_with_derived_filters():
     reqs = sample_requirements()
     assert [r.id for r in search(reqs, is_derived=True)] == [3]
     assert [r.id for r in search(reqs, has_derived=True)] == [2]
-    assert [r.id for r in search(reqs, is_derived=True, suspect_only=True)] == [3]
-    assert [r.id for r in search(reqs, has_derived=True, suspect_only=True)] == [2]
 
 
 def test_field_queries():

--- a/tools/migrate_to_docs.py
+++ b/tools/migrate_to_docs.py
@@ -96,7 +96,7 @@ def migrate_to_docs(directory: str | Path, *, rules: str | None = None, default:
         item = {
             "id": info["num"],
             "title": info["data"].get("title", ""),
-            "text": info["data"].get("statement", ""),
+            "statement": info["data"].get("statement", info["data"].get("text", "")),
             "labels": [
                 lbl for lbl in info["labels"] if not lbl.startswith("doc=")
             ],


### PR DESCRIPTION
## Summary
- Simplify requirement model to use string links and drop legacy derived fields
- Rename item body to `statement` and update CLI, docs, and examples
- Rework search, UI, and tests to operate solely on `links`
- Remove obsolete parent section from the requirement editor panel
- Drop unused `trace_up`/`trace_down` fields from model, UI, translations, and tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c7ccd859648320a3137a169eeca88c