### PR TITLE
Persist splitter layout and fix migration links

### DIFF
--- a/app/ui/main_frame.py
+++ b/app/ui/main_frame.py
@@ -133,8 +133,10 @@ class MainFrame(wx.Frame):
         self._disable_splitter_unsplit(self.main_splitter)
         self.doc_splitter = wx.SplitterWindow(self.main_splitter)
         self._disable_splitter_unsplit(self.doc_splitter)
+        self.doc_splitter.SetMinimumPaneSize(160)
         self.splitter = wx.SplitterWindow(self.doc_splitter)
         self._disable_splitter_unsplit(self.splitter)
+        self.splitter.SetMinimumPaneSize(200)
         self.doc_tree = DocumentTree(
             self.doc_splitter,
             on_select=self.on_document_selected,
@@ -729,12 +731,18 @@ class MainFrame(wx.Frame):
             self.panel,
             self.log_panel,
             self.log_menu_item,
+            editor_splitter=self.splitter,
         )
-        self.splitter.SetSashPosition(300)
 
     def _save_layout(self) -> None:
         """Persist window geometry, splitter, console, and column widths."""
-        self.config.save_layout(self, self.doc_splitter, self.main_splitter, self.panel)
+        self.config.save_layout(
+            self,
+            self.doc_splitter,
+            self.main_splitter,
+            self.panel,
+            editor_splitter=self.splitter,
+        )
 
     def _disable_splitter_unsplit(self, splitter: wx.SplitterWindow) -> None:
         """Attach handlers preventing ``splitter`` from unsplitting on double click."""

--- a/tools/migrate_to_docs.py
+++ b/tools/migrate_to_docs.py
@@ -74,6 +74,17 @@ def _serialize_requirement(req: Requirement) -> dict[str, Any]:
     for key, value in list(data.items()):
         if isinstance(value, Enum):
             data[key] = value.value
+    if req.links:
+        serialized_links: list[Any] = []
+        for link in req.links:
+            payload = link.to_dict()
+            if len(payload) == 1:
+                serialized_links.append(payload["rid"])
+            else:
+                serialized_links.append(payload)
+        data["links"] = serialized_links
+    else:
+        data["links"] = []
     return data
 
 


### PR DESCRIPTION
## Summary
- persist the editor splitter sash and clamp document tree width when restoring layouts
- set splitter minimum pane sizes and update layout tests to cover the new behaviour
- ensure migrate_to_docs emits simple string links unless metadata is present

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68c981ea00c48320946effae13bbaaf9