### PR TITLE
Fix leftover merge artifact in model tests

### DIFF
--- a/tests/unit/test_model.py
+++ b/tests/unit/test_model.py
@@ -87,11 +87,8 @@ def test_requirement_extended_roundtrip():
     assert again.attachments[0].note == "ref"
     assert again.approved_at == "2024-01-01 00:00:00"
     assert again.notes == "extra"
-<<<<< codex/remove-deprecated-keys-and-fields-85qubp
-=======
     assert again.rationale == "because"
     assert again.assumptions == "if ready"
->>>>> main
 
 
 def test_requirement_from_dict_missing_statement():


### PR DESCRIPTION
## Summary
- clean up stray merge markers in `tests/unit/test_model.py`
- restore assertions for `rationale` and `assumptions` round-trip

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c802263b7c8320800bd0e0f6fd112c