### PR TITLE
refactor: use RID links in editor

### DIFF
--- a/app/ui/main_frame.py
+++ b/app/ui/main_frame.py
@@ -461,16 +461,17 @@ class MainFrame(wx.Frame):
             self.splitter.UpdateSize()
 
     def _on_editor_save(self) -> None:
-        if not self.current_dir:
+        if not (
+            self.current_dir
+            and self.docs_controller
+            and self.current_doc_prefix
+        ):
             return
         try:
-            if self.docs_controller and self.current_doc_prefix:
-                doc = self.docs_controller.documents[self.current_doc_prefix]
-                self.editor.save(
-                    self.current_dir / self.current_doc_prefix, doc=doc
-                )
-            else:
-                self.editor.save(self.current_dir)
+            doc = self.docs_controller.documents[self.current_doc_prefix]
+            self.editor.save(
+                self.current_dir / self.current_doc_prefix, doc=doc
+            )
         except Exception as exc:  # pragma: no cover - GUI event
             wx.MessageBox(str(exc), _("Error"), wx.ICON_ERROR)
             return

--- a/tests/gui/test_link_column_width.py
+++ b/tests/gui/test_link_column_width.py
@@ -28,7 +28,7 @@ def test_title_column_expands_to_available_width(wx_app, monkeypatch):
     frame.Show()
     wx.GetApp().Yield()
 
-    panel.links_id.SetValue("1")
+    panel.links_id.SetValue("SYS001")
     panel._on_add_link_generic("links")
 
     panel.links_list.SendSizeEvent()

--- a/tests/gui/test_link_titles.py
+++ b/tests/gui/test_link_titles.py
@@ -24,9 +24,9 @@ def test_added_link_shows_id_and_title(wx_app, monkeypatch):
         verification=Verification.ANALYSIS,
     )
 
-    panel.links_id.SetValue("123")
+    panel.links_id.SetValue("SYS123")
     panel._on_add_link_generic("links")
 
-    assert panel.links_list.GetItemText(0, 0) == "123"
+    assert panel.links_list.GetItemText(0, 0) == "SYS123"
     assert panel.links_list.GetItemText(0, 1) == ""
     frame.Destroy()

--- a/tests/gui/test_links_visibility.py
+++ b/tests/gui/test_links_visibility.py
@@ -17,7 +17,7 @@ def test_links_list_becomes_visible(wx_app, monkeypatch):
         called["called"] = True
 
     monkeypatch.setattr(panel, "FitInside", fake_fitinside)
-    panel.links_id.SetValue("123")
+    panel.links_id.SetValue("SYS001")
     panel._on_add_link_generic("links")
 
     assert panel.links_list.IsShown()


### PR DESCRIPTION
## Summary
- remove legacy req_ops usage
- handle requirement links by RID
- require Document when saving from EditorPanel

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c8114cfe548320bc978302d65c364a