### PR TITLE
Centralize real LLM flag gating

### DIFF
--- a/tests/gui/conftest.py
+++ b/tests/gui/conftest.py
@@ -1,0 +1,7 @@
+"""Pytest configuration for GUI test suite."""
+
+import pytest
+
+# Apply the ``gui`` marker to every test in this package so they can be selected
+# with ``-m gui`` and handled separately from non-GUI checks.
+pytestmark = pytest.mark.gui

--- a/tests/integration/test_llm_openrouter_integration.py
+++ b/tests/integration/test_llm_openrouter_integration.py
@@ -4,9 +4,11 @@ from pathlib import Path
 import pytest
 
 from app.llm.client import LLMClient
-from tests.llm_utils import settings_with_llm
+from tests.llm_utils import require_real_llm_tests_flag, settings_with_llm
 
-pytestmark = pytest.mark.integration
+REQUIRES_REAL_LLM = True
+
+pytestmark = [pytest.mark.integration, pytest.mark.real_llm]
 
 
 def _load_openrouter_key() -> str | None:
@@ -21,10 +23,8 @@ def _load_openrouter_key() -> str | None:
     return None
 
 
-@pytest.mark.real_llm
 def test_openrouter_check_llm(tmp_path):
-    if not os.getenv("COOKAREQ_RUN_REAL_LLM_TESTS"):
-        pytest.skip("Set COOKAREQ_RUN_REAL_LLM_TESTS=1 to enable this test")
+    require_real_llm_tests_flag()
     key = _load_openrouter_key()
     if not key:
         pytest.skip("OPEN_ROUTER key not available")

--- a/tests/llm_utils.py
+++ b/tests/llm_utils.py
@@ -1,10 +1,28 @@
 """Utilities for LLM-related tests."""
 
 import json
+import os
 from pathlib import Path
 from types import SimpleNamespace
 
+import pytest
+
 from app.settings import AppSettings, load_app_settings
+
+
+def require_real_llm_tests_flag(*, env_var: str = "COOKAREQ_RUN_REAL_LLM_TESTS") -> None:
+    """Ensure the opt-in flag for real LLM tests is present or skip.
+
+    ``pytest.skip`` is raised when the environment variable designated by
+    ``env_var`` is absent or false-y, guaranteeing consistent behaviour across
+    tests and fixtures that depend on the real LLM backend.
+    """
+
+    if os.getenv(env_var):
+        return
+    pytest.skip(
+        "Set COOKAREQ_RUN_REAL_LLM_TESTS=1 to run tests hitting real LLM",
+    )
 
 
 def make_openai_mock(responses: dict[str, tuple[str, dict] | Exception]):


### PR DESCRIPTION
## Summary
- add a shared helper to enforce the COOKAREQ_RUN_REAL_LLM_TESTS flag
- reuse the helper from the global OpenRouter mock and the integration suite
- keep the integration test focused on loading the real API key once the flag is satisfied

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68c91f57a2cc8320805f70469270875c