### PR TITLE
Localize requirement list column headers

### DIFF
--- a/app/locale/en/LC_MESSAGES/CookaReq.po
+++ b/app/locale/en/LC_MESSAGES/CookaReq.po
@@ -181,6 +181,12 @@ msgstr "Requirement type"
 msgid "Requirement revision"
 msgstr "Requirement revision"
 
+msgid "Document prefix"
+msgstr "Document prefix"
+
+msgid "Requirement RID"
+msgstr "Requirement RID"
+
 msgid "Retired"
 msgstr "Retired"
 
@@ -374,6 +380,9 @@ msgstr "MCP"
 
 msgid "Manage Labels"
 msgstr "Manage Labels"
+
+msgid "Links"
+msgstr "Links"
 
 
 msgid "Match any labels"

--- a/app/locale/ru/LC_MESSAGES/CookaReq.po
+++ b/app/locale/ru/LC_MESSAGES/CookaReq.po
@@ -125,6 +125,12 @@ msgstr "Условия и режимы"
 msgid "Requirement revision"
 msgstr "Ревизия требования"
 
+msgid "Document prefix"
+msgstr "Префикс документа"
+
+msgid "Requirement RID"
+msgstr "RID требования"
+
 msgid "Modified at"
 msgstr "Дата изменения"
 
@@ -380,6 +386,9 @@ msgstr "MCP"
 
 msgid "Manage Labels"
 msgstr "Управление метками"
+
+msgid "Links"
+msgstr "Связи"
 
 msgid "Match any labels"
 msgstr "Совпадает с любой меткой"

--- a/app/ui/list_panel.py
+++ b/app/ui/list_panel.py
@@ -305,7 +305,7 @@ class ListPanel(wx.Panel, ColumnSorterMixin):
             if field == "labels":
                 continue
             idx = self.list.GetColumnCount()
-            self.list.InsertColumn(idx, field)
+            self.list.InsertColumn(idx, locale.field_label(field))
             self._field_order.append(field)
         ColumnSorterMixin.__init__(self, self.list.GetColumnCount())
         with suppress(Exception):  # remove mixin's default binding and use our own

--- a/app/ui/locale.py
+++ b/app/ui/locale.py
@@ -30,6 +30,12 @@ FIELD_LABELS = {
     "assumptions": _("Assumptions"),
     "labels": _("Labels"),
     "derived_count": _("Derived count"),
+    "attachments": _("Attachments"),
+    "approved_at": _("Approved at"),
+    "notes": _("Notes"),
+    "links": _("Links"),
+    "doc_prefix": _("Document prefix"),
+    "rid": _("Requirement RID"),
 }
 
 

--- a/tests/gui/test_list_panel.py
+++ b/tests/gui/test_list_panel.py
@@ -1029,7 +1029,14 @@ def test_reorder_columns(monkeypatch):
     panel.set_columns(["id", "status", "priority"])
     panel.reorder_columns(1, 3)
     assert panel.columns == ["status", "priority", "id"]
-    assert panel.list._cols == ["Title", "status", "priority", "id"]
+    _ = list_panel_module._
+    field_label = list_panel_module.locale.field_label
+    assert panel.list._cols == [
+        _("Title"),
+        field_label("status"),
+        field_label("priority"),
+        field_label("id"),
+    ]
 
 
 def test_load_column_widths_assigns_defaults(monkeypatch):

--- a/tests/gui/test_list_panel_gui.py
+++ b/tests/gui/test_list_panel_gui.py
@@ -225,5 +225,5 @@ def test_reorder_columns_gui(wx_app):
     panel.set_columns(["id", "status"])
     panel.reorder_columns(1, 2)
     assert panel.columns == ["status", "id"]
-    assert panel.list.GetColumn(1).GetText() == "status"
+    assert panel.list.GetColumn(1).GetText() == list_panel.locale.field_label("status")
     frame.Destroy()


### PR DESCRIPTION
## Summary
- localize requirement list column headers with locale.field_label to avoid raw field names
- extend locale field labels and translations for additional requirement columns
- update GUI tests to expect localized column captions

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68c96e8abcac832092a38a6e0acb26c1