### PR TITLE
Centralize linking logic and validate labels

### DIFF
--- a/app/mcp/tools_write.py
+++ b/app/mcp/tools_write.py
@@ -4,8 +4,7 @@ from pathlib import Path
 from typing import Any, Mapping
 
 from ..core import doc_store
-from ..core.doc_store import is_ancestor, load_documents, load_item, parse_rid, save_item
-from ..core.model import requirement_from_dict, requirement_to_dict
+from ..core.model import requirement_to_dict
 from .utils import ErrorCode, log_tool, mcp_error
 
 
@@ -132,63 +131,32 @@ def link_requirements(
         "link_type": link_type,
         "rev": rev,
     }
-    if link_type != "parent":
-        return log_tool(
-            "link_requirements",
-            params,
-            mcp_error(ErrorCode.VALIDATION_ERROR, f"invalid link_type: {link_type}"),
-        )
     try:
-        src_prefix, src_id = parse_rid(source_rid)
-        dst_prefix, dst_id = parse_rid(derived_rid)
-    except ValueError as exc:
+        req = doc_store.link_requirements(
+            directory,
+            source_rid=source_rid,
+            derived_rid=derived_rid,
+            link_type=link_type,
+            expected_revision=rev,
+        )
+    except doc_store.ValidationError as exc:
         return log_tool(
             "link_requirements",
             params,
             mcp_error(ErrorCode.VALIDATION_ERROR, str(exc)),
         )
-    docs = load_documents(directory)
-    src_doc = docs.get(src_prefix)
-    dst_doc = docs.get(dst_prefix)
-    if src_doc is None or dst_doc is None:
+    except doc_store.RevisionMismatchError as exc:
         return log_tool(
             "link_requirements",
             params,
-            mcp_error(ErrorCode.NOT_FOUND, "document not found"),
+            mcp_error(ErrorCode.CONFLICT, str(exc)),
         )
-    if not is_ancestor(dst_prefix, src_prefix, docs):
+    except doc_store.RequirementNotFoundError as exc:
         return log_tool(
             "link_requirements",
             params,
-            mcp_error(ErrorCode.VALIDATION_ERROR, f"invalid link target: {source_rid}"),
+            mcp_error(ErrorCode.NOT_FOUND, str(exc)),
         )
-    src_dir = Path(directory) / src_prefix
-    dst_dir = Path(directory) / dst_prefix
-    try:
-        load_item(src_dir, src_doc, src_id)
-        data, _ = load_item(dst_dir, dst_doc, dst_id)
-    except FileNotFoundError:
-        return log_tool(
-            "link_requirements",
-            params,
-            mcp_error(ErrorCode.NOT_FOUND, "requirement not found"),
-        )
-    current = data.get("revision", 1)
-    if current != rev:
-        return log_tool(
-            "link_requirements",
-            params,
-            mcp_error(
-                ErrorCode.CONFLICT,
-                f"revision mismatch: expected {rev}, have {current}",
-            ),
-        )
-    links = sorted(set(data.get("links", [])) | {source_rid})
-    data["links"] = links
-    data["revision"] = current + 1
-    try:
-        req = requirement_from_dict(data, doc_prefix=dst_prefix, rid=derived_rid)
-        save_item(dst_dir, dst_doc, requirement_to_dict(req))
     except Exception as exc:  # pragma: no cover - defensive
         return log_tool(
             "link_requirements", params, mcp_error(ErrorCode.INTERNAL, str(exc))


### PR DESCRIPTION
## Summary
- add a dedicated doc_store.link_requirements helper and switch the MCP tool to use it
- tighten label normalization to reject non-list inputs such as bare strings
- extend MCP writer tests to cover label type validation and invalid link types

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68c8fdc4e28c83208bcd863d44d594ec