### PR TITLE
Refactor config schema and add coverage

### DIFF
--- a/tests/unit/test_config_manager.py
+++ b/tests/unit/test_config_manager.py
@@ -28,6 +28,99 @@ class DummyListPanel:
         self.saved_order = True
 
 
+def _const(value):
+    def factory(_tmp_path):
+        if isinstance(value, list):
+            return list(value)
+        return value
+
+    return factory
+
+
+def _list_columns_factory(_tmp_path):
+    return ["id", "title"]
+
+
+def _recent_dirs_factory(tmp_path):
+    return [str(tmp_path / "a"), str(tmp_path / "b")]
+
+
+@pytest.mark.parametrize(
+    ("name", "expected"),
+    [
+        ("list_columns", []),
+        ("recent_dirs", []),
+        ("auto_open_last", False),
+        ("remember_sort", False),
+        ("language", None),
+        ("mcp_port", 59362),
+        ("llm_max_output_tokens", None),
+        ("sort_column", -1),
+        ("sort_ascending", True),
+        ("log_shown", False),
+        ("win_w", 800),
+    ],
+)
+def test_schema_default_values(tmp_path, wx_app, name, expected):
+    cfg = ConfigManager(app_name="TestApp", path=tmp_path / "cfg.ini")
+
+    assert cfg.get_value(name) == expected
+
+
+@pytest.mark.parametrize(
+    ("name", "value_factory", "expected_factory"),
+    [
+        pytest.param("list_columns", _list_columns_factory, _list_columns_factory, id="list_columns"),
+        pytest.param("recent_dirs", _recent_dirs_factory, _recent_dirs_factory, id="recent_dirs"),
+        pytest.param("auto_open_last", _const(True), _const(True), id="auto_open_last"),
+        pytest.param("remember_sort", _const(True), _const(True), id="remember_sort"),
+        pytest.param("language", _const("fr"), _const("fr"), id="language-set"),
+        pytest.param("language", _const(None), _const(None), id="language-none"),
+        pytest.param("mcp_host", _const("10.0.0.1"), _const("10.0.0.1"), id="mcp_host"),
+        pytest.param("mcp_port", _const(6543), _const(6543), id="mcp_port"),
+        pytest.param("mcp_require_token", _const(True), _const(True), id="mcp_require_token"),
+        pytest.param("mcp_token", _const("secret"), _const("secret"), id="mcp_token"),
+        pytest.param("llm_base_url", _const("http://api"), _const("http://api"), id="llm_base_url"),
+        pytest.param("llm_model", _const("model"), _const("model"), id="llm_model"),
+        pytest.param("llm_api_key", _const("secret"), _const("secret"), id="llm_api_key"),
+        pytest.param("llm_api_key", _const(None), _const(None), id="llm_api_key-none"),
+        pytest.param("llm_max_retries", _const(7), _const(7), id="llm_max_retries"),
+        pytest.param("llm_max_output_tokens", _const(128), _const(128), id="llm_max_output_tokens"),
+        pytest.param("llm_max_output_tokens", _const(None), _const(None), id="llm_max_output_tokens-none"),
+        pytest.param("llm_timeout_minutes", _const(12), _const(12), id="llm_timeout"),
+        pytest.param("llm_stream", _const(True), _const(True), id="llm_stream"),
+        pytest.param("sort_column", _const(5), _const(5), id="sort_column"),
+        pytest.param("sort_ascending", _const(False), _const(False), id="sort_ascending"),
+        pytest.param("log_sash", _const(512), _const(512), id="log_sash"),
+        pytest.param("log_shown", _const(True), _const(True), id="log_shown"),
+        pytest.param("win_w", _const(1024), _const(1024), id="win_w"),
+    ],
+)
+def test_schema_round_trip(tmp_path, wx_app, name, value_factory, expected_factory):
+    cfg = ConfigManager(app_name="TestApp", path=tmp_path / "cfg.ini")
+
+    value = value_factory(tmp_path)
+    cfg.set_value(name, value)
+    cfg.flush()
+
+    assert cfg.get_value(name) == expected_factory(tmp_path)
+
+
+def test_schema_legacy_llm_base(tmp_path, wx_app):
+    cfg = ConfigManager(app_name="TestApp", path=tmp_path / "cfg.ini")
+
+    cfg.write("llm_api_base", "http://legacy")
+    cfg.flush()
+
+    assert cfg.get_value("llm_base_url") == "http://legacy"
+
+
+def test_schema_override_default(tmp_path, wx_app):
+    cfg = ConfigManager(app_name="TestApp", path=tmp_path / "cfg.ini")
+
+    assert cfg.get_value("log_sash", default=123) == 123
+
+
 @pytest.mark.parametrize("log_shown", [True, False])
 def test_save_and_restore_layout(tmp_path, log_shown, wx_app):
     wx = pytest.importorskip("wx")


### PR DESCRIPTION
## Summary
- define a FieldSpec schema for every persisted configuration entry
- route ConfigManager helpers through the schema-driven get_value/set_value accessors
- extend the config manager test suite with schema default/round-trip cases and legacy fallback coverage

## Testing
- pytest tests/unit/test_config_manager.py -q
- pytest -q *(fails: segfault in wx GUI tests during restore_layout)*

------
https://chatgpt.com/codex/tasks/task_e_68c90c737e108320bfe9cd62ba6d3cbd