### PR TITLE
Fix resizing of label image list to avoid add errors

### DIFF
--- a/tests/gui/test_list_panel.py
+++ b/tests/gui/test_list_panel.py
@@ -167,6 +167,9 @@ def _build_wx_stub():
         def GetTextExtent(self, text):
             return (len(text) * 6, 10)
 
+        def DrawBitmap(self, bmp, x, y, use_mask=False):
+            pass
+
     class Dialog(Window):
         def __init__(self, parent=None, title=""):
             super().__init__(parent)
@@ -349,6 +352,8 @@ def _build_wx_stub():
             self._images = []
 
         def Add(self, bmp):
+            if bmp.GetWidth() != self._w or bmp.GetHeight() != self._h:
+                raise ValueError("bitmap size mismatch")
             self._images.append(bmp)
             return len(self._images) - 1
 
@@ -717,6 +722,107 @@ def test_labels_column_uses_imagelist(monkeypatch):
     else:
         assert panel.list._col_images[(0, labels_col)] >= 0
         assert panel.list._item_images[0] == -1
+
+
+def test_label_imagelist_handles_resizes(monkeypatch):
+    wx_stub, mixins, ulc = _build_wx_stub()
+    agw = types.SimpleNamespace(ultimatelistctrl=ulc)
+    monkeypatch.setitem(sys.modules, "wx", wx_stub)
+    monkeypatch.setitem(sys.modules, "wx.lib.mixins.listctrl", mixins)
+    monkeypatch.setitem(sys.modules, "wx.lib.agw", agw)
+    monkeypatch.setitem(sys.modules, "wx.lib.agw.ultimatelistctrl", ulc)
+
+    list_panel_module = importlib.import_module("app.ui.list_panel")
+    importlib.reload(list_panel_module)
+    requirement_model_cls = importlib.import_module(
+        "app.ui.requirement_model",
+    ).RequirementModel
+    list_panel_cls = list_panel_module.ListPanel
+
+    frame = wx_stub.Panel(None)
+    panel = list_panel_cls(frame, model=requirement_model_cls())
+    panel.set_columns(["labels"])
+
+    # initial narrow label
+    panel.set_requirements([_req(1, "A", labels=["aa"])])
+    first_w, first_h = panel.list.GetImageList(wx_stub.IMAGE_LIST_SMALL).GetSize()
+    assert first_w > 0
+    assert first_h > 0
+    assert panel._label_images[("aa",)] == 0
+
+    # introduce wider label, which should resize the list but keep the first image
+    panel.set_requirements(
+        [
+            _req(1, "A", labels=["aa"]),
+            _req(2, "B", labels=["averylonglabelhere"]),
+        ]
+    )
+    second_w, second_h = panel.list.GetImageList(wx_stub.IMAGE_LIST_SMALL).GetSize()
+    assert second_w >= first_w
+    assert second_h >= first_h
+    assert panel._label_images[("aa",)] >= 0
+    assert panel._label_images[("averylonglabelhere",)] >= 0
+
+    # add a shorter label after resizing to ensure padding works
+    panel.set_requirements(
+        [
+            _req(1, "A", labels=["aa"]),
+            _req(2, "B", labels=["averylonglabelhere"]),
+            _req(3, "C", labels=["mid"]),
+        ]
+    )
+    third_w, third_h = panel.list.GetImageList(wx_stub.IMAGE_LIST_SMALL).GetSize()
+    assert third_w == second_w
+    assert third_h == second_h
+    assert panel._label_images[("mid",)] >= 0
+
+    labels_col = panel._field_order.index("labels")
+    for row in range(3):
+        if labels_col == 0:
+            assert panel.list._item_images[row] >= 0
+        else:
+            assert panel.list._col_images[(row, labels_col)] >= 0
+
+
+def test_label_image_add_failure_falls_back_to_text(monkeypatch):
+    wx_stub, mixins, ulc = _build_wx_stub()
+    agw = types.SimpleNamespace(ultimatelistctrl=ulc)
+    monkeypatch.setitem(sys.modules, "wx", wx_stub)
+    monkeypatch.setitem(sys.modules, "wx.lib.mixins.listctrl", mixins)
+    monkeypatch.setitem(sys.modules, "wx.lib.agw", agw)
+    monkeypatch.setitem(sys.modules, "wx.lib.agw.ultimatelistctrl", ulc)
+
+    list_panel_module = importlib.import_module("app.ui.list_panel")
+    importlib.reload(list_panel_module)
+    requirement_model_cls = importlib.import_module(
+        "app.ui.requirement_model",
+    ).RequirementModel
+    list_panel_cls = list_panel_module.ListPanel
+
+    frame = wx_stub.Panel(None)
+    panel = list_panel_cls(frame, model=requirement_model_cls())
+    panel.set_columns(["labels"])
+    panel.set_requirements([_req(1, "A", labels=["aa"])])
+
+    # ensure next addition triggers fallback
+    panel._label_images.clear()
+    panel._image_list = panel.list.GetImageList(wx_stub.IMAGE_LIST_SMALL)
+
+    def fail_add(_bmp):
+        return -1
+
+    panel._image_list.Add = fail_add
+    panel.set_requirements([_req(2, "B", labels=["bb"])])
+
+    labels_col = panel._field_order.index("labels")
+    if labels_col == 0:
+        assert panel.list._item_images[0] == -1
+        assert panel.list._items[0] == "bb"
+    else:
+        assert panel.list._col_images[(0, labels_col)] == -1
+        assert panel.list._cells[(0, labels_col)] == "bb"
+        assert panel.list._item_images[0] == -1
+    assert panel._label_images[("bb",)] == -1
 
 
 def test_sort_by_labels(monkeypatch):


### PR DESCRIPTION
## Summary
- normalize label images to the current image list size and pad existing bitmaps when resizing
- add graceful fallback to textual labels if the image list rejects a bitmap
- harden GUI stubs and extend list panel tests to cover resizing and failure scenarios

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68c881632f448320be97d6b0b75beb22