### PR TITLE
Remove deprecated MCPClient _call_tool wrapper

### DIFF
--- a/app/mcp/client.py
+++ b/app/mcp/client.py
@@ -142,8 +142,3 @@ class MCPClient:
             log_event("ERROR", {"error": err})
             return {"ok": False, "error": err}
 
-    # ------------------------------------------------------------------
-    def _call_tool(self, name: str, arguments: Mapping[str, Any]) -> dict[str, Any]:
-        """Backward compatible wrapper for :meth:`call_tool`."""
-
-        return self.call_tool(name, arguments)


### PR DESCRIPTION
## Summary
- remove the unused MCPClient._call_tool compatibility wrapper

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68c84c16cad08320a598191cfbac444f