### PR TITLE
Improve legacy requirement loading and error handling

### DIFF
--- a/app/ui/document_tree.py
+++ b/app/ui/document_tree.py
@@ -90,6 +90,9 @@ class DocumentTree(wx.Panel):
 
     def _handle_select(self, event: wx.TreeEvent) -> None:
         item = event.GetItem()
+        if not item or not getattr(item, "IsOk", lambda: False)():
+            event.Skip()
+            return
         prefix = self._prefix_for_id.get(item)
         if prefix and self._on_select:
             self._on_select(prefix)

--- a/tests/unit/test_document_tree.py
+++ b/tests/unit/test_document_tree.py
@@ -209,3 +209,15 @@ def test_root_context_keeps_existing_selection(document_tree_module):
     tree.tree.SelectItem(node)
     tree._show_menu_for_item(None, allow_selection_fallback=False)
     assert tree.tree.GetSelection() is node
+
+
+def test_document_tree_ignores_invalid_selection(document_tree_module):
+    wx_stub, module = document_tree_module
+    parent = wx_stub.Panel(None)
+    selected: list[str] = []
+
+    tree = module.DocumentTree(parent, on_select=selected.append)
+    event = wx_stub.TreeEvent()
+    tree._handle_select(event)
+
+    assert selected == []

--- a/tests/unit/test_model.py
+++ b/tests/unit/test_model.py
@@ -60,6 +60,25 @@ def test_requirement_prefix_and_rid():
     assert "rid" not in roundtrip
 
 
+def test_requirement_from_dict_missing_metadata_defaults():
+    data = {
+        "id": "7",
+        "statement": "Legacy statement",
+    }
+    req = requirement_from_dict(data)
+    assert req.id == 7
+    assert req.title == ""
+    assert req.type is RequirementType.REQUIREMENT
+    assert req.status is Status.DRAFT
+    assert req.owner == ""
+    assert req.priority is Priority.MEDIUM
+    assert req.source == ""
+    assert req.verification is Verification.ANALYSIS
+    assert req.labels == []
+    assert req.links == []
+    assert req.revision == 1
+
+
 def test_requirement_extended_roundtrip():
     req = Requirement(
         id=7,
@@ -119,4 +138,14 @@ def test_requirement_from_dict_rejects_text_field():
         "verification": "analysis",
     }
     with pytest.raises(KeyError):
+        requirement_from_dict(data)
+
+
+def test_requirement_from_dict_rejects_invalid_revision():
+    data = {
+        "id": 1,
+        "statement": "S",
+        "revision": "beta",
+    }
+    with pytest.raises(TypeError):
         requirement_from_dict(data)


### PR DESCRIPTION
## Summary
- relax requirement_from_dict to provide sensible defaults for missing legacy fields and validate numeric identifiers
- migrate legacy JSON items through the domain model so generated files include full metadata
- handle document load failures in the main frame by reporting the error and clear the tree selection safely
- guard tree selection handler against invalid wx items and extend unit coverage

## Testing
- pytest tests/unit -q
- pytest -q *(fails: wx GUI tests crash with segmentation fault even under xvfb-run)*

------
https://chatgpt.com/codex/tasks/task_e_68c9250c29c0832087786e51bd5b73f6