### PR TITLE
Fix document store merge regression and update migration

### DIFF
--- a/app/core/document_store/items.py
+++ b/app/core/document_store/items.py
@@ -8,7 +8,13 @@ from typing import Any, Iterable, Mapping, Sequence
 
 import jsonpatch
 
-from ..model import Link, Requirement, requirement_fingerprint, requirement_from_dict, requirement_to_dict
+from ..model import (
+    Link,
+    Requirement,
+    requirement_fingerprint,
+    requirement_from_dict,
+    requirement_to_dict,
+)
 from ..search import filter_by_labels, filter_by_status, search
 from . import (
     Document,
@@ -165,26 +171,18 @@ def save_item(directory: str | Path, doc: Document, data: dict) -> Path:
     docs = load_documents(root)
     from .links import validate_item_links  # local import to avoid cycle
 
-<<<<<codex/remove-redundant-names-in-files
-    validate_item_links(root, doc, data, docs)
-    directory_path = Path(directory)
-    item_id = int(data["id"])
-    path = item_path(directory_path, doc, item_id)
-    path.parent.mkdir(parents=True, exist_ok=True)
-    with path.open("w", encoding="utf-8") as fh:
-        json.dump(data, fh, ensure_ascii=False, indent=2, sort_keys=True)
-    legacy_path = directory_path / "items" / _legacy_item_filename(doc, item_id)
-    if legacy_path != path and legacy_path.exists():
-        legacy_path.unlink()
-====
     payload = dict(data)
     validate_item_links(root, doc, payload, docs)
     _prepare_links_for_storage(root, docs, payload)
-    path = item_path(directory, doc, int(payload["id"]))
+    directory_path = Path(directory)
+    item_id = int(payload["id"])
+    path = item_path(directory_path, doc, item_id)
     path.parent.mkdir(parents=True, exist_ok=True)
     with path.open("w", encoding="utf-8") as fh:
         json.dump(payload, fh, ensure_ascii=False, indent=2, sort_keys=True)
->>>>> m
+    legacy_path = directory_path / "items" / _legacy_item_filename(doc, item_id)
+    if legacy_path != path and legacy_path.exists():
+        legacy_path.unlink()
     return path
 
 

--- a/tests/unit/test_cli_item.py
+++ b/tests/unit/test_cli_item.py
@@ -332,16 +332,10 @@ def test_item_delete_removes_links(tmp_path, capsys):
     out = capsys.readouterr().out.strip()
     assert out == "SYS001"
 
-<<<<< codex/remove-redundant-names-in-files
     assert not item_path(tmp_path / "SYS", doc_sys, 1).exists()
     hlr_path = item_path(tmp_path / "HLR", doc_hlr, 1)
-    data = json.loads(hlr_path.read_text())
-    assert data.get("links") == []
-=====
-    assert not (tmp_path / "SYS" / "items" / "SYS001.json").exists()
-    data = json.loads((tmp_path / "HLR" / "items" / "HLR01.json").read_text())
+    data = json.loads(hlr_path.read_text(encoding="utf-8"))
     assert data.get("links") in (None, [])
->>>>> main
 
 
 @pytest.mark.unit
@@ -370,15 +364,10 @@ def test_item_delete_dry_run_lists_links(tmp_path, capsys):
     out = capsys.readouterr().out.splitlines()
     assert out == ["SYS001", "HLR01"]
     # nothing removed or updated
-<<<< codex/remove-redundant-names-in-files
     assert item_path(tmp_path / "SYS", doc_sys, 1).exists()
-    data = json.loads(item_path(tmp_path / "HLR", doc_hlr, 1).read_text())
-    assert data.get("links") == ["SYS001"]
-====
-    assert (tmp_path / "SYS" / "items" / "SYS001.json").exists()
-    data = json.loads((tmp_path / "HLR" / "items" / "HLR01.json").read_text())
+    data = json.loads(item_path(tmp_path / "HLR", doc_hlr, 1).read_text(encoding="utf-8"))
     assert [entry["rid"] for entry in data.get("links", [])] == ["SYS001"]
->>>> main
+    assert all(entry.get("fingerprint") for entry in data.get("links", []))
 
 
 def test_item_delete_requires_confirmation(tmp_path, capsys):

--- a/tests/unit/test_cli_link.py
+++ b/tests/unit/test_cli_link.py
@@ -1,16 +1,11 @@
 import argparse
 import json
-from pathlib import Path
 
 import pytest
 
 from app.cli import commands
-<<<<< codex/remove-redundant-names-in-files
 from app.core.document_store import Document, item_path, save_document, save_item
-=====
-from app.core.document_store import Document, save_document, save_item
 from app.core.model import requirement_fingerprint
->>>> main
 
 
 @pytest.mark.unit
@@ -32,7 +27,7 @@ def test_link_add(tmp_path, capsys):
 
     path = item_path(tmp_path / "HLR", doc_hlr, 1)
     data = json.loads(path.read_text(encoding="utf-8"))
-    parent_path = Path(tmp_path) / "SYS" / "items" / "SYS001.json"
+    parent_path = item_path(tmp_path / "SYS", doc_sys, 1)
     parent_data = json.loads(parent_path.read_text(encoding="utf-8"))
     expected_fp = requirement_fingerprint(parent_data)
     assert data["links"] == [{"rid": "SYS001", "fingerprint": expected_fp}]

--- a/tests/unit/test_migrate_to_docs.py
+++ b/tests/unit/test_migrate_to_docs.py
@@ -125,7 +125,11 @@ def test_migrate_to_docs_links(tmp_path: Path) -> None:
     data = json.loads(
         (tmp_path / "SYS" / "items" / "002.json").read_text(encoding="utf-8")
     )
-    assert data["links"] == ["SYS001", "EXT-9"]
+    links = data.get("links", [])
+    assert [entry["rid"] for entry in links] == ["SYS001", "EXT-9"]
+    assert links[0].get("fingerprint")
+    assert links[0].get("suspect") is False
+    assert links[1].get("suspect") is True
 
 
 @pytest.mark.parametrize("legacy_id", [1, "1"])
@@ -175,7 +179,10 @@ def test_migrate_to_docs_numeric_ids(tmp_path: Path, legacy_id) -> None:
     assert consumer_data is not None
     assert consumer_data["id"] == 2
     assert consumer_data["labels"] == []
-    assert consumer_data["links"] == [expected_numeric_rid, "EXT-9"]
+    links = consumer_data.get("links", [])
+    assert [entry["rid"] for entry in links] == [expected_numeric_rid, "EXT-9"]
+    assert links[0].get("fingerprint")
+    assert links[0].get("suspect") is False
 
 
 def test_migrate_to_docs_preserves_metadata(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- restore the document store's link preparation when saving items while cleaning up legacy filenames
- adjust CLI tests to expect numeric filenames and link fingerprints under the new storage layout
- update the migration utility to emit prefixless filenames with populated link fingerprints for downstream tooling

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68c98714009883209408c5414c993752