### PR TITLE
Add document tree context menu and document management

### DIFF
--- a/app/ui/document_dialog.py
+++ b/app/ui/document_dialog.py
@@ -1,0 +1,117 @@
+"""Dialogs for managing requirement documents."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import re
+
+import wx
+
+from ..i18n import _
+
+
+PREFIX_RE = re.compile(r"^[A-Z][A-Z0-9_]*$")
+
+
+@dataclass
+class DocumentProperties:
+    """Properties describing a requirements document."""
+
+    prefix: str
+    title: str
+    digits: int
+
+
+class DocumentPropertiesDialog(wx.Dialog):
+    """Prompt user for document properties."""
+
+    def __init__(
+        self,
+        parent: wx.Window,
+        *,
+        mode: str,
+        prefix: str = "",
+        title: str = "",
+        digits: int = 3,
+        parent_prefix: str | None = None,
+    ) -> None:
+        if mode not in {"create", "rename"}:
+            raise ValueError(f"unsupported mode: {mode}")
+        heading = _("New document") if mode == "create" else _("Rename document")
+        super().__init__(parent, title=heading)
+        self._mode = mode
+        self._result: DocumentProperties | None = None
+        main_sizer = wx.BoxSizer(wx.VERTICAL)
+        grid = wx.FlexGridSizer(0, 2, 5, 5)
+        grid.AddGrowableCol(1, 1)
+
+        prefix_label = wx.StaticText(self, label=_("Prefix"))
+        grid.Add(prefix_label, 0, wx.ALIGN_CENTER_VERTICAL)
+        self.prefix_ctrl = wx.TextCtrl(self, value=prefix)
+        if mode == "rename":
+            self.prefix_ctrl.Enable(False)
+        grid.Add(self.prefix_ctrl, 1, wx.EXPAND)
+
+        title_label = wx.StaticText(self, label=_("Title"))
+        grid.Add(title_label, 0, wx.ALIGN_CENTER_VERTICAL)
+        self.title_ctrl = wx.TextCtrl(self, value=title)
+        grid.Add(self.title_ctrl, 1, wx.EXPAND)
+
+        digits_label = wx.StaticText(self, label=_("Digits"))
+        grid.Add(digits_label, 0, wx.ALIGN_CENTER_VERTICAL)
+        max_digits = digits if digits > 0 else 1
+        max_digits = max(9, max_digits)
+        self.digits_ctrl = wx.SpinCtrl(
+            self, min=1, max=max_digits, initial=max(digits, 1)
+        )
+        grid.Add(self.digits_ctrl, 1, wx.EXPAND)
+
+        parent_label = wx.StaticText(self, label=_("Parent"))
+        grid.Add(parent_label, 0, wx.ALIGN_CENTER_VERTICAL)
+        parent_value = parent_prefix or _("(top-level)")
+        grid.Add(wx.StaticText(self, label=parent_value), 0, wx.ALIGN_CENTER_VERTICAL)
+
+        main_sizer.Add(grid, 0, wx.ALL | wx.EXPAND, 10)
+
+        btn_sizer = self.CreateStdDialogButtonSizer(wx.OK | wx.CANCEL)
+        if btn_sizer:
+            main_sizer.Add(btn_sizer, 0, wx.ALIGN_RIGHT | wx.ALL, 10)
+
+        self.SetSizer(main_sizer)
+        self.SetMinSize((320, 200))
+        if mode == "create":
+            self.prefix_ctrl.SetFocus()
+        else:
+            self.title_ctrl.SetFocus()
+        self.Bind(wx.EVT_BUTTON, self._on_ok, id=wx.ID_OK)
+
+    def _on_ok(self, event: wx.CommandEvent) -> None:
+        prefix = self.prefix_ctrl.GetValue().strip()
+        title = self.title_ctrl.GetValue().strip()
+        digits = int(self.digits_ctrl.GetValue())
+        if self._mode == "create":
+            if not prefix:
+                wx.MessageBox(_("Document prefix is required."), _("Error"), wx.ICON_ERROR)
+                self.prefix_ctrl.SetFocus()
+                return
+            if not PREFIX_RE.match(prefix):
+                wx.MessageBox(
+                    _("Prefix must start with a capital letter and contain only letters, digits or underscores."),
+                    _("Error"),
+                    wx.ICON_ERROR,
+                )
+                self.prefix_ctrl.SetFocus()
+                return
+        if digits <= 0:
+            wx.MessageBox(_("Digits must be positive."), _("Error"), wx.ICON_ERROR)
+            self.digits_ctrl.SetFocus()
+            return
+        if not title:
+            title = prefix
+        self._result = DocumentProperties(prefix=prefix, title=title, digits=digits)
+        self.EndModal(wx.ID_OK)
+
+    def get_properties(self) -> DocumentProperties | None:
+        """Return document properties when dialog was accepted."""
+
+        return self._result

--- a/app/ui/document_tree.py
+++ b/app/ui/document_tree.py
@@ -13,9 +13,20 @@ from ..i18n import _
 class DocumentTree(wx.Panel):
     """Tree view of documents with selection callback."""
 
-    def __init__(self, parent: wx.Window, *, on_select: Callable[[str], None] | None = None) -> None:
+    def __init__(
+        self,
+        parent: wx.Window,
+        *,
+        on_select: Callable[[str], None] | None = None,
+        on_new_document: Callable[[str | None], None] | None = None,
+        on_rename_document: Callable[[str], None] | None = None,
+        on_delete_document: Callable[[str], None] | None = None,
+    ) -> None:
         super().__init__(parent)
         self._on_select = on_select
+        self._on_new_document = on_new_document
+        self._on_rename_document = on_rename_document
+        self._on_delete_document = on_delete_document
         self.tree = wx.TreeCtrl(self)
         sizer = wx.BoxSizer(wx.VERTICAL)
         sizer.Add(self.tree, 1, wx.EXPAND)
@@ -24,6 +35,16 @@ class DocumentTree(wx.Panel):
         self._prefix_for_id: Dict[wx.TreeItemId, str] = {}
         self.root = self.tree.AddRoot(_("Documents"))
         self.tree.Bind(wx.EVT_TREE_SEL_CHANGED, self._handle_select)
+        self.tree.Bind(wx.EVT_TREE_ITEM_MENU, self._show_context_menu)
+        self._menu_target_prefix: str | None = None
+        self._menu_ids = {
+            "new": wx.Window.NewControlId(),
+            "rename": wx.Window.NewControlId(),
+            "delete": wx.Window.NewControlId(),
+        }
+        self.Bind(wx.EVT_MENU, self._handle_menu_new, id=self._menu_ids["new"])
+        self.Bind(wx.EVT_MENU, self._handle_menu_rename, id=self._menu_ids["rename"])
+        self.Bind(wx.EVT_MENU, self._handle_menu_delete, id=self._menu_ids["delete"])
 
     def set_documents(self, docs: Dict[str, Document]) -> None:
         """Populate tree from mapping ``docs``."""
@@ -48,9 +69,73 @@ class DocumentTree(wx.Panel):
             add(prefix)
         self.tree.ExpandAll()
 
+    def select(self, prefix: str) -> None:
+        """Select tree item corresponding to ``prefix`` if present."""
+
+        node = self._node_for_prefix.get(prefix)
+        if node:
+            self.tree.SelectItem(node)
+            self.tree.EnsureVisible(node)
+
+    def get_selected_prefix(self) -> str | None:
+        """Return prefix associated with the currently selected node."""
+
+        item = self.tree.GetSelection()
+        if not item.IsOk():
+            return None
+        return self._prefix_for_id.get(item)
+
     def _handle_select(self, event: wx.TreeEvent) -> None:
         item = event.GetItem()
         prefix = self._prefix_for_id.get(item)
         if prefix and self._on_select:
             self._on_select(prefix)
         event.Skip()
+
+    def _show_context_menu(self, event: wx.TreeEvent) -> None:
+        item = event.GetItem()
+        if not item or not item.IsOk():
+            item = self.tree.GetSelection()
+        if not item or not item.IsOk():
+            item = self.root
+        self.tree.SelectItem(item)
+        prefix = self._prefix_for_id.get(item)
+        self._menu_target_prefix = prefix
+        menu = wx.Menu()
+        new_item = menu.Append(self._menu_ids["new"], _("New document"))
+        rename_item = menu.Append(self._menu_ids["rename"], _("Rename"))
+        delete_item = menu.Append(self._menu_ids["delete"], _("Delete"))
+        if self._on_new_document is None:
+            new_item.Enable(False)
+        if prefix is None or self._on_rename_document is None:
+            rename_item.Enable(False)
+        if prefix is None or self._on_delete_document is None:
+            delete_item.Enable(False)
+        self.tree.PopupMenu(menu)
+        menu.Destroy()
+        self._menu_target_prefix = None
+
+    def _handle_menu_new(self, _event: wx.CommandEvent) -> None:
+        if self._on_new_document is None:
+            return
+        parent_prefix = self._menu_target_prefix
+        self._menu_target_prefix = None
+        self._on_new_document(parent_prefix)
+
+    def _handle_menu_rename(self, _event: wx.CommandEvent) -> None:
+        if self._on_rename_document is None:
+            return
+        if self._menu_target_prefix is None:
+            return
+        prefix = self._menu_target_prefix
+        self._menu_target_prefix = None
+        self._on_rename_document(prefix)
+
+    def _handle_menu_delete(self, _event: wx.CommandEvent) -> None:
+        if self._on_delete_document is None:
+            return
+        if self._menu_target_prefix is None:
+            return
+        prefix = self._menu_target_prefix
+        self._menu_target_prefix = None
+        self._on_delete_document(prefix)


### PR DESCRIPTION
## Summary
- add a context menu to the document tree with actions for creating, renaming, and deleting documents
- implement dialog-driven document creation/renaming flows in the main frame and controller persistence helpers
- cover document filesystem operations with new unit tests for the documents controller

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68c87826efbc8320a8ce685b14385d5f