### PR TITLE
refactor: unify label validation

### DIFF
--- a/app/core/doc_store.py
+++ b/app/core/doc_store.py
@@ -6,7 +6,7 @@ import shutil
 from hashlib import sha256
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
-from typing import Any, Iterable, Mapping
+from typing import Any, Iterable, Mapping, Optional
 
 
 @dataclass
@@ -168,6 +168,34 @@ def collect_labels(prefix: str, docs: Mapping[str, Document]) -> tuple[set[str],
 
     defs, freeform = collect_label_defs(prefix, docs)
     return {d.key for d in defs}, freeform
+
+
+def validate_labels(
+    prefix: str, labels: list[str], docs: Mapping[str, Document]
+) -> Optional[str]:
+    """Validate ``labels`` for items under document ``prefix``.
+
+    Parameters
+    ----------
+    prefix:
+        Document prefix for which the labels are being validated.
+    labels:
+        Labels requested for the requirement.
+    docs:
+        Mapping of document prefixes to :class:`Document` instances.
+
+    Returns
+    -------
+    Optional[str]
+        ``None`` if labels are valid, otherwise an error message.
+    """
+
+    allowed, freeform = collect_labels(prefix, docs)
+    if labels and not freeform:
+        unknown = [lbl for lbl in labels if lbl not in allowed]
+        if unknown:
+            return f"unknown label: {unknown[0]}"
+    return None
 
 
 def rid_for(doc: Document, item_id: int) -> str:

--- a/tests/unit/test_mcp_tools_write.py
+++ b/tests/unit/test_mcp_tools_write.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from app.core.doc_store import Document, save_document
+from app.core.doc_store import Document, DocumentLabels, LabelDef, save_document
 from app.mcp import tools_write
 
 
@@ -29,6 +29,59 @@ def test_create_patch_delete(tmp_path: Path) -> None:
     assert res2["revision"] == 2
     res3 = tools_write.delete_requirement(tmp_path, "SYS001", rev=2)
     assert res3 == {"rid": "SYS001"}
+
+
+def test_create_rejects_unknown_label(tmp_path: Path) -> None:
+    save_document(tmp_path / "SYS", Document(prefix="SYS", title="Doc", digits=3))
+    res = tools_write.create_requirement(
+        tmp_path, prefix="SYS", data={**_base_req(), "labels": ["bad"]}
+    )
+    assert res["error"]["code"] == "VALIDATION_ERROR"
+
+
+def test_create_accepts_inherited_label(tmp_path: Path) -> None:
+    save_document(
+        tmp_path / "SYS",
+        Document(
+            prefix="SYS",
+            title="Doc",
+            digits=3,
+            labels=DocumentLabels(defs=[LabelDef("ui", "UI")]),
+        ),
+    )
+    save_document(
+        tmp_path / "HLR",
+        Document(prefix="HLR", title="H", digits=2, parent="SYS"),
+    )
+    res = tools_write.create_requirement(
+        tmp_path, prefix="HLR", data={**_base_req(), "labels": ["ui"]}
+    )
+    assert res["rid"] == "HLR01"
+    assert res["labels"] == ["ui"]
+
+
+def test_patch_rejects_unknown_label(tmp_path: Path) -> None:
+    save_document(tmp_path / "SYS", Document(prefix="SYS", title="Doc", digits=3))
+    created = tools_write.create_requirement(tmp_path, prefix="SYS", data=_base_req())
+    patch = [{"op": "replace", "path": "/labels", "value": ["bad"]}]
+    res = tools_write.patch_requirement(tmp_path, created["rid"], patch, rev=1)
+    assert res["error"]["code"] == "VALIDATION_ERROR"
+
+
+def test_patch_accepts_inherited_label(tmp_path: Path) -> None:
+    save_document(
+        tmp_path / "SYS",
+        Document(
+            prefix="SYS",
+            title="Doc",
+            digits=3,
+            labels=DocumentLabels(defs=[LabelDef("ui", "UI")]),
+        ),
+    )
+    created = tools_write.create_requirement(tmp_path, prefix="SYS", data=_base_req())
+    patch = [{"op": "replace", "path": "/labels", "value": ["ui"]}]
+    res = tools_write.patch_requirement(tmp_path, created["rid"], patch, rev=1)
+    assert res["labels"] == ["ui"]
 
 
 def test_link_requirements(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- centralize label checking in new `validate_labels` helper
- reuse shared validation in CLI and MCP write tools
- cover inherited labels and errors in CLI and MCP tests

## Testing
- `pytest tests/unit/test_cli_item_add_labels.py tests/unit/test_mcp_tools_write.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c804b0b208832096652212110449dc