### PR TITLE
Add CLI entry point for migrate_to_docs script

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,12 @@ into the document-based layout:
 python3 -m app.cli migrate to-docs <legacy_dir> --default SYS --rules "label:doc=HLR->HLR"
 ```
 
+Для быстрых проверок можно запускать скрипт напрямую:
+
+```bash
+python tools/migrate_to_docs.py requirements --rules 'label:doc=SYS->SYS' --default SYS
+```
+
 Files are assigned to documents according to label rules. Links between
 requirements are rewritten to the new RIDs. The resulting layout follows
 `requirements/<PREFIX>/items/<RID>.json`.

--- a/tools/migrate_to_docs.py
+++ b/tools/migrate_to_docs.py
@@ -162,3 +162,19 @@ def migrate_to_docs(directory: str | Path, *, rules: str | None = None, default:
         }
         with (doc_dir / "document.json").open("w", encoding="utf-8") as fh:
             json.dump(doc, fh, ensure_ascii=False, indent=2, sort_keys=True)
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Convert legacy flat requirements into document-based hierarchy.",
+    )
+    parser.add_argument("directory", help="Directory with legacy requirement files")
+    parser.add_argument(
+        "--rules",
+        help="Assignment rules in the form 'label:key=value->PREFIX;...'",
+    )
+    parser.add_argument("--default", required=True, help="Default document prefix")
+    cli_args = parser.parse_args()
+    migrate_to_docs(cli_args.directory, rules=cli_args.rules, default=cli_args.default)


### PR DESCRIPTION
## Summary
- add an argparse-based entry point so tools/migrate_to_docs.py can be executed directly
- document a direct execution example for the migration utility in the README

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68c8811de41c8320b3359b5bf8cf45cf