### PR TITLE
Prompt for unsaved changes when switching directories

### DIFF
--- a/tests/gui/test_editor_dirty.py
+++ b/tests/gui/test_editor_dirty.py
@@ -1,0 +1,48 @@
+"""Tests for editor dirty state tracking."""
+
+import pytest
+
+
+pytestmark = pytest.mark.gui
+
+
+def test_editor_panel_dirty_detection_fields(wx_app):
+    pytest.importorskip("wx")
+    import wx
+
+    from app.ui.editor_panel import EditorPanel
+
+    frame = wx.Frame(None)
+    try:
+        panel = EditorPanel(frame)
+        panel.mark_clean()
+        assert panel.is_dirty() is False
+
+        panel.fields["title"].ChangeValue("Sample")
+        assert panel.is_dirty() is True
+
+        panel.fields["title"].ChangeValue("")
+        assert panel.is_dirty() is False
+    finally:
+        frame.Destroy()
+
+
+def test_editor_panel_mark_clean_resets_dirty(wx_app):
+    pytest.importorskip("wx")
+    import wx
+
+    from app.ui.editor_panel import EditorPanel
+
+    frame = wx.Frame(None)
+    try:
+        panel = EditorPanel(frame)
+        panel.fields["title"].ChangeValue("Initial")
+        assert panel.is_dirty() is True
+
+        panel.mark_clean()
+        assert panel.is_dirty() is False
+
+        panel.fields["title"].ChangeValue("Updated")
+        assert panel.is_dirty() is True
+    finally:
+        frame.Destroy()

--- a/tests/gui/test_main_dirty_prompt.py
+++ b/tests/gui/test_main_dirty_prompt.py
@@ -1,0 +1,41 @@
+"""Tests for MainFrame dirty-state confirmation logic."""
+
+import pytest
+
+
+pytestmark = pytest.mark.gui
+
+
+def test_confirm_discard_changes(monkeypatch, wx_app):
+    pytest.importorskip("wx")
+
+    import app.ui.main_frame as main_frame_mod
+
+    frame = main_frame_mod.MainFrame(None)
+    try:
+        frame.editor.fields["title"].ChangeValue("Dirty")
+        assert frame.editor.is_dirty() is True
+
+        messages: list[str] = []
+
+        def reject(message: str) -> bool:
+            messages.append(message)
+            return False
+
+        monkeypatch.setattr(main_frame_mod, "confirm", reject)
+
+        assert frame._confirm_discard_changes() is False
+        assert messages[-1] == main_frame_mod._("Discard unsaved changes?")
+        assert frame.editor.is_dirty() is True
+
+        def accept(message: str) -> bool:
+            messages.append(message)
+            return True
+
+        monkeypatch.setattr(main_frame_mod, "confirm", accept)
+
+        assert frame._confirm_discard_changes() is True
+        assert messages[-1] == main_frame_mod._("Discard unsaved changes?")
+        assert frame.editor.is_dirty() is False
+    finally:
+        frame.Destroy()


### PR DESCRIPTION
## Summary
- track the last saved state within `EditorPanel` and expose an `is_dirty` helper
- reset the stored state after load/save operations and compare current values to detect edits
- require confirmation before discarding pending edits when opening another folder, loading a recent folder, or closing the main window
- add GUI tests covering the new dirty-state checks and confirmation logic

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68c85a78197c8320a8933a2cc01f5d83