### PR TITLE
Anchor settings help popups to the dialog

### DIFF
--- a/app/ui/editor_panel.py
+++ b/app/ui/editor_panel.py
@@ -34,7 +34,7 @@ from ..util.time import local_now_str, normalize_timestamp
 from ..i18n import _
 from . import locale
 from .enums import ENUMS
-from .helpers import AutoHeightListCtrl, HelpStaticBox, make_help_button, show_help
+from .helpers import AutoHeightListCtrl, HelpStaticBox, make_help_button
 from .label_selection_dialog import LabelSelectionDialog
 
 logger = logging.getLogger(__name__)
@@ -269,7 +269,6 @@ class EditorPanel(ScrolledPanel):
             self,
             _("Attachments"),
             self._help_texts["attachments"],
-            lambda msg: show_help(self, msg),
         )
         a_box = a_sizer.GetStaticBox()
         self.attachments_list = AutoHeightListCtrl(
@@ -327,7 +326,6 @@ class EditorPanel(ScrolledPanel):
             self,
             _("Labels"),
             self._help_texts["labels"],
-            lambda msg: show_help(self, msg),
         )
         box = box_sizer.GetStaticBox()
         row = wx.BoxSizer(wx.HORIZONTAL)
@@ -432,7 +430,6 @@ class EditorPanel(ScrolledPanel):
             self,
             label,
             self._help_texts[help_key],
-            lambda msg: show_help(self, msg),
         )
         box = sizer.GetStaticBox()
         row = wx.BoxSizer(wx.HORIZONTAL)

