### PR TITLE
Translate MCP help strings to English

### DIFF
--- a/app/locale/en/LC_MESSAGES/CookaReq.po
+++ b/app/locale/en/LC_MESSAGES/CookaReq.po
@@ -504,9 +504,6 @@ msgstr "running"
 msgid "MCP is a local server providing tools for requirement management used by agents and the LLM."
 msgstr "MCP is a local server providing tools for requirement management used by agents and the LLM."
 
-msgid "Запускать MCP-сервер автоматически при старте CookaReq."
-msgstr "Start the MCP server automatically when CookaReq launches."
-
 msgid "path to JSON/TOML settings"
 msgstr "path to JSON/TOML settings"
 
@@ -515,6 +512,36 @@ msgstr "ready"
 
 msgid "verify LLM and MCP settings"
 msgstr "verify LLM and MCP settings"
+
+msgid "Base URL of the LLM API. Example: https://api.openai.com/v1\nRequired; defines where requests are sent."
+msgstr "Base URL of the LLM API. Example: https://api.openai.com/v1\nRequired; defines where requests are sent."
+
+msgid "LLM model name. Example: gpt-4-turbo\nRequired; selects which model to use."
+msgstr "LLM model name. Example: gpt-4-turbo\nRequired; selects which model to use."
+
+msgid "LLM access key. Example: sk-XXXX\nRequired when the service needs authentication."
+msgstr "LLM access key. Example: sk-XXXX\nRequired when the service needs authentication."
+
+msgid "HTTP request timeout in minutes. Example: 1\nOptional; defaults to 60 minutes."
+msgstr "HTTP request timeout in minutes. Example: 1\nOptional; defaults to 60 minutes."
+
+msgid "Start the MCP server automatically when CookaReq launches."
+msgstr "Start the MCP server automatically when CookaReq launches."
+
+msgid "Hostname for the MCP server. Example: 127.0.0.1\nRequired; defines where to run the server."
+msgstr "Hostname for the MCP server. Example: 127.0.0.1\nRequired; defines where to run the server."
+
+msgid "MCP server port. Example: 8123\nRequired field."
+msgstr "MCP server port. Example: 8123\nRequired field."
+
+msgid "Base folder with requirements. Example: /tmp/reqs\nRequired; the server serves files from this directory."
+msgstr "Base folder with requirements. Example: /tmp/reqs\nRequired; the server serves files from this directory."
+
+msgid "When enabled, the server requires an authentication token."
+msgstr "When enabled, the server requires an authentication token."
+
+msgid "Access token for MCP. Example: secret123\nRequired when \"Require token\" is enabled."
+msgstr "Access token for MCP. Example: secret123\nRequired when \"Require token\" is enabled."
 
 # Updated help texts for requirement fields
 msgid ""

--- a/app/locale/ru/LC_MESSAGES/CookaReq.po
+++ b/app/locale/ru/LC_MESSAGES/CookaReq.po
@@ -516,6 +516,36 @@ msgstr "готов"
 msgid "verify LLM and MCP settings"
 msgstr "проверить настройки LLM и MCP"
 
