### PR TITLE
Unify MCP client responses

### DIFF
--- a/app/agent/local_agent.py
+++ b/app/agent/local_agent.py
@@ -50,12 +50,16 @@ class LocalAgent:
 
     # ------------------------------------------------------------------
     def run_command(self, text: str) -> dict[str, Any]:
-        """Use the LLM to parse *text* and execute the resulting tool call."""
+        """Use the LLM to parse *text* and execute the resulting tool call.
+
+        Returns a dictionary following the same ``{"ok": bool, "error": ...}``
+        contract as :meth:`MCPClient.call_tool`.
+        """
 
         try:
             name, arguments = self._llm.parse_command(text)
         except Exception as exc:
             err = mcp_error(ErrorCode.VALIDATION_ERROR, str(exc))["error"]
             log_event("ERROR", {"error": err})
-            return {"error": err}
+            return {"ok": False, "error": err}
         return self._mcp.call_tool(name, arguments)

--- a/app/ui/command_dialog.py
+++ b/app/ui/command_dialog.py
@@ -85,13 +85,14 @@ class CommandDialog(wx.Dialog):
         if not text:
             return
         result = self._agent.run_command(text)
-        if "error" in result:
-            err = result["error"]
-            code = err.get("code", "")
-            msg = err.get("message", "")
+        if not result.get("ok", False):
+            err = result.get("error") or {}
+            code = err.get("code", "") if isinstance(err, dict) else ""
+            msg = err.get("message", "") if isinstance(err, dict) else str(err)
             display = f"{code}: {msg}".strip(": ")
         else:
-            display = json.dumps(result, ensure_ascii=False, indent=2)
+            payload = result.get("result")
+            display = json.dumps(payload, ensure_ascii=False, indent=2)
         self.output.SetValue(display)
         self.output.ShowPosition(self.output.GetLastPosition())
         self._append_history(text, display)

--- a/tests/gui/test_command_dialog.py
+++ b/tests/gui/test_command_dialog.py
@@ -19,7 +19,7 @@ def test_command_dialog_shows_result_and_saves_history(tmp_path, wx_app):
 
     class DummyMCP:
         def call_tool(self, name, arguments):
-            return {"value": 42}
+            return {"ok": True, "error": None, "result": {"value": 42}}
 
     agent = LocalAgent(llm=DummyLLM(), mcp=DummyMCP())
     history_file = tmp_path / "history.json"
@@ -54,7 +54,7 @@ def test_command_dialog_shows_error(tmp_path, wx_app):
 
     class DummyMCP:
         def call_tool(self, name, arguments):
-            return {"error": {"code": "FAIL", "message": "bad"}}
+            return {"ok": False, "error": {"code": "FAIL", "message": "bad"}}
 
     agent = LocalAgent(llm=DummyLLM(), mcp=DummyMCP())
     history_file = tmp_path / "history.json"
@@ -72,7 +72,7 @@ def test_command_dialog_persists_between_instances(tmp_path, wx_app):
 
     class DummyAgent:
         def run_command(self, text):
-            return {"echo": text}
+            return {"ok": True, "error": None, "result": {"echo": text}}
 
     history_file = tmp_path / "history.json"
 
@@ -97,7 +97,7 @@ def test_command_dialog_handles_invalid_history(tmp_path, wx_app):
 
     class DummyAgent:
         def run_command(self, text):
-            return {}
+            return {"ok": True, "error": None, "result": {}}
 
     dlg = CommandDialog(None, agent=DummyAgent(), history_path=bad_file)
     assert dlg.history == []

--- a/tests/gui/test_settings_dialog.py
+++ b/tests/gui/test_settings_dialog.py
@@ -216,7 +216,7 @@ def test_llm_agent_checks(monkeypatch, wx_app):
             self.settings = settings
 
         def check_tools(self):
-            return {"ok": True}
+            return {"ok": True, "error": None}
 
     monkeypatch.setattr(
         "app.ui.settings_dialog.LLMClient",

--- a/tests/integration/test_local_agent.py
+++ b/tests/integration/test_local_agent.py
@@ -47,6 +47,7 @@ def test_check_llm_and_check_tools_propagate_errors():
 def test_run_command_handles_llm_error():
     agent = LocalAgent(llm=FailingLLM(), mcp=DummyMCP())
     result = agent.run_command("whatever")
+    assert result["ok"] is False
     assert result["error"]["code"] == ErrorCode.VALIDATION_ERROR
     assert result["error"]["message"] == "parse fail"
 
@@ -78,10 +79,10 @@ def test_custom_confirm_message(monkeypatch):
         def call_tool(self, name, arguments):
             if name in {"delete_requirement", "patch_requirement"}:
                 self.confirm("Delete requirement?")
-            return {"ok": True}
+            return {"ok": True, "error": None, "result": {}}
 
     monkeypatch.setattr(la, "LLMClient", StubLLM)
     monkeypatch.setattr(la, "MCPClient", StubMCP)
     agent = LocalAgent(settings=AppSettings(), confirm=custom_confirm)
-    assert agent.run_command("remove") == {"ok": True}
+    assert agent.run_command("remove") == {"ok": True, "error": None, "result": {}}
     assert messages == ["Delete requirement?"]

--- a/tests/integration/test_mcp_text_commands.py
+++ b/tests/integration/test_mcp_text_commands.py
@@ -43,7 +43,8 @@ def test_run_command_list_logs(tmp_path: Path, monkeypatch, mcp_server) -> None:
     finally:
         logger.setLevel(prev_level)
         logger.removeHandler(handler)
-    assert result["items"] == []
+    assert result["ok"] is True
+    assert result["result"]["items"] == []
     entries = [json.loads(line) for line in log_file.read_text().splitlines()]
     events = {e.get("event") for e in entries}
     assert {"LLM_REQUEST", "LLM_RESPONSE", "TOOL_CALL", "TOOL_RESULT", "DONE"} <= events
@@ -75,7 +76,7 @@ def test_run_command_error_logs(tmp_path: Path, monkeypatch, mcp_server) -> None
     finally:
         logger.setLevel(prev_level)
         logger.removeHandler(handler)
-    assert "error" in result
+    assert result["ok"] is False
     entries = [json.loads(line) for line in log_file.read_text().splitlines()]
     events = {e.get("event") for e in entries}
     assert {


### PR DESCRIPTION
## Summary
- return a consistent {"ok": ..., "error": ...} payload from MCPClient and document the new contract
- propagate the wrapper through LocalAgent and the command dialog UI so successful tool calls expose their result under result
- adjust GUI and integration tests to expect the unified structure

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68c83e1c7e448320896dedf9b7c149d4