### PR TITLE
Refactor requirement services

### DIFF
--- a/app/mcp/tools_read.py
+++ b/app/mcp/tools_read.py
@@ -3,46 +3,23 @@ from __future__ import annotations
 from collections.abc import Sequence
 from pathlib import Path
 
-from ..core.doc_store import (
-    load_documents,
-    list_item_ids,
-    load_document,
-    load_item,
-    parse_rid,
-    rid_for,
-)
-from ..core.model import Requirement, requirement_from_dict, requirement_to_dict
-from ..core.search import filter_by_labels, filter_by_status, search
+from ..core import doc_store
+from ..core.model import requirement_to_dict
 from .utils import ErrorCode, log_tool, mcp_error
 
 
-def _load_all(directory: str | Path) -> list[Requirement]:
-    root = Path(directory)
-    docs = load_documents(root)
-    items: list[Requirement] = []
-    for prefix, doc in docs.items():
-        dir_path = root / prefix
-        for item_id in list_item_ids(dir_path, doc):
-            data, _ = load_item(dir_path, doc, item_id)
-            req = requirement_from_dict(data, doc_prefix=prefix, rid=rid_for(doc, item_id))
-            items.append(req)
-    return items
-
-
-def _paginate(requirements: Sequence[Requirement], page: int, per_page: int) -> dict:
-    if page < 1:
-        page = 1
-    if per_page < 1:
-        per_page = 1
-    total = len(requirements)
-    start = (page - 1) * per_page
-    end = start + per_page
-    items = []
-    for r in requirements[start:end]:
-        data = requirement_to_dict(r)
-        data["rid"] = r.rid
+def _page_to_payload(page: doc_store.RequirementPage) -> dict:
+    items: list[dict] = []
+    for req in page.items:
+        data = requirement_to_dict(req)
+        data["rid"] = req.rid
         items.append(data)
-    return {"total": total, "page": page, "per_page": per_page, "items": items}
+    return {
+        "total": page.total,
+        "page": page.page,
+        "per_page": page.per_page,
+        "items": items,
+    }
 
 
 def list_requirements(
@@ -61,7 +38,13 @@ def list_requirements(
         "labels": list(labels) if labels else None,
     }
     try:
-        reqs = _load_all(directory)
+        page_data = doc_store.list_requirements(
+            directory,
+            page=page,
+            per_page=per_page,
+            status=status,
+            labels=labels,
+        )
     except FileNotFoundError:
         return log_tool(
             "list_requirements",
@@ -72,23 +55,24 @@ def list_requirements(
                 {"directory": str(directory)},
             ),
         )
-    reqs = filter_by_status(reqs, status)
-    reqs = filter_by_labels(reqs, labels or [])
-    return log_tool("list_requirements", params, _paginate(reqs, page, per_page))
+    return log_tool("list_requirements", params, _page_to_payload(page_data))
 
 
 def get_requirement(directory: str | Path, rid: str) -> dict:
     params = {"directory": str(directory), "rid": rid}
     try:
-        prefix, item_id = parse_rid(rid)
-        doc = load_document(Path(directory) / prefix)
-        data, _ = load_item(Path(directory) / prefix, doc, item_id)
-        req = requirement_from_dict(data, doc_prefix=prefix, rid=rid)
-    except FileNotFoundError:
+        req = doc_store.get_requirement(directory, rid)
+    except ValueError as exc:
         return log_tool(
             "get_requirement",
             params,
-            mcp_error(ErrorCode.NOT_FOUND, f"requirement {rid} not found"),
+            mcp_error(ErrorCode.VALIDATION_ERROR, str(exc)),
+        )
+    except doc_store.RequirementNotFoundError as exc:
+        return log_tool(
+            "get_requirement",
+            params,
+            mcp_error(ErrorCode.NOT_FOUND, str(exc)),
         )
     except Exception as exc:  # pragma: no cover - defensive
         return log_tool(
@@ -96,7 +80,9 @@ def get_requirement(directory: str | Path, rid: str) -> dict:
             params,
             mcp_error(ErrorCode.INTERNAL, str(exc)),
         )
-    return log_tool("get_requirement", params, requirement_to_dict(req))
+    result = requirement_to_dict(req)
+    result["rid"] = req.rid
+    return log_tool("get_requirement", params, result)
 
 
 def search_requirements(
@@ -117,7 +103,14 @@ def search_requirements(
         "per_page": per_page,
     }
     try:
-        reqs = _load_all(directory)
+        page_data = doc_store.search_requirements(
+            directory,
+            query=query,
+            labels=labels,
+            status=status,
+            page=page,
+            per_page=per_page,
+        )
     except FileNotFoundError:
         return log_tool(
             "search_requirements",
@@ -128,6 +121,4 @@ def search_requirements(
                 {"directory": str(directory)},
             ),
         )
-    reqs = filter_by_status(reqs, status)
-    reqs = search(reqs, labels=labels, query=query)
-    return log_tool("search_requirements", params, _paginate(reqs, page, per_page))
+    return log_tool("search_requirements", params, _page_to_payload(page_data))


### PR DESCRIPTION
## Summary
- add shared requirement service helpers in the document store
- rewrite MCP read/write tools to call the new services
- update the CLI item creation path to reuse the shared helpers

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68c87c36f10c8320b7041c028e522ad9