### PR TITLE
feat: add rationale and assumptions fields

### DIFF
--- a/app/cli/commands.py
+++ b/app/cli/commands.py
@@ -188,6 +188,8 @@ def cmd_item_add(args: argparse.Namespace) -> None:
         if getattr(args, "acceptance", None) is not None
         else base.get("acceptance"),
         "conditions": getattr(args, "conditions", None) or base.get("conditions", ""),
+        "rationale": getattr(args, "rationale", None) or base.get("rationale", ""),
+        "assumptions": getattr(args, "assumptions", None) or base.get("assumptions", ""),
         "version": getattr(args, "version", None) or base.get("version", ""),
         "modified_at": getattr(args, "modified_at", None) or base.get("modified_at", ""),
         "labels": labels,
@@ -238,6 +240,10 @@ def cmd_item_move(args: argparse.Namespace) -> None:
         data["acceptance"] = args.acceptance
     if getattr(args, "conditions", None) is not None:
         data["conditions"] = args.conditions
+    if getattr(args, "rationale", None) is not None:
+        data["rationale"] = args.rationale
+    if getattr(args, "assumptions", None) is not None:
+        data["assumptions"] = args.assumptions
     if getattr(args, "version", None) is not None:
         data["version"] = args.version
     if getattr(args, "modified_at", None) is not None:
@@ -318,6 +324,8 @@ def add_item_arguments(p: argparse.ArgumentParser) -> None:
     add_p.add_argument("--verification", choices=VERIFICATION_CHOICES, default=Verification.ANALYSIS.value)
     add_p.add_argument("--acceptance")
     add_p.add_argument("--conditions")
+    add_p.add_argument("--rationale")
+    add_p.add_argument("--assumptions")
     add_p.add_argument("--version")
     add_p.add_argument("--modified-at", dest="modified_at")
     add_p.add_argument("--approved-at", dest="approved_at")
@@ -342,6 +350,8 @@ def add_item_arguments(p: argparse.ArgumentParser) -> None:
     move_p.add_argument("--verification", choices=VERIFICATION_CHOICES)
     move_p.add_argument("--acceptance")
     move_p.add_argument("--conditions")
+    move_p.add_argument("--rationale")
+    move_p.add_argument("--assumptions")
     move_p.add_argument("--version")
     move_p.add_argument("--modified-at", dest="modified_at")
     move_p.add_argument("--approved-at", dest="approved_at")

--- a/app/core/model.py
+++ b/app/core/model.py
@@ -67,6 +67,8 @@ class Requirement:
     verification: Verification
     acceptance: str | None = None
     conditions: str = ""
+    rationale: str = ""
+    assumptions: str = ""
     version: str = ""
     modified_at: str = ""
     labels: list[str] = field(default_factory=list)
@@ -135,6 +137,8 @@ def requirement_from_dict(
         verification=Verification(data["verification"]),
         acceptance=data.get("acceptance"),
         conditions=data.get("conditions", ""),
+        rationale=data.get("rationale", ""),
+        assumptions=data.get("assumptions", ""),
         version=data.get("version", ""),
         modified_at=normalize_timestamp(data.get("modified_at")),
         labels=labels,

--- a/app/core/search.py
+++ b/app/core/search.py
@@ -14,6 +14,8 @@ SEARCHABLE_FIELDS = {
     "source",
     "owner",
     "notes",
+    "rationale",
+    "assumptions",
 }
 
 

--- a/app/ui/editor_panel.py
+++ b/app/ui/editor_panel.py
@@ -182,6 +182,8 @@ class EditorPanel(ScrolledPanel):
             ("statement", True),
             ("acceptance", True),
             ("conditions", True),
+            ("rationale", True),
+            ("assumptions", True),
             ("source", True),
         ]:
             label = wx.StaticText(self, label=labels[name])
@@ -665,6 +667,8 @@ class EditorPanel(ScrolledPanel):
             ),
             "acceptance": self.fields["acceptance"].GetValue(),
             "conditions": self.fields["conditions"].GetValue(),
