### PR TITLE
Implement suspect link tracking with fingerprints

### DIFF
--- a/app/cli/commands.py
+++ b/app/cli/commands.py
@@ -36,10 +36,12 @@ from app.core.document_store import (
     validate_labels,
 )
 from app.core.model import (
+    Link,
     Priority,
     RequirementType,
     Status,
     Verification,
+    requirement_fingerprint,
     requirement_from_dict,
     requirement_to_dict,
 )
@@ -201,7 +203,20 @@ def _resolve_links(
         return list(default)
     if not isinstance(base_value, list):
         raise ValidationError(_("links must be a list"))
-    return [str(token) for token in base_value]
+    resolved: list[str] = []
+    for entry in base_value:
+        if isinstance(entry, str):
+            token = entry.strip()
+            if token:
+                resolved.append(token)
+            continue
+        if isinstance(entry, Mapping):
+            rid = entry.get("rid")
+            if isinstance(rid, str) and rid.strip():
+                resolved.append(rid.strip())
+            continue
+        raise ValidationError(_("links must be a list"))
+    return resolved
 
 
 def _resolve_attachments(
@@ -530,6 +545,7 @@ def cmd_link(args: argparse.Namespace) -> None:
     except FileNotFoundError:
         sys.stdout.write(_("item not found: {rid}\n").format(rid=args.rid))
         return
+    parent_payloads: dict[str, dict] = {}
     for rid in args.parents:
         if rid == args.rid:
             sys.stdout.write(_("invalid link target: {rid}\n").format(rid=rid))
@@ -548,16 +564,24 @@ def cmd_link(args: argparse.Namespace) -> None:
         parent_dir = Path(args.directory) / parent_prefix
         parent_doc = docs[parent_prefix]
         try:
-            load_item(parent_dir, parent_doc, parent_id)
+            parent_data, _parent_mtime = load_item(parent_dir, parent_doc, parent_id)
         except FileNotFoundError:
             sys.stdout.write(_("linked item not found: {rid}\n").format(rid=rid))
             return
-    links = set(data.get("links", []))
+        parent_payloads[rid] = parent_data
+
+    req = requirement_from_dict(data, doc_prefix=doc.prefix, rid=args.rid)
+    existing_links = {link.rid: link for link in getattr(req, "links", [])}
     if args.replace:
-        links.clear()
-    links.update(args.parents)
-    data["links"] = sorted(links)
-    save_item(item_dir, doc, data)
+        existing_links.clear()
+    for rid, parent_data in parent_payloads.items():
+        existing_links[rid] = Link(
+            rid=rid,
+            fingerprint=requirement_fingerprint(parent_data),
+            suspect=False,
+        )
+    req.links = [existing_links[rid] for rid in sorted(existing_links)]
+    save_item(item_dir, doc, requirement_to_dict(req))
     sys.stdout.write(f"{args.rid}\n")
 
 

--- a/app/core/document_store/links.py
+++ b/app/core/document_store/links.py
@@ -4,11 +4,12 @@ import shutil
 from pathlib import Path
 from typing import Any, Iterable, Mapping
 
-from ..model import Requirement, requirement_from_dict, requirement_to_dict
+from ..model import Link, Requirement, requirement_fingerprint, requirement_from_dict, requirement_to_dict
 from . import Document, RevisionMismatchError, ValidationError
 from .documents import is_ancestor, load_documents
 from .items import (
     _ensure_documents,
+    _update_link_suspicions,
     _resolve_requirement,
     item_path,
     list_item_ids,
@@ -28,7 +29,14 @@ def validate_item_links(
         return
     if not isinstance(links, list):
         raise ValidationError("links must be a list")
-    for rid in links:
+    for entry in links:
+        try:
+            link = Link.from_raw(entry)
+        except TypeError as exc:
+            raise ValidationError(str(exc)) from exc
+        except ValueError as exc:
+            raise ValidationError(str(exc)) from exc
+        rid = link.rid
         try:
             prefix, item_id = parse_rid(rid)
         except ValueError as exc:
@@ -55,7 +63,17 @@ def iter_links(root: str | Path) -> Iterable[tuple[str, str]]:
         for item_id in sorted(list_item_ids(directory, doc)):
             data, _ = load_item(directory, doc, item_id)
             rid = rid_for(doc, item_id)
-            for parent in sorted(data.get("links", [])):
+            raw_links = data.get("links")
+            if not isinstance(raw_links, list):
+                continue
+            parents: list[str] = []
+            for entry in raw_links:
+                try:
+                    link = Link.from_raw(entry)
+                except (TypeError, ValueError):  # pragma: no cover - defensive
+                    continue
+                parents.append(link.rid)
+            for parent in sorted(parents):
                 yield rid, parent
 
 
@@ -85,8 +103,16 @@ def plan_delete_item(
         for other_id in list_item_ids(dir_path, d):
             data, _ = load_item(dir_path, d, other_id)
             links = data.get("links")
-            if isinstance(links, list) and rid in links:
-                affected.append(rid_for(d, other_id))
+            if not isinstance(links, list):
+                continue
+            for entry in links:
+                try:
+                    link = Link.from_raw(entry)
+                except (TypeError, ValueError):  # pragma: no cover - defensive
+                    continue
+                if link.rid == rid:
+                    affected.append(rid_for(d, other_id))
+                    break
     return True, sorted(affected)
 
 
@@ -147,8 +173,22 @@ def delete_item(
         for other_id in list_item_ids(dir_path, d):
             data, _ = load_item(dir_path, d, other_id)
             links = data.get("links")
-            if isinstance(links, list) and rid in links:
-                data["links"] = [link for link in links if link != rid]
+            if not isinstance(links, list):
+                continue
+            changed = False
+            new_links: list[dict[str, Any]] = []
+            for entry in links:
+                try:
+                    link = Link.from_raw(entry)
+                except (TypeError, ValueError):  # pragma: no cover - defensive
+                    new_links.append(entry)
+                    continue
+                if link.rid == rid:
+                    changed = True
+                    continue
+                new_links.append(link.to_dict())
+            if changed:
+                data["links"] = new_links
                 save_item(dir_path, d, data)
     return True
 
@@ -199,9 +239,13 @@ def link_requirements(
     docs_map = _ensure_documents(root_path, docs)
 
     try:
-        source_prefix, _source_id, _source_doc, _source_dir, _ = _resolve_requirement(
-            root_path, source_rid, docs_map
-        )
+        (
+            source_prefix,
+            _source_id,
+            source_doc,
+            source_dir,
+            source_data,
+        ) = _resolve_requirement(root_path, source_rid, docs_map)
     except ValueError as exc:  # pragma: no cover - defensive
         raise ValidationError(str(exc)) from exc
 
@@ -224,16 +268,29 @@ def link_requirements(
     if current != expected_revision:
         raise RevisionMismatchError(expected_revision, current)
 
-    existing = data.get("links")
-    if existing is None:
-        existing_links: list[str] = []
-    elif isinstance(existing, list):
-        existing_links = [str(link) for link in existing]
-    else:  # pragma: no cover - defensive
-        raise ValidationError("links must be a list")
+    existing_raw = data.get("links")
+    existing_links: dict[str, Link] = {}
+    if existing_raw is not None:
+        if not isinstance(existing_raw, list):
+            raise ValidationError("links must be a list")
+        for entry in existing_raw:
+            try:
+                link = Link.from_raw(entry)
+            except (TypeError, ValueError) as exc:
+                raise ValidationError("invalid link entry") from exc
+            existing_links[link.rid] = link
+
+    new_link = Link(
+        rid=source_rid,
+        fingerprint=requirement_fingerprint(source_data),
+        suspect=False,
+    )
+    existing_links[source_rid] = new_link
 
     updated = dict(data)
-    updated["links"] = sorted(set(existing_links) | {source_rid})
+    updated_links = [link.to_dict() for link in existing_links.values()]
+    updated_links.sort(key=lambda item: item.get("rid", ""))
+    updated["links"] = updated_links
     revision_value = updated.get("revision", current)
     try:
         revision = int(revision_value)
@@ -244,5 +301,6 @@ def link_requirements(
     updated["revision"] = revision
 
     req = requirement_from_dict(updated, doc_prefix=derived_prefix, rid=derived_rid)
+    _update_link_suspicions(root_path, docs_map, req)
     save_item(derived_dir, derived_doc, requirement_to_dict(req))
     return req

--- a/app/core/search.py
+++ b/app/core/search.py
@@ -122,7 +122,8 @@ def filter_has_derived(
     sources: set[str] = set()
     for req in all_requirements:
         for parent in getattr(req, "links", []):
-            sources.add(parent)
+            parent_rid = getattr(parent, "rid", parent)
+            sources.add(str(parent_rid))
 
     result: list[Requirement] = []
     for req in reqs:

--- a/app/ui/controllers/documents.py
+++ b/app/ui/controllers/documents.py
@@ -61,7 +61,8 @@ class DocumentsController:
             req = requirement_from_dict(data, doc_prefix=doc.prefix, rid=rid)
             items.append(req)
             for parent in getattr(req, "links", []):
-                derived_map.setdefault(parent, []).append(req.id)
+                parent_rid = getattr(parent, "rid", parent)
+                derived_map.setdefault(parent_rid, []).append(req.id)
         self.model.set_requirements(items)
         return derived_map
 

--- a/app/ui/list_panel.py
+++ b/app/ui/list_panel.py
@@ -403,7 +403,8 @@ class ListPanel(wx.Panel, ColumnSorterMixin):
             derived_map = {}
             for req in requirements:
                 for parent in getattr(req, "links", []):
-                    derived_map.setdefault(parent, []).append(req.id)
+                    parent_rid = getattr(parent, "rid", parent)
+                    derived_map.setdefault(parent_rid, []).append(req.id)
         self.derived_map = derived_map
         self._refresh()
 
@@ -530,7 +531,14 @@ class ListPanel(wx.Panel, ColumnSorterMixin):
                     continue
                 if field == "links":
                     links = getattr(req, "links", [])
-                    value = ", ".join(str(l) for l in links)
+                    formatted: list[str] = []
+                    for link in links:
+                        rid = getattr(link, "rid", str(link))
+                        if getattr(link, "suspect", False):
+                            formatted.append(f"{rid} ⚠")
+                        else:
+                            formatted.append(str(rid))
+                    value = ", ".join(formatted)
                     self.list.SetItem(index, col, value)
                     continue
                 if field == "derived_count":
@@ -564,7 +572,8 @@ class ListPanel(wx.Panel, ColumnSorterMixin):
         derived_map: dict[str, list[int]] = {}
         for req in requirements:
             for parent in getattr(req, "links", []):
-                derived_map.setdefault(parent, []).append(req.id)
+                parent_rid = getattr(parent, "rid", parent)
+                derived_map.setdefault(parent_rid, []).append(req.id)
         self.derived_map = derived_map
         self._refresh()
 

--- a/tests/unit/test_cli_item.py
+++ b/tests/unit/test_cli_item.py
@@ -160,7 +160,8 @@ def test_item_move_merges_sources(tmp_path, capsys):
     assert data_new["attachments"] == [{"path": "cli.txt", "note": "cli"}]
     assert data_new["approved_at"] == "2024-03-02 00:00:00"
     assert data_new["notes"] == "Template notes"
-    assert data_new["links"] == ["SYS002", "SYS003"]
+    assert [entry["rid"] for entry in data_new["links"]] == ["SYS002", "SYS003"]
+    assert all(entry.get("fingerprint") for entry in data_new["links"])
     assert data_new["revision"] == 7
 
 
@@ -273,7 +274,8 @@ def test_item_add_merges_base_and_arguments(tmp_path, capsys):
     assert data["attachments"] == [{"path": "cli.txt", "note": "n"}]
     assert data["approved_at"] == "2024-02-01 00:00:00"
     assert data["notes"] == "Base notes"
-    assert data["links"] == ["SYS001", "SYS002"]
+    assert [entry["rid"] for entry in data["links"]] == ["SYS001", "SYS002"]
+    assert all(entry.get("fingerprint") for entry in data["links"])
     assert data["revision"] == 5
 
 
@@ -325,7 +327,7 @@ def test_item_delete_removes_links(tmp_path, capsys):
 
     assert not (tmp_path / "SYS" / "items" / "SYS001.json").exists()
     data = json.loads((tmp_path / "HLR" / "items" / "HLR01.json").read_text())
-    assert data.get("links") == []
+    assert data.get("links") in (None, [])
 
 
 @pytest.mark.unit
@@ -356,7 +358,7 @@ def test_item_delete_dry_run_lists_links(tmp_path, capsys):
     # nothing removed or updated
     assert (tmp_path / "SYS" / "items" / "SYS001.json").exists()
     data = json.loads((tmp_path / "HLR" / "items" / "HLR01.json").read_text())
-    assert data.get("links") == ["SYS001"]
+    assert [entry["rid"] for entry in data.get("links", [])] == ["SYS001"]
 
 
 def test_item_delete_requires_confirmation(tmp_path, capsys):

--- a/tests/unit/test_cli_link.py
+++ b/tests/unit/test_cli_link.py
@@ -6,6 +6,7 @@ import pytest
 
 from app.cli import commands
 from app.core.document_store import Document, save_document, save_item
+from app.core.model import requirement_fingerprint
 
 
 @pytest.mark.unit
@@ -27,7 +28,10 @@ def test_link_add(tmp_path, capsys):
 
     path = Path(tmp_path) / "HLR" / "items" / "HLR01.json"
     data = json.loads(path.read_text(encoding="utf-8"))
-    assert data["links"] == ["SYS001"]
+    parent_path = Path(tmp_path) / "SYS" / "items" / "SYS001.json"
+    parent_data = json.loads(parent_path.read_text(encoding="utf-8"))
+    expected_fp = requirement_fingerprint(parent_data)
+    assert data["links"] == [{"rid": "SYS001", "fingerprint": expected_fp}]
 
 
 @pytest.mark.unit
@@ -50,7 +54,7 @@ def test_link_rejects_self_link(tmp_path, capsys):
 
     path = Path(tmp_path) / "SYS" / "items" / "SYS001.json"
     data = json.loads(path.read_text(encoding="utf-8"))
-    assert data["links"] == []
+    assert data.get("links") in (None, [])
 
 
 @pytest.mark.unit
@@ -74,4 +78,4 @@ def test_link_rejects_non_ancestor(tmp_path, capsys):
 
     path = Path(tmp_path) / "HLR" / "items" / "HLR01.json"
     data = json.loads(path.read_text(encoding="utf-8"))
-    assert data.get("links") == []
+    assert data.get("links") in (None, [])

--- a/tests/unit/test_doc_store.py
+++ b/tests/unit/test_doc_store.py
@@ -18,6 +18,7 @@ from app.core.document_store import (
     plan_delete_document,
     plan_delete_item,
 )
+from app.core.model import requirement_fingerprint
 
 pytestmark = pytest.mark.unit
 
@@ -76,7 +77,7 @@ def test_delete_item_removes_links(tmp_path: Path):
     assert not (tmp_path / "SYS" / "items" / "SYS001.json").exists()
     # link cleaned
     data, _ = load_item(tmp_path / "HLR", hlr_doc, 1)
-    assert data.get("links") == []
+    assert data.get("links") in (None, [])
 
 
 def test_delete_document_recursively(tmp_path: Path):
@@ -114,7 +115,9 @@ def test_plan_delete_item_lists_references(tmp_path: Path):
     # nothing removed
     assert (tmp_path / "SYS" / "items" / "SYS001.json").exists()
     data, _ = load_item(tmp_path / "HLR", hlr_doc, 1)
-    assert data.get("links") == ["SYS001"]
+    parent_data, _ = load_item(tmp_path / "SYS", sys_doc, 1)
+    expected_fp = requirement_fingerprint(parent_data)
+    assert data.get("links") == [{"rid": "SYS001", "fingerprint": expected_fp}]
 
 
 def test_plan_delete_document_lists_subtree(tmp_path: Path):

--- a/tests/unit/test_documents_controller.py
+++ b/tests/unit/test_documents_controller.py
@@ -162,7 +162,7 @@ def test_delete_requirement_removes_links(tmp_path: Path):
     controller.delete_requirement("SYS", 1)
     assert not (sys_dir / "items" / "SYS001.json").exists()
     data2, _ = load_item(hlr_dir, hlr_doc, 1)
-    assert data2.get("links") == []
+    assert data2.get("links") in (None, [])
 
 
 def test_delete_document_recursively(tmp_path: Path):

--- a/tests/unit/test_mcp_tools_write.py
+++ b/tests/unit/test_mcp_tools_write.py
@@ -118,7 +118,7 @@ def test_link_requirements(tmp_path: Path) -> None:
         link_type="parent",
         rev=1,
     )
-    assert parent["rid"] in linked["links"]
+    assert any(entry["rid"] == parent["rid"] for entry in linked["links"])
 
 
 def test_link_requirements_rejects_invalid_type(tmp_path: Path) -> None:

--- a/tests/unit/test_model.py
+++ b/tests/unit/test_model.py
@@ -4,11 +4,13 @@ import pytest
 
 from app.core.model import (
     Attachment,
+    Link,
     Priority,
     Requirement,
     RequirementType,
     Status,
     Verification,
+    requirement_fingerprint,
     requirement_from_dict,
     requirement_to_dict,
 )
@@ -107,6 +109,46 @@ def test_requirement_extended_roundtrip():
     assert again.notes == "extra"
     assert again.rationale == "because"
     assert again.assumptions == "if ready"
+
+
+def test_requirement_links_roundtrip():
+    req = Requirement(
+        id=1,
+        title="Parent",
+        statement="Statement",
+        type=RequirementType.REQUIREMENT,
+        status=Status.DRAFT,
+        owner="",
+        priority=Priority.MEDIUM,
+        source="",
+        verification=Verification.ANALYSIS,
+        links=[Link(rid="SYS001", fingerprint="abc", suspect=True)],
+    )
+    data = requirement_to_dict(req)
+    assert data["links"] == [{"rid": "SYS001", "fingerprint": "abc", "suspect": True}]
+    again = requirement_from_dict(data)
+    assert len(again.links) == 1
+    assert again.links[0].rid == "SYS001"
+    assert again.links[0].fingerprint == "abc"
+    assert again.links[0].suspect is True
+
+
+def test_requirement_fingerprint_changes_on_text_update():
+    req = Requirement(
+        id=5,
+        title="Title",
+        statement="Alpha",
+        type=RequirementType.REQUIREMENT,
+        status=Status.DRAFT,
+        owner="",
+        priority=Priority.MEDIUM,
+        source="",
+        verification=Verification.ANALYSIS,
+    )
+    fp1 = requirement_fingerprint(req)
+    req.statement = "Beta"
+    fp2 = requirement_fingerprint(req)
+    assert fp1 != fp2
 
 
 def test_requirement_from_dict_missing_statement():


### PR DESCRIPTION
## Summary
- introduce Link dataclasses with fingerprint support and mark suspect links when parent fingerprints diverge
- update document store, CLI, and UI flows to compute/store fingerprints and surface suspect status in editors and lists
- extend unit tests to cover the new link structure and suspect detection logic across storage and tooling

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68c970fbafc4832085d05e678dbc9b37