### PR TITLE
Guard against duplicate requirement IDs

### DIFF
--- a/app/core/document_store/__init__.py
+++ b/app/core/document_store/__init__.py
@@ -42,6 +42,16 @@ class RevisionMismatchError(RequirementError):
         super().__init__(f"revision mismatch: expected {expected}, have {actual}")
 
 
+class RequirementIDCollisionError(RequirementError):
+    """Raised when attempting to reuse an existing requirement identifier."""
+
+    def __init__(self, doc_prefix: str, req_id: int, *, rid: str | None = None) -> None:
+        self.doc_prefix = doc_prefix
+        self.req_id = req_id
+        self.rid = rid or f"{doc_prefix}{req_id}"
+        super().__init__(f"requirement {self.rid} already exists")
+
+
 @dataclass
 class LabelDef:
     """Definition of a label available to document items."""
@@ -122,6 +132,7 @@ __all__ = [
     "DocumentNotFoundError",
     "RequirementNotFoundError",
     "RevisionMismatchError",
+    "RequirementIDCollisionError",
     "LabelDef",
     "DocumentLabels",
     "Document",

--- a/app/ui/main_frame.py
+++ b/app/ui/main_frame.py
@@ -11,7 +11,12 @@ from ..agent import LocalAgent
 from ..config import ConfigManager
 from ..confirm import confirm
 from ..core.model import Requirement
-from ..core.document_store import Document, LabelDef, save_document
+from ..core.document_store import (
+    Document,
+    LabelDef,
+    RequirementIDCollisionError,
+    save_document,
+)
 from ..i18n import _
 from ..log import logger
 from ..mcp.controller import MCPController
@@ -642,6 +647,8 @@ class MainFrame(wx.Frame):
             self.editor.save(
                 self.current_dir / self.current_doc_prefix, doc=doc
             )
+        except RequirementIDCollisionError:
+            return
         except Exception as exc:  # pragma: no cover - GUI event
             wx.MessageBox(str(exc), _("Error"), wx.ICON_ERROR)
             return

--- a/tests/gui/test_editor_duplicate_id.py
+++ b/tests/gui/test_editor_duplicate_id.py
@@ -1,0 +1,72 @@
+import pytest
+
+from pathlib import Path
+
+from app.core.document_store import (
+    Document,
+    RequirementIDCollisionError,
+    load_document,
+    save_document,
+    save_item,
+)
+from app.core.model import (
+    Requirement,
+    RequirementType,
+    Status,
+    Priority,
+    Verification,
+    requirement_to_dict,
+)
+from app.ui.editor_panel import EditorPanel
+
+pytestmark = pytest.mark.gui
+
+
+def _make_requirement(req_id: int) -> Requirement:
+    return Requirement(
+        id=req_id,
+        title="Existing",
+        statement="Statement",
+        type=RequirementType.REQUIREMENT,
+        status=Status.DRAFT,
+        owner="owner",
+        priority=Priority.MEDIUM,
+        source="source",
+        verification=Verification.ANALYSIS,
+    )
+
+
+def test_editor_save_rejects_duplicate_id(monkeypatch, wx_app, tmp_path: Path) -> None:
+    wx = pytest.importorskip("wx")
+    doc = Document(prefix="SYS", title="System", digits=3)
+    doc_dir = tmp_path / "SYS"
+    save_document(doc_dir, doc)
+    save_item(doc_dir, doc, requirement_to_dict(_make_requirement(1)))
+
+    frame = wx.Frame(None)
+    panel = EditorPanel(frame)
+    panel.set_directory(doc_dir)
+    panel.new_requirement()
+    panel.fields["id"].ChangeValue("1")
+    panel.fields["title"].ChangeValue("Duplicate")
+    panel.fields["statement"].ChangeValue("Copy")
+
+    messages: list[str] = []
+
+    import app.ui.editor_panel as editor_module
+
+    def fake_message(message: str, caption: str, style: int = 0) -> int:
+        messages.append(message)
+        return wx.ID_OK
+
+    monkeypatch.setattr(editor_module.wx, "MessageBox", fake_message)
+
+    with pytest.raises(RequirementIDCollisionError):
+        panel.save(doc_dir, doc=load_document(doc_dir))
+
+    assert messages, "duplicate warning should be shown"
+    assert "already exists" in messages[0]
+    assert panel._id_conflict is True
+
+    panel.Destroy()
+    frame.Destroy()


### PR DESCRIPTION
## Summary
- add a RequirementIDCollisionError for reuse when requirement IDs collide
- validate new IDs inside DocumentsController add/save helpers to stop duplicates
- enhance EditorPanel to cache known IDs, flag duplicates in the UI, and abort saving with a message box that is handled gracefully in MainFrame
- cover the new behaviour with unit and GUI tests for duplicate IDs

## Testing
- `pytest -q` *(fails: segmentation fault inside wx GUI tests)*

------
https://chatgpt.com/codex/tasks/task_e_68c91e18ea908320a5b46d90859a21e0