### PR TITLE
refactor: enforce statement/labels schema

### DIFF
--- a/tests/unit/test_model.py
+++ b/tests/unit/test_model.py
@@ -81,3 +81,34 @@ def test_requirement_extended_roundtrip():
     assert again.attachments[0].note == "ref"
     assert again.approved_at == "2024-01-01 00:00:00"
     assert again.notes == "extra"
+
+
+def test_requirement_from_dict_missing_statement():
+    data = {
+        "id": 1,
+        "title": "T",
+        "type": "requirement",
+        "status": "draft",
+        "owner": "o",
+        "priority": "medium",
+        "source": "s",
+        "verification": "analysis",
+    }
+    with pytest.raises(KeyError):
+        requirement_from_dict(data)
+
+
+def test_requirement_from_dict_rejects_text_field():
+    data = {
+        "id": 1,
+        "title": "T",
+        "text": "legacy",
+        "type": "requirement",
+        "status": "draft",
+        "owner": "o",
+        "priority": "medium",
+        "source": "s",
+        "verification": "analysis",
+    }
+    with pytest.raises(KeyError):
+        requirement_from_dict(data)

--- a/tools/migrate_to_docs.py
+++ b/tools/migrate_to_docs.py
@@ -93,10 +93,13 @@ def migrate_to_docs(directory: str | Path, *, rules: str | None = None, default:
     # Second pass: rewrite items and links
     items: list[tuple[str, str, dict]] = []
     for info in parsed:
+        statement = info["data"].get("statement")
+        if statement is None:
+            raise ValueError(f"missing statement in {info['fp']}")
         item = {
             "id": info["num"],
             "title": info["data"].get("title", ""),
-            "statement": info["data"].get("statement", info["data"].get("text", "")),
+            "statement": statement,
             "labels": [
                 lbl for lbl in info["labels"] if not lbl.startswith("doc=")
             ],


### PR DESCRIPTION
## Summary
- drop legacy `text` field and transitional keys
- validate required fields in `requirement_from_dict`
- require `statement` during migration and update tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c7fc82a5688320a690ffc9b492802d