+            "rationale": self.fields["rationale"].GetValue(),
+            "assumptions": self.fields["assumptions"].GetValue(),
             "version": self.fields["version"].GetValue(),
             "modified_at": self.fields["modified_at"].GetValue(),
             "labels": list(self.extra.get("labels", [])),

--- a/tests/unit/test_doc_store_extended.py
+++ b/tests/unit/test_doc_store_extended.py
@@ -33,6 +33,8 @@ def test_save_and_load_extended_fields(tmp_path: Path):
         attachments=[Attachment(path="file.txt", note="n")],
         approved_at="2024-01-01",
         notes="note",
+        rationale="reason",
+        assumptions="context",
     )
     save_item(doc_dir, doc, requirement_to_dict(req))
     data, _ = load_item(doc_dir, doc, 1)
@@ -40,3 +42,5 @@ def test_save_and_load_extended_fields(tmp_path: Path):
     assert loaded.attachments[0].path == "file.txt"
     assert loaded.approved_at == "2024-01-01"
     assert loaded.notes == "note"
+    assert loaded.rationale == "reason"
+    assert loaded.assumptions == "context"

--- a/tests/unit/test_model.py
+++ b/tests/unit/test_model.py
@@ -34,6 +34,8 @@ def test_requirement_defaults():
     assert req.approved_at is None
     assert req.notes == ""
     assert req.conditions == ""
+    assert req.rationale == ""
+    assert req.assumptions == ""
     assert req.version == ""
     assert req.modified_at == ""
 
@@ -72,15 +74,21 @@ def test_requirement_extended_roundtrip():
         attachments=[Attachment(path="doc.txt", note="ref")],
         approved_at="2024-01-01 00:00:00",
         notes="extra",
+        rationale="because",
+        assumptions="if ready",
     )
     data = requirement_to_dict(req)
     assert data["attachments"][0]["path"] == "doc.txt"
     assert data["approved_at"] == "2024-01-01 00:00:00"
     assert "acceptance" in data and data["acceptance"] is None
+    assert data["rationale"] == "because"
+    assert data["assumptions"] == "if ready"
     again = requirement_from_dict(data)
     assert again.attachments[0].note == "ref"
     assert again.approved_at == "2024-01-01 00:00:00"
     assert again.notes == "extra"
+    assert again.rationale == "because"
+    assert again.assumptions == "if ready"
 
 
 def test_requirement_from_dict_missing_statement():

--- a/tests/unit/test_search.py
+++ b/tests/unit/test_search.py
@@ -35,6 +35,8 @@ def sample_requirements():
             verification=Verification.ANALYSIS,
             labels=["ui", "auth"],
             notes="Requires username",
+            rationale="Secure access",
+            assumptions="Users have accounts",
         ),
         Requirement(
             id=2,
@@ -87,6 +89,10 @@ def test_search_text():
     assert [r.id for r in found] == [1]
     found = search_text(reqs, "EXPORT", ["title"])
     assert [r.id for r in found] == [3]
+    found = search_text(reqs, "secure", ["rationale"])
+    assert [r.id for r in found] == [1]
+    found = search_text(reqs, "accounts", ["assumptions"])
+    assert [r.id for r in found] == [1]
 
 
 def test_search_text_empty_query_returns_all():
@@ -129,6 +135,8 @@ def test_field_queries():
     assert [r.id for r in found] == [1]
     found = search(reqs, field_queries={"title": "report", "owner": "carol"})
     assert [r.id for r in found] == [3]
+    found = search(reqs, field_queries={"rationale": "secure"})
+    assert [r.id for r in found] == [1]
 
 
 def test_filter_by_status_function():


### PR DESCRIPTION
## Summary
- extend requirement model with `rationale` and `assumptions`
- support new fields in CLI, search, and editor panel
- cover new behavior with unit tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c7fe3064b4832090d7790aaee1776f