+msgid "Base URL of the LLM API. Example: https://api.openai.com/v1\nRequired; defines where requests are sent."
+msgstr "Базовый URL LLM API. Пример: https://api.openai.com/v1\nОбязательное поле; определяет, куда отправляются запросы."
+
+msgid "LLM model name. Example: gpt-4-turbo\nRequired; selects which model to use."
+msgstr "Имя модели LLM. Пример: gpt-4-turbo\nОбязательное поле; определяет используемую модель."
+
+msgid "LLM access key. Example: sk-XXXX\nRequired when the service needs authentication."
+msgstr "Ключ доступа к LLM. Пример: sk-XXXX\nОбязателен, если сервис требует авторизации."
+
+msgid "HTTP request timeout in minutes. Example: 1\nOptional; defaults to 60 minutes."
+msgstr "Тайм-аут HTTP-запроса в минутах. Пример: 1\nНеобязательное поле; по умолчанию 60 минут."
+
+msgid "Start the MCP server automatically when CookaReq launches."
+msgstr "Запускать MCP-сервер автоматически при старте CookaReq."
+
+msgid "Hostname for the MCP server. Example: 127.0.0.1\nRequired; defines where to run the server."
+msgstr "Адрес хоста MCP-сервера. Пример: 127.0.0.1\nОбязательное поле; определяет, где запускать сервер."
+
+msgid "MCP server port. Example: 8123\nRequired field."
+msgstr "Порт MCP-сервера. Пример: 8123\nОбязательное поле."
+
+msgid "Base folder with requirements. Example: /tmp/reqs\nRequired; the server serves files from this directory."
+msgstr "Базовая папка с требованиями. Пример: /tmp/reqs\nОбязательное поле; сервер обслуживает файлы из этой директории."
+
+msgid "When enabled, the server requires an authentication token."
+msgstr "Если включено, сервер требует токен аутентификации."
+
+msgid "Access token for MCP. Example: secret123\nRequired when \"Require token\" is enabled."
+msgstr "Токен доступа для MCP. Пример: secret123\nОбязателен, если включено \"Требуется токен\"."
+
 # Updated help texts for requirement fields
 msgid ""
 "The 'Requirement ID' is a unique integer used as the stable anchor for a "

--- a/app/ui/settings_dialog.py
+++ b/app/ui/settings_dialog.py
@@ -15,44 +15,44 @@ from .helpers import format_error_message, make_help_button
 
 LLM_HELP: dict[str, str] = {
     "base_url": _(
-        "Базовый URL LLM API. Пример: https://api.openai.com/v1\n"
-        "Обязательное поле; определяет, куда отправляются запросы.",
+        "Base URL of the LLM API. Example: https://api.openai.com/v1\n"
+        "Required; defines where requests are sent.",
     ),
     "model": _(
-        "Имя модели LLM. Пример: gpt-4-turbo\n"
-        "Обязательное поле, определяет используемую модель.",
+        "LLM model name. Example: gpt-4-turbo\n"
+        "Required; selects which model to use.",
     ),
     "api_key": _(
-        "Ключ доступа к LLM. Пример: sk-XXXX\n"
-        "Обязателен, если сервис требует авторизации.",
+        "LLM access key. Example: sk-XXXX\n"
+        "Required when the service needs authentication.",
     ),
     "timeout_minutes": _(
-        "Тайм-аут HTTP-запроса в минутах. Пример: 1\n"
-        "Необязательное поле; по умолчанию 60 секунд.",
+        "HTTP request timeout in minutes. Example: 1\n"
+        "Optional; defaults to 60 minutes.",
     ),
 }
 
 MCP_HELP: dict[str, str] = {
     "auto_start": _(
-        "Запускать MCP-сервер автоматически при старте CookaReq.",
+        "Start the MCP server automatically when CookaReq launches.",
     ),
     "host": _(
-        "Адрес хоста MCP-сервера. Пример: 127.0.0.1\n"
-        "Обязательное поле; определяет, где запускать сервер.",
+        "Hostname for the MCP server. Example: 127.0.0.1\n"
+        "Required; defines where to run the server.",
     ),
     "port": _(
-        "Порт MCP-сервера. Пример: 8123\nОбязательное поле.",
+        "MCP server port. Example: 8123\nRequired field.",
     ),
     "base_path": _(
-        "Базовая папка с требованиями. Пример: /tmp/reqs\n"
-        "Обязательное поле; сервер обслуживает файлы из этой директории.",
+        "Base folder with requirements. Example: /tmp/reqs\n"
+        "Required; the server serves files from this directory.",
     ),
     "require_token": _(
-        "Если включено, сервер требует токен аутентификации.",
+        "When enabled, the server requires an authentication token.",
     ),
     "token": _(
-        "Токен доступа для MCP. Пример: secret123\n"
-        "Обязателен, если включено 'Require token'.",
+        "Access token for MCP. Example: secret123\n"
+        "Required when \"Require token\" is enabled.",
     ),
 }
 


### PR DESCRIPTION
## Summary
- switch MCP and LLM help tooltips to English source strings and correct the timeout default wording
- update English and Russian translation catalogs to match the new msgids

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68c940fd5d748320a88d03835df68701