### PR TITLE
feat: extend requirement CLI and serialization

### DIFF
--- a/app/core/model.py
+++ b/app/core/model.py
@@ -89,7 +89,8 @@ def requirement_from_dict(
     into their respective dataclasses. Missing optional fields fall back to
     sensible defaults.
     """
-    attachments = [Attachment(**a) for a in data.get("attachments", [])]
+    attachments_data = data.get("attachments") or []
+    attachments = [Attachment(**a) for a in attachments_data]
     raw_links = data.get("links", [])
     links = [str(link) for link in raw_links] if isinstance(raw_links, list) else []
     statement = data.get("statement", data.get("text", ""))
@@ -107,7 +108,7 @@ def requirement_from_dict(
         conditions=data.get("conditions", ""),
         version=data.get("version", ""),
         modified_at=normalize_timestamp(data.get("modified_at")),
-        labels=list(data.get("labels", [])),
+        labels=list(data.get("labels") or []),
         attachments=attachments,
         revision=data.get("revision", 1),
         approved_at=(
@@ -134,4 +135,4 @@ def requirement_to_dict(req: Requirement) -> dict[str, Any]:
         value = data.get(key)
         if isinstance(value, Enum):
             data[key] = value.value
-    return {k: v for k, v in data.items() if v is not None}
+    return data

--- a/tests/unit/test_doc_store_extended.py
+++ b/tests/unit/test_doc_store_extended.py
@@ -1,0 +1,42 @@
+import pytest
+from pathlib import Path
+
+from app.core.doc_store import Document, save_document, save_item, load_item
+from app.core.model import (
+    Attachment,
+    Priority,
+    Requirement,
+    RequirementType,
+    Status,
+    Verification,
+    requirement_from_dict,
+    requirement_to_dict,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def test_save_and_load_extended_fields(tmp_path: Path):
+    doc = Document(prefix="SYS", title="System", digits=3)
+    doc_dir = tmp_path / "SYS"
+    save_document(doc_dir, doc)
+    req = Requirement(
+        id=1,
+        title="T",
+        statement="S",
+        type=RequirementType.REQUIREMENT,
+        status=Status.DRAFT,
+        owner="o",
+        priority=Priority.MEDIUM,
+        source="s",
+        verification=Verification.ANALYSIS,
+        attachments=[Attachment(path="file.txt", note="n")],
+        approved_at="2024-01-01",
+        notes="note",
+    )
+    save_item(doc_dir, doc, requirement_to_dict(req))
+    data, _ = load_item(doc_dir, doc, 1)
+    loaded = requirement_from_dict(data)
+    assert loaded.attachments[0].path == "file.txt"
+    assert loaded.approved_at == "2024-01-01"
+    assert loaded.notes == "note"

--- a/tests/unit/test_model.py
+++ b/tests/unit/test_model.py
@@ -3,6 +3,7 @@
 import pytest
 
 from app.core.model import (
+    Attachment,
     Priority,
     Requirement,
     RequirementType,
@@ -55,3 +56,28 @@ def test_requirement_prefix_and_rid():
     roundtrip = requirement_to_dict(req)
     assert "doc_prefix" not in roundtrip
     assert "rid" not in roundtrip
+
+
+def test_requirement_extended_roundtrip():
+    req = Requirement(
+        id=7,
+        title="T",
+        statement="S",
+        type=RequirementType.REQUIREMENT,
+        status=Status.DRAFT,
+        owner="o",
+        priority=Priority.MEDIUM,
+        source="s",
+        verification=Verification.ANALYSIS,
+        attachments=[Attachment(path="doc.txt", note="ref")],
+        approved_at="2024-01-01 00:00:00",
+        notes="extra",
+    )
+    data = requirement_to_dict(req)
+    assert data["attachments"][0]["path"] == "doc.txt"
+    assert data["approved_at"] == "2024-01-01 00:00:00"
+    assert "acceptance" in data and data["acceptance"] is None
+    again = requirement_from_dict(data)
+    assert again.attachments[0].note == "ref"
+    assert again.approved_at == "2024-01-01 00:00:00"
+    assert again.notes == "extra"


### PR DESCRIPTION
## Summary
- allow `item add` and `item move` to accept full requirement fields or load a JSON template
- keep optional fields during requirement serialization
- cover attachments and notes round-trips with tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c7f6f05dd083208233e2a7a94d4daa