### PR TITLE
Restore migration tool and ensure schema-complete output

### DIFF
--- a/tests/unit/test_migrate_to_docs.py
+++ b/tests/unit/test_migrate_to_docs.py
@@ -1,0 +1,229 @@
+import json
+from dataclasses import fields as dataclass_fields
+from pathlib import Path
+
+import pytest
+
+from app.core.model import Requirement
+from tools.migrate_to_docs import migrate_to_docs, parse_rules
+
+pytestmark = pytest.mark.unit
+
+REQUIREMENT_KEYS = {
+    f.name for f in dataclass_fields(Requirement) if f.name not in {"doc_prefix", "rid"}
+}
+
+
+def write_req(path: Path, data: dict) -> None:
+    path.write_text(json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8")
+
+
+def test_migrate_to_docs_basic(tmp_path: Path) -> None:
+    r1 = {
+        "id": "CR-001",
+        "title": "One",
+        "statement": "First",
+        "labels": ["doc=SYS", "alpha"],
+        "revision": 1,
+    }
+    r2 = {
+        "id": "CR-002",
+        "title": "Two",
+        "statement": "Second",
+        "labels": ["doc=HLR", "beta"],
+    }
+    write_req(tmp_path / "CR-001.json", r1)
+    write_req(tmp_path / "CR-002.json", r2)
+
+    migrate_to_docs(
+        tmp_path,
+        rules="label:doc=SYS->SYS; label:doc=HLR->HLR",
+        default="SYS",
+    )
+
+    # original files removed
+    assert not (tmp_path / "CR-001.json").exists()
+
+    sys_item = tmp_path / "SYS" / "items" / "SYS001.json"
+    hlr_item = tmp_path / "HLR" / "items" / "HLR002.json"
+    assert sys_item.is_file()
+    assert hlr_item.is_file()
+
+    sys_data = json.loads(sys_item.read_text(encoding="utf-8"))
+    hlr_data = json.loads(hlr_item.read_text(encoding="utf-8"))
+
+    assert set(sys_data) == REQUIREMENT_KEYS
+    assert sys_data["id"] == 1
+    assert sys_data["title"] == "One"
+    assert sys_data["statement"] == "First"
+    assert sys_data["labels"] == ["alpha"]
+    assert sys_data["links"] == []
+    assert sys_data["type"] == "requirement"
+    assert sys_data["status"] == "draft"
+    assert sys_data["owner"] == ""
+    assert sys_data["priority"] == "medium"
+    assert sys_data["source"] == ""
+    assert sys_data["verification"] == "analysis"
+    assert sys_data["attachments"] == []
+
+    assert set(hlr_data) == REQUIREMENT_KEYS
+    assert hlr_data["id"] == 2
+    assert hlr_data["labels"] == ["beta"]
+    assert hlr_data["status"] == "draft"
+
+    doc = json.loads((tmp_path / "SYS" / "document.json").read_text(encoding="utf-8"))
+    assert doc["prefix"] == "SYS"
+    assert doc["digits"] == 3
+    assert doc["labels"]["allowFreeform"] is True
+    assert doc["attributes"] == {}
+
+
+def test_migrate_to_docs_creates_default_document(tmp_path: Path) -> None:
+    lone = {
+        "id": "HLR-001",
+        "title": "Lone HLR",
+        "statement": "Only high-level requirement",
+        "labels": ["doc=HLR"],
+    }
+
+    write_req(tmp_path / "HLR-001.json", lone)
+
+    migrate_to_docs(tmp_path, rules="label:doc=HLR->HLR", default="SYS")
+
+    sys_doc_path = tmp_path / "SYS" / "document.json"
+    assert sys_doc_path.exists()
+    sys_doc = json.loads(sys_doc_path.read_text(encoding="utf-8"))
+    assert sys_doc["prefix"] == "SYS"
+    assert sys_doc["digits"] == 3
+    assert sys_doc["attributes"] == {}
+
+    sys_items_dir = tmp_path / "SYS" / "items"
+    assert sys_items_dir.is_dir()
+    assert not any(sys_items_dir.iterdir())
+
+
+def test_migrate_to_docs_links(tmp_path: Path) -> None:
+    r1 = {
+        "id": "CR-001",
+        "title": "One",
+        "statement": "First",
+        "labels": ["doc=SYS"],
+    }
+    r2 = {
+        "id": "CR-002",
+        "title": "Two",
+        "statement": "Second",
+        "labels": ["doc=SYS"],
+        "links": ["CR-001", "EXT-9"],
+    }
+    write_req(tmp_path / "CR-001.json", r1)
+    write_req(tmp_path / "CR-002.json", r2)
+
+    migrate_to_docs(tmp_path, rules="label:doc=SYS->SYS", default="SYS")
+
+    data = json.loads(
+        (tmp_path / "SYS" / "items" / "SYS002.json").read_text(encoding="utf-8")
+    )
+    assert data["links"] == ["SYS001", "EXT-9"]
+
+
+@pytest.mark.parametrize("legacy_id", [1, "1"])
+def test_migrate_to_docs_numeric_ids(tmp_path: Path, legacy_id) -> None:
+    numeric = {
+        "id": legacy_id,
+        "title": "Legacy numeric",
+        "statement": "Numeric statement",
+        "labels": ["doc=SYS"],
+    }
+    consumer_links = [legacy_id, "EXT-9"]
+    consumer = {
+        "id": "CR-002",
+        "title": "Consumer",
+        "statement": "Reference numeric",
+        "labels": ["doc=SYS"],
+        "links": consumer_links,
+    }
+
+    write_req(tmp_path / "numeric.json", numeric)
+    write_req(tmp_path / "consumer.json", consumer)
+
+    migrate_to_docs(tmp_path, rules="label:doc=SYS->SYS", default="SYS")
+
+    doc = json.loads((tmp_path / "SYS" / "document.json").read_text(encoding="utf-8"))
+    digits = doc["digits"]
+    expected_numeric_rid = f"SYS{int(str(legacy_id)):0{digits}d}"
+
+    numeric_path = tmp_path / "SYS" / "items" / f"{expected_numeric_rid}.json"
+    assert numeric_path.exists()
+    numeric_data = json.loads(numeric_path.read_text(encoding="utf-8"))
+    assert numeric_data["id"] == 1
+    assert numeric_data["title"] == "Legacy numeric"
+    assert numeric_data["labels"] == []
+    assert numeric_data["links"] == []
+
+    consumer_items = list((tmp_path / "SYS" / "items").glob("*.json"))
+    consumer_data = None
+    for item_path in consumer_items:
+        if item_path.name == f"{expected_numeric_rid}.json":
+            continue
+        data = json.loads(item_path.read_text(encoding="utf-8"))
+        if data["title"] == "Consumer":
+            consumer_data = data
+            break
+    assert consumer_data is not None
+    assert consumer_data["id"] == 2
+    assert consumer_data["labels"] == []
+    assert consumer_data["links"] == [expected_numeric_rid, "EXT-9"]
+
+
+def test_migrate_to_docs_preserves_metadata(tmp_path: Path) -> None:
+    legacy = {
+        "id": "CR-010",
+        "title": "Legacy",
+        "statement": "Detailed statement",
+        "labels": ["doc=SYS"],
+        "status": "approved",
+        "owner": "Lead",
+        "priority": "high",
+        "source": "spec",
+        "verification": "test",
+        "acceptance": "All tests pass",
+        "notes": "Migrated",
+        "revision": 3,
+    }
+    write_req(tmp_path / "legacy.json", legacy)
+
+    migrate_to_docs(tmp_path, rules="label:doc=SYS->SYS", default="SYS")
+
+    item_path = tmp_path / "SYS" / "items" / "SYS010.json"
+    data = json.loads(item_path.read_text(encoding="utf-8"))
+    assert data["status"] == "approved"
+    assert data["owner"] == "Lead"
+    assert data["priority"] == "high"
+    assert data["source"] == "spec"
+    assert data["verification"] == "test"
+    assert data["acceptance"] == "All tests pass"
+    assert data["notes"] == "Migrated"
+    assert data["revision"] == 3
+
+
+def test_migrate_to_docs_structured_source(tmp_path: Path) -> None:
+    structured = {
+        "id": "CR-020",
+        "title": "Structured source",
+        "statement": "Has composite source",
+        "labels": ["doc=SYS"],
+        "source": {"text": "Spec", "ref": "DOC-9"},
+    }
+    write_req(tmp_path / "structured.json", structured)
+
+    migrate_to_docs(tmp_path, rules="label:doc=SYS->SYS", default="SYS")
+
+    item_path = tmp_path / "SYS" / "items" / "SYS020.json"
+    data = json.loads(item_path.read_text(encoding="utf-8"))
+    assert data["source"] == json.dumps(structured["source"], ensure_ascii=False, sort_keys=True)
+
+
+def test_parse_rules_reject_tag_prefix() -> None:
+    with pytest.raises(ValueError):
+        parse_rules("tag:doc=SYS->SYS")

--- a/tools/migrate_to_docs.py
+++ b/tools/migrate_to_docs.py
@@ -1,0 +1,228 @@
+"""Convert legacy flat requirements into document-based hierarchy."""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import asdict, dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Any, Iterable, List
+
+from app.core.model import Requirement, requirement_from_dict
+
+RULE_RE = re.compile(r"^label:([^=]+)=([^->]+)->([A-Z][A-Z0-9_]*)$")
+LEGACY_ID_RE = re.compile(
+    r"^(?:(?P<prefix>(?=.*[A-Za-z_])[A-Za-z0-9_]+?)[-_]?)?(?P<num>[0-9]+)$"
+)
+
+
+@dataclass
+class Rule:
+    """Mapping from a label to target document prefix."""
+
+    label: str
+    target: str
+
+
+def parse_rules(expr: str | None) -> list[Rule]:
+    """Parse rule expression ``label:key=value->PREFIX;...``."""
+
+    rules: list[Rule] = []
+    if not expr:
+        return rules
+    for part in expr.split(";"):
+        part = part.strip()
+        if not part:
+            continue
+        m = RULE_RE.match(part)
+        if not m:
+            raise ValueError(f"invalid rule: {part}")
+        key, value, target = m.groups()
+        rules.append(Rule(label=f"{key}={value}", target=target))
+    return rules
+
+
+def select_prefix(labels: Iterable[str], rules: list[Rule], default: str) -> str:
+    """Return document prefix based on ``labels`` and ``rules``."""
+
+    for rule in rules:
+        if rule.label in labels:
+            return rule.target
+    return default
+
+
+def _normalize_source(value: Any) -> str:
+    """Return a string representation of ``value`` preserving structure."""
+
+    if value in (None, ""):
+        return ""
+    if isinstance(value, str):
+        return value
+    try:
+        return json.dumps(value, ensure_ascii=False, sort_keys=True)
+    except TypeError:
+        return str(value)
+
+
+def _serialize_requirement(req: Requirement) -> dict[str, Any]:
+    """Convert ``req`` into JSON-serializable dictionary with all schema fields."""
+
+    data = asdict(req)
+    data.pop("doc_prefix", None)
+    data.pop("rid", None)
+    for key, value in list(data.items()):
+        if isinstance(value, Enum):
+            data[key] = value.value
+    return data
+
+
+def migrate_to_docs(directory: str | Path, *, rules: str | None = None, default: str) -> None:
+    """Migrate legacy requirement files in ``directory`` to document structure."""
+
+    root = Path(directory)
+    if not root.is_dir():
+        raise FileNotFoundError(str(directory))
+
+    rule_objs = parse_rules(rules)
+    digits_map: dict[str, int] = {default: 0}
+    parsed: List[dict] = []
+    max_width = 0
+
+    # First pass: read legacy files and collect metadata
+    for fp in root.glob("*.json"):
+        with fp.open(encoding="utf-8") as fh:
+            data = json.load(fh)
+        raw_id = data.get("id")
+        if raw_id is None:
+            raise ValueError(f"missing id in {fp}")
+
+        aliases: list[str] = []
+
+        def add_alias(value: str) -> None:
+            if value not in aliases:
+                aliases.append(value)
+
+        if isinstance(raw_id, int):
+            digits_id = str(raw_id)
+            normalized_id = f"{default}{digits_id}"
+            add_alias(normalized_id)
+            add_alias(digits_id)
+            display_id = digits_id
+        elif isinstance(raw_id, str):
+            normalized_id = raw_id
+            add_alias(normalized_id)
+            display_id = raw_id
+        else:
+            raise ValueError(f"invalid id format: {raw_id}")
+
+        match = LEGACY_ID_RE.match(normalized_id)
+        if not match:
+            raise ValueError(f"invalid id format: {display_id}")
+
+        num_str = match.group("num")
+        num = int(num_str)
+        width = len(num_str)
+        if width > max_width:
+            max_width = width
+        labels = list(data.get("labels", []))
+        prefix = select_prefix(labels, rule_objs, default)
+        digits_map[prefix] = max(digits_map.get(prefix, 0), width)
+        parsed.append(
+            {
+                "fp": fp,
+                "data": data,
+                "aliases": aliases,
+                "num": num,
+                "prefix": prefix,
+                "labels": labels,
+                "links": list(data.get("links", [])),
+            }
+        )
+
+    if digits_map[default] == 0:
+        digits_map[default] = max_width or 3
+
+    # Determine new identifiers and build mapping
+    id_map: dict[str, str] = {}
+    for info in parsed:
+        digits = digits_map[info["prefix"]]
+        rid = f"{info['prefix']}{info['num']:0{digits}d}"
+        info["rid"] = rid
+        for alias in info["aliases"]:
+            id_map[alias] = rid
+
+    # Second pass: rewrite items and links
+    items: list[tuple[str, str, dict]] = []
+    for info in parsed:
+        statement = info["data"].get("statement")
+        if statement is None:
+            raise ValueError(f"missing statement in {info['fp']}")
+        legacy = dict(info["data"])
+        legacy["id"] = info["num"]
+        legacy["statement"] = statement
+        legacy["title"] = legacy.get("title", "") or ""
+        legacy.pop("text", None)
+        legacy.pop("tags", None)
+        legacy["labels"] = [
+            lbl for lbl in info["labels"] if not lbl.startswith("doc=")
+        ]
+        if "source" in legacy:
+            legacy["source"] = _normalize_source(legacy["source"])
+        if info["links"]:
+            remapped_links = []
+            for link in info["links"]:
+                new_link = id_map.get(link)
+                if new_link is None and not isinstance(link, str):
+                    new_link = id_map.get(str(link))
+                remapped_links.append(new_link if new_link is not None else link)
+            legacy["links"] = remapped_links
+        else:
+            legacy.pop("links", None)
+        req = requirement_from_dict(
+            legacy,
+            doc_prefix=info["prefix"],
+            rid=info["rid"],
+        )
+        item = _serialize_requirement(req)
+        items.append((info["prefix"], info["rid"], item, info["fp"]))
+
+    # Write new items and remove legacy files
+    for prefix, rid, item, fp in items:
+        items_dir = root / prefix / "items"
+        items_dir.mkdir(parents=True, exist_ok=True)
+        with (items_dir / f"{rid}.json").open("w", encoding="utf-8") as fh:
+            json.dump(item, fh, ensure_ascii=False, indent=2, sort_keys=True)
+        fp.unlink()
+
+    # Create document descriptors
+    for prefix, digits in digits_map.items():
+        doc_dir = root / prefix
+        doc_dir.mkdir(parents=True, exist_ok=True)
+        (doc_dir / "items").mkdir(exist_ok=True)
+        doc = {
+            "prefix": prefix,
+            "title": prefix,
+            "digits": digits,
+            "parent": None,
+            "labels": {"allowFreeform": True, "defs": []},
+            "attributes": {},
+        }
+        with (doc_dir / "document.json").open("w", encoding="utf-8") as fh:
+            json.dump(doc, fh, ensure_ascii=False, indent=2, sort_keys=True)
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Convert legacy flat requirements into document-based hierarchy.",
+    )
+    parser.add_argument("directory", help="Directory with legacy requirement files")
+    parser.add_argument(
+        "--rules",
+        help="Assignment rules in the form 'label:key=value->PREFIX;...'",
+    )
+    parser.add_argument("--default", required=True, help="Default document prefix")
+    cli_args = parser.parse_args()
+    migrate_to_docs(cli_args.directory, rules=cli_args.rules, default=cli_args.default)


### PR DESCRIPTION
## Summary
- restore the migrate_to_docs utility and update it to normalize structured `source` values, keep all requirement schema fields, and add missing document metadata
- add a dedicated unit test suite that exercises migration scenarios including structured sources, numeric IDs, link remapping, and schema completeness

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68c974927a58832081ab03a6cc2cc87a