--- a/app/ui/settings_dialog.py
+++ b/app/ui/settings_dialog.py
@@ -159,7 +159,7 @@ class SettingsDialog(wx.Dialog):
         )
         base_sz.Add(self._base_url, 1, wx.ALIGN_CENTER_VERTICAL)
         base_sz.Add(
-            make_help_button(llm, LLM_HELP["base_url"]),
+            make_help_button(llm, LLM_HELP["base_url"], dialog_parent=self),
             0,
             wx.ALIGN_CENTER_VERTICAL | wx.LEFT,
             5,
@@ -174,7 +174,7 @@ class SettingsDialog(wx.Dialog):
         )
         model_sz.Add(self._model, 1, wx.ALIGN_CENTER_VERTICAL)
         model_sz.Add(
-            make_help_button(llm, LLM_HELP["model"]),
+            make_help_button(llm, LLM_HELP["model"], dialog_parent=self),
             0,
             wx.ALIGN_CENTER_VERTICAL | wx.LEFT,
             5,
@@ -189,7 +189,7 @@ class SettingsDialog(wx.Dialog):
         )
         key_sz.Add(self._api_key, 1, wx.ALIGN_CENTER_VERTICAL)
         key_sz.Add(
-            make_help_button(llm, LLM_HELP["api_key"]),
+            make_help_button(llm, LLM_HELP["api_key"], dialog_parent=self),
             0,
             wx.ALIGN_CENTER_VERTICAL | wx.LEFT,
             5,
@@ -222,7 +222,7 @@ class SettingsDialog(wx.Dialog):
         )
         timeout_sz.Add(self._timeout, 1, wx.ALIGN_CENTER_VERTICAL)
         timeout_sz.Add(
-            make_help_button(llm, LLM_HELP["timeout_minutes"]),
+            make_help_button(llm, LLM_HELP["timeout_minutes"], dialog_parent=self),
             0,
             wx.ALIGN_CENTER_VERTICAL | wx.LEFT,
             5,
@@ -281,7 +281,7 @@ class SettingsDialog(wx.Dialog):
         )
         host_sz.Add(self._host, 1, wx.ALIGN_CENTER_VERTICAL)
         host_sz.Add(
-            make_help_button(mcp, MCP_HELP["host"]),
+            make_help_button(mcp, MCP_HELP["host"], dialog_parent=self),
             0,
             wx.ALIGN_CENTER_VERTICAL | wx.LEFT,
             5,
@@ -296,7 +296,7 @@ class SettingsDialog(wx.Dialog):
         )
         port_sz.Add(self._port, 1, wx.ALIGN_CENTER_VERTICAL)
         port_sz.Add(
-            make_help_button(mcp, MCP_HELP["port"]),
+            make_help_button(mcp, MCP_HELP["port"], dialog_parent=self),
             0,
             wx.ALIGN_CENTER_VERTICAL | wx.LEFT,
             5,
@@ -311,7 +311,7 @@ class SettingsDialog(wx.Dialog):
         )
         base_sz.Add(self._base_path, 1, wx.ALIGN_CENTER_VERTICAL)
         base_sz.Add(
-            make_help_button(mcp, MCP_HELP["base_path"]),
+            make_help_button(mcp, MCP_HELP["base_path"], dialog_parent=self),
             0,
             wx.ALIGN_CENTER_VERTICAL | wx.LEFT,
             5,
@@ -320,7 +320,7 @@ class SettingsDialog(wx.Dialog):
         token_toggle_sz = wx.BoxSizer(wx.HORIZONTAL)
         token_toggle_sz.Add(self._require_token, 0, wx.ALIGN_CENTER_VERTICAL)
         token_toggle_sz.Add(
-            make_help_button(mcp, MCP_HELP["require_token"]),
+            make_help_button(mcp, MCP_HELP["require_token"], dialog_parent=self),
             0,
             wx.ALIGN_CENTER_VERTICAL | wx.LEFT,
             5,
@@ -335,7 +335,7 @@ class SettingsDialog(wx.Dialog):
         )
         token_sz.Add(self._token, 1, wx.ALIGN_CENTER_VERTICAL)
         token_sz.Add(
-            make_help_button(mcp, MCP_HELP["token"]),
+            make_help_button(mcp, MCP_HELP["token"], dialog_parent=self),
             0,
             wx.ALIGN_CENTER_VERTICAL | wx.LEFT,
             5,

--- a/tests/gui/test_help_static_box.py
+++ b/tests/gui/test_help_static_box.py
@@ -6,7 +6,7 @@ from app.ui.helpers import HelpStaticBox
 pytestmark = pytest.mark.gui
 
 
-def _noop(msg: str) -> None:  # pragma: no cover - placeholder callback
+def _noop(anchor: wx.Window, msg: str) -> None:  # pragma: no cover - placeholder callback
     pass
 
 
@@ -37,3 +37,47 @@ def test_help_static_box_handles_prepend_and_insert(wx_app):
     assert sizer.GetItem(3).GetWindow() is second
     assert sizer.GetItemCount() == 4
     frame.Destroy()
+
+
+def test_calculate_popup_position_prefers_right():
+    from app.ui import helpers
+
+    anchor = wx.Rect(100, 100, 40, 20)
+    popup = wx.Size(200, 120)
+    display = wx.Rect(0, 0, 800, 600)
+
+    x, y = helpers._calculate_popup_position(anchor, popup, display)
+    assert (x, y) == (148, 100)
+
+
+def test_calculate_popup_position_uses_left_when_needed():
+    from app.ui import helpers
+
+    anchor = wx.Rect(700, 120, 80, 30)
+    popup = wx.Size(200, 100)
+    display = wx.Rect(0, 0, 800, 600)
+
+    x, y = helpers._calculate_popup_position(anchor, popup, display)
+    assert (x, y) == (492, 120)
+
+
+def test_calculate_popup_position_falls_back_below():
+    from app.ui import helpers
+
+    anchor = wx.Rect(40, 40, 260, 80)
+    popup = wx.Size(200, 120)
+    display = wx.Rect(0, 0, 320, 600)
+
+    x, y = helpers._calculate_popup_position(anchor, popup, display)
+    assert (x, y) == (40, 128)
+
+
+def test_calculate_popup_position_clamps_to_screen():
+    from app.ui import helpers
+
+    anchor = wx.Rect(0, 0, 10, 10)
+    popup = wx.Size(300, 260)
+    display = wx.Rect(0, 0, 200, 150)
+
+    x, y = helpers._calculate_popup_position(anchor, popup, display)
+    assert (x, y) == (8, 8)

--- a/tests/gui/test_settings_dialog.py
+++ b/tests/gui/test_settings_dialog.py
@@ -260,8 +260,12 @@ def test_settings_help_buttons(monkeypatch, wx_app):
     from app.ui import helpers
     from app.ui.settings_dialog import LLM_HELP, MCP_HELP, SettingsDialog
 
-    shown: list[str] = []
-    monkeypatch.setattr(helpers, "show_help", lambda parent, msg: shown.append(msg))
+    shown: list[tuple[wx.Window | None, wx.Window | None, str]] = []
+
+    def _fake_show_help(parent, msg, *, anchor=None, **_kwargs):
+        shown.append((parent, anchor, msg))
+
+    monkeypatch.setattr(helpers, "show_help", _fake_show_help)
 
     dlg = SettingsDialog(
         None,
@@ -288,7 +292,7 @@ def test_settings_help_buttons(monkeypatch, wx_app):
         if isinstance(item.GetWindow(), wx.Button)
     )
     base_btn.GetEventHandler().ProcessEvent(wx.CommandEvent(wx.EVT_BUTTON.typeId))
-    assert shown[-1] == LLM_HELP["base_url"]
+    assert shown[-1] == (dlg, base_btn, LLM_HELP["base_url"])
 
     host_btn = next(
         item.GetWindow()
@@ -296,6 +300,6 @@ def test_settings_help_buttons(monkeypatch, wx_app):
         if isinstance(item.GetWindow(), wx.Button)
     )
     host_btn.GetEventHandler().ProcessEvent(wx.CommandEvent(wx.EVT_BUTTON.typeId))
-    assert shown[-1] == MCP_HELP["host"]
+    assert shown[-1] == (dlg, host_btn, MCP_HELP["host"])
 
     dlg.Destroy()


### PR DESCRIPTION
## Summary
- extend `make_help_button` so callers can override the window that owns the popup dialog
- use the new hook in the settings dialog to keep every hint window anchored to the question-mark buttons
- update the GUI regression test to assert that settings help buttons pass both the dialog parent and the triggering control

## Testing
- pytest tests/gui/test_help_static_box.py tests/gui/test_settings_dialog.py -q

------
https://chatgpt.com/codex/tasks/task_e_68c8816d2cd08320904e8ffc65bb65f4