### PR TITLE
Fix clone/derive actions selection and add tests

### DIFF
--- a/app/ui/main_frame.py
+++ b/app/ui/main_frame.py
@@ -783,9 +783,9 @@ class MainFrame(wx.Frame):
         self.editor.fields["id"].SetValue(str(new_id))
         data = self.editor.get_data()
         self.docs_controller.add_requirement(self.current_doc_prefix, data)
-        self.panel.refresh()
-        self.editor.load(data, path=None, mtime=None)
         self._selected_requirement_id = new_id
+        self.panel.refresh(select_id=new_id)
+        self.editor.load(data, path=None, mtime=None)
         self.editor.Show()
         self.splitter.UpdateSize()
 
@@ -805,9 +805,9 @@ class MainFrame(wx.Frame):
             revision=1,
         )
         self.docs_controller.add_requirement(self.current_doc_prefix, clone)
-        self.panel.refresh()
-        self.editor.load(clone, path=None, mtime=None)
         self._selected_requirement_id = new_id
+        self.panel.refresh(select_id=new_id)
+        self.editor.load(clone, path=None, mtime=None)
         self.editor.Show()
         self.splitter.UpdateSize()
 
@@ -837,9 +837,9 @@ class MainFrame(wx.Frame):
         clone = self._create_linked_copy(source)
         self.docs_controller.add_requirement(self.current_doc_prefix, clone)
         self.panel.record_link(source.rid or str(source.id), clone.id)
-        self.panel.refresh()
-        self.editor.load(clone, path=None, mtime=None)
         self._selected_requirement_id = clone.id
+        self.panel.refresh(select_id=clone.id)
+        self.editor.load(clone, path=None, mtime=None)
         self.editor.Show()
         self.splitter.UpdateSize()
 

--- a/tests/gui/test_list_panel_gui.py
+++ b/tests/gui/test_list_panel_gui.py
@@ -126,6 +126,59 @@ def test_list_panel_context_menu_calls_handlers(monkeypatch, wx_app):
     frame.Destroy()
 
 
+def test_list_panel_refresh_selects_new_row(wx_app):
+    wx = pytest.importorskip("wx")
+    import app.ui.list_panel as list_panel
+
+    importlib.reload(list_panel)
+    frame = wx.Frame(None)
+    from app.ui.requirement_model import RequirementModel
+
+    panel = list_panel.ListPanel(frame, model=RequirementModel())
+    panel.set_columns(["id", "title"])
+    panel.set_requirements([
+        _req(1, "A"),
+        _req(2, "B"),
+        _req(3, "C"),
+    ])
+    wx_app.Yield()
+
+    panel.refresh(select_id=3)
+    wx_app.Yield()
+
+    selected = panel.list.GetFirstSelected()
+    assert selected != wx.NOT_FOUND
+    assert panel.list.GetItemData(selected) == 3
+
+    frame.Destroy()
+
+
+def test_context_menu_hides_single_item_actions(wx_app):
+    wx = pytest.importorskip("wx")
+    import app.ui.list_panel as list_panel
+
+    importlib.reload(list_panel)
+    frame = wx.Frame(None)
+    from app.ui.requirement_model import RequirementModel
+
+    panel = list_panel.ListPanel(frame, model=RequirementModel())
+    panel.set_columns(["title"])
+    panel.set_requirements([
+        _req(1, "A"),
+        _req(2, "B"),
+    ])
+    panel.list.SetItemState(0, wx.LIST_STATE_SELECTED, wx.LIST_STATE_SELECTED)
+    panel.list.SetItemState(1, wx.LIST_STATE_SELECTED, wx.LIST_STATE_SELECTED)
+
+    menu, clone_item, delete_item, edit_item = panel._create_context_menu(0, 0)
+    labels = [item.GetItemLabelText() for item in menu.GetMenuItems()]
+    assert "Clone" not in labels
+    assert "Derive" not in labels
+    assert clone_item is None
+    menu.Destroy()
+    frame.Destroy()
+
+
 def test_list_panel_context_menu_via_event(monkeypatch, wx_app):
     wx = pytest.importorskip("wx")
     import app.ui.list_panel as list_panel

--- a/tests/gui/test_main_clone_derive.py
+++ b/tests/gui/test_main_clone_derive.py
@@ -1,0 +1,118 @@
+"""Tests for cloning and deriving requirements from the main frame."""
+
+import importlib
+
+import pytest
+
+from app.core.document_store import Document, save_document, save_item
+from app.core.model import (
+    Priority,
+    Requirement,
+    RequirementType,
+    Status,
+    Verification,
+    requirement_to_dict,
+)
+from app.ui.controllers import DocumentsController
+from app.ui.requirement_model import RequirementModel
+
+pytestmark = pytest.mark.gui
+
+
+def _req(req_id: int, title: str) -> Requirement:
+    return Requirement(
+        id=req_id,
+        title=title,
+        statement="",
+        type=RequirementType.REQUIREMENT,
+        status=Status.DRAFT,
+        owner="",
+        priority=Priority.MEDIUM,
+        source="",
+        verification=Verification.ANALYSIS,
+    )
+
+
+def _prepare_frame(monkeypatch, tmp_path):
+    wx = pytest.importorskip("wx")
+    import app.ui.main_frame as main_frame_mod
+
+    importlib.reload(main_frame_mod)
+    monkeypatch.setattr(main_frame_mod.MCPController, "start", lambda self, settings: None)
+
+    model = RequirementModel()
+    frame = main_frame_mod.MainFrame(None, model=model)
+    doc = Document(prefix="REQ", title="Doc", digits=3)
+    doc_dir = tmp_path / "REQ"
+    save_document(doc_dir, doc)
+    base_req = _req(1, "Base")
+    save_item(doc_dir, doc, requirement_to_dict(base_req))
+
+    controller = DocumentsController(tmp_path, model)
+    controller.load_documents()
+    controller.load_items("REQ")
+
+    frame.docs_controller = controller
+    frame.current_dir = tmp_path
+    frame.current_doc_prefix = "REQ"
+    frame.panel.set_documents_controller(controller)
+    frame.panel.set_active_document("REQ")
+    frame.panel.recalc_derived_map(model.get_all())
+    frame.editor.set_directory(doc_dir)
+    return frame
+
+
+def test_clone_creates_new_requirement(monkeypatch, wx_app, tmp_path):
+    frame = _prepare_frame(monkeypatch, tmp_path)
+    wx = pytest.importorskip("wx")
+
+    try:
+        wx_app.Yield()
+        frame.on_clone_requirement(1)
+        wx_app.Yield()
+
+        assert frame._selected_requirement_id == 2
+        assert frame.editor.fields["id"].GetValue() == "2"
+        assert frame.editor.IsShown()
+
+        clone = frame.model.get_by_id(2)
+        assert clone is not None
+        assert clone.title.startswith("(Copy)")
+
+        selected = frame.panel.list.GetFirstSelected()
+        assert selected != wx.NOT_FOUND
+        assert frame.panel.list.GetItemData(selected) == 2
+    finally:
+        frame.Destroy()
+
+
+def test_derive_creates_linked_requirement(monkeypatch, wx_app, tmp_path):
+    frame = _prepare_frame(monkeypatch, tmp_path)
+    wx = pytest.importorskip("wx")
+
+    try:
+        wx_app.Yield()
+        source = frame.model.get_by_id(1)
+        assert source is not None
+        parent_rid = source.rid or "REQ-001"
+
+        frame.on_derive_requirement(1)
+        wx_app.Yield()
+
+        assert frame._selected_requirement_id == 2
+        derived = frame.model.get_by_id(2)
+        assert derived is not None
+        assert derived.title.startswith("(Derived)")
+        assert any(
+            getattr(link, "rid", str(link)) == parent_rid for link in derived.links
+        )
+
+        mapping = frame.panel.derived_map[parent_rid]
+        assert 2 in mapping
+
+        selected = frame.panel.list.GetFirstSelected()
+        assert selected != wx.NOT_FOUND
+        assert frame.panel.list.GetItemData(selected) == 2
+    finally:
+        frame.Destroy()
+


### PR DESCRIPTION
## Summary
- ensure the requirements list can focus a specific ID after refresh and hide clone/derive in the context menu when multiple rows are selected
- update main frame actions for new/clone/derive so the freshly created requirement is auto-selected and opened in the editor
- extend GUI test coverage for list panel selection behaviour and clone/derive flows in the main frame

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68c98f56ef28832081096f481c71c95c