### PR TITLE
Add help buttons for settings actions

### DIFF
--- a/app/locale/en/LC_MESSAGES/CookaReq.po
+++ b/app/locale/en/LC_MESSAGES/CookaReq.po
@@ -591,6 +591,24 @@ msgstr "When enabled, the server requires an authentication token."
 msgid "Access token for MCP. Example: secret123\nRequired when \"Require token\" is enabled."
 msgstr "Access token for MCP. Example: secret123\nRequired when \"Require token\" is enabled."
 
+msgid "Send a test request to the configured LLM using the current settings.\nUse this to verify credentials and network connectivity."
+msgstr "Send a test request to the configured LLM using the current settings.\nUse this to verify credentials and network connectivity."
+
+msgid "Contact the MCP server with the current connection settings and list the available tools.\nEnsures the agent integration is configured correctly."
+msgstr "Contact the MCP server with the current connection settings and list the available tools.\nEnsures the agent integration is configured correctly."
+
+msgid "Launch the MCP server in the background using the current connection settings."
+msgstr "Launch the MCP server in the background using the current connection settings."
+
+msgid "Stop the MCP server instance that was started from CookaReq."
+msgstr "Stop the MCP server instance that was started from CookaReq."
+
+msgid "Connect to the MCP server and report whether it is reachable.\nDisplays diagnostic information about the running instance."
+msgstr "Connect to the MCP server and report whether it is reachable.\nDisplays diagnostic information about the running instance."
+
+msgid "Shows whether the MCP server is currently running according to CookaReq and the result of the last check."
+msgstr "Shows whether the MCP server is currently running according to CookaReq and the result of the last check."
+
 # Updated help texts for requirement fields
 msgid ""
 "The 'Requirement ID' is a unique integer used as the stable anchor for a "

--- a/app/locale/ru/LC_MESSAGES/CookaReq.po
+++ b/app/locale/ru/LC_MESSAGES/CookaReq.po
@@ -594,6 +594,24 @@ msgstr "Если включено, сервер требует токен аут
 msgid "Access token for MCP. Example: secret123\nRequired when \"Require token\" is enabled."
 msgstr "Токен доступа для MCP. Пример: secret123\nОбязателен, если включено \"Требуется токен\"."
 
+msgid "Send a test request to the configured LLM using the current settings.\nUse this to verify credentials and network connectivity."
+msgstr "Отправляет тестовый запрос в настроенную LLM с текущими параметрами.\nИспользуйте его, чтобы убедиться в корректности ключей и сетевого соединения."
+
+msgid "Contact the MCP server with the current connection settings and list the available tools.\nEnsures the agent integration is configured correctly."
+msgstr "Подключается к серверу MCP с указанными параметрами и запрашивает список доступных инструментов.\nПомогает убедиться, что интеграция агента настроена правильно."
+
+msgid "Launch the MCP server in the background using the current connection settings."
+msgstr "Запускает сервер MCP в фоне с текущими параметрами подключения."
+
+msgid "Stop the MCP server instance that was started from CookaReq."
+msgstr "Останавливает экземпляр сервера MCP, запущенный из CookaReq."
+
+msgid "Connect to the MCP server and report whether it is reachable.\nDisplays diagnostic information about the running instance."
+msgstr "Подключается к серверу MCP и сообщает, доступен ли он.\nПоказывает диагностическую информацию о работающем экземпляре."
+
+msgid "Shows whether the MCP server is currently running according to CookaReq and the result of the last check."
+msgstr "Показывает, считает ли CookaReq сервер MCP запущенным, и результат последней проверки."
+
 # Updated help texts for requirement fields
 msgid ""
 "The 'Requirement ID' is a unique integer used as the stable anchor for a "

--- a/app/ui/settings_dialog.py
+++ b/app/ui/settings_dialog.py
@@ -58,6 +58,15 @@ LLM_HELP: dict[str, str] = {
         "Stream partial responses from the LLM as they arrive.\n"
         "Disable to wait for the full reply before showing it.",
     ),
+    "check_llm": _(
+        "Send a test request to the configured LLM using the current settings.\n"
+        "Use this to verify credentials and network connectivity.",
+    ),
+    "check_tools": _(
+        "Contact the MCP server with the current connection settings and"
+        " list the available tools.\n"
+        "Ensures the agent integration is configured correctly.",
+    ),
 }
 
 MCP_HELP: dict[str, str] = {
@@ -81,6 +90,21 @@ MCP_HELP: dict[str, str] = {
     "token": _(
         "Access token for MCP. Example: secret123\n"
         "Required when \"Require token\" is enabled.",
+    ),
+    "start": _(
+        "Launch the MCP server in the background using the current"
+        " connection settings.",
+    ),
+    "stop": _(
+        "Stop the MCP server instance that was started from CookaReq.",
+    ),
+    "check": _(
+        "Connect to the MCP server and report whether it is reachable.\n"
+        "Displays diagnostic information about the running instance.",
+    ),
+    "status": _(
+        "Shows whether the MCP server is currently running according to"
+        " CookaReq and the result of the last check.",
     ),
 }
 
@@ -314,10 +338,28 @@ class SettingsDialog(wx.Dialog):
         llm_sizer.Add(stream_sz, 0, wx.ALL | wx.EXPAND, 5)
         btn_sz = wx.BoxSizer(wx.HORIZONTAL)
         llm_btn_sz = wx.BoxSizer(wx.VERTICAL)
-        llm_btn_sz.Add(self._check_llm, 0, wx.BOTTOM, 2)
+        llm_btn_sz.Add(
+            self._make_control_with_help(
+                parent=llm,
+                control=self._check_llm,
+                help_text=LLM_HELP["check_llm"],
+            ),
+            0,
+            wx.BOTTOM,
+            2,
+        )
         llm_btn_sz.Add(self._llm_status, 0, wx.ALIGN_CENTER)
         tools_btn_sz = wx.BoxSizer(wx.VERTICAL)
-        tools_btn_sz.Add(self._check_tools, 0, wx.BOTTOM, 2)
+        tools_btn_sz.Add(
+            self._make_control_with_help(
+                parent=llm,
+                control=self._check_tools,
+                help_text=LLM_HELP["check_tools"],
+            ),
+            0,
+            wx.BOTTOM,
+            2,
+        )
         tools_btn_sz.Add(self._tools_status, 0, wx.ALIGN_CENTER)
         btn_sz.Add(llm_btn_sz, 0, wx.RIGHT, 5)
         btn_sz.Add(tools_btn_sz, 0)
@@ -434,11 +476,45 @@ class SettingsDialog(wx.Dialog):
         )
         mcp_sizer.Add(token_sz, 0, wx.ALL | wx.EXPAND, 5)
         btn_sz = wx.BoxSizer(wx.HORIZONTAL)
-        btn_sz.Add(self._start, 0, wx.RIGHT, 5)
-        btn_sz.Add(self._stop, 0, wx.RIGHT, 5)
-        btn_sz.Add(self._check, 0)
+        btn_sz.Add(
+            self._make_control_with_help(
+                parent=mcp,
+                control=self._start,
+                help_text=MCP_HELP["start"],
+            ),
+            0,
+            wx.RIGHT,
+            5,
+        )
+        btn_sz.Add(
+            self._make_control_with_help(
+                parent=mcp,
+                control=self._stop,
+                help_text=MCP_HELP["stop"],
+            ),
+            0,
+            wx.RIGHT,
+            5,
+        )
+        btn_sz.Add(
+            self._make_control_with_help(
+                parent=mcp,
+                control=self._check,
+                help_text=MCP_HELP["check"],
+            ),
+            0,
+        )
         mcp_sizer.Add(btn_sz, 0, wx.ALL, 5)
-        mcp_sizer.Add(self._status, 0, wx.ALL, 5)
+        mcp_sizer.Add(
+            self._make_control_with_help(
+                parent=mcp,
+                control=self._status,
+                help_text=MCP_HELP["status"],
+            ),
+            0,
+            wx.ALL,
+            5,
+        )
         mcp_sizer.Add(help_txt, 0, wx.ALL | wx.EXPAND, 5)
         mcp.SetSizer(mcp_sizer)
         self._update_mcp_controls()
@@ -468,6 +544,24 @@ class SettingsDialog(wx.Dialog):
         self._stop.Enable(running)
         status = _("running") if running else _("not running")
         self._status.SetLabel(f"{_('Status')}: {status}")
+
+    def _make_control_with_help(
+        self,
+        *,
+        parent: wx.Window,
+        control: wx.Window,
+        help_text: str,
+        border: int = 5,
+    ) -> wx.BoxSizer:
+        row = wx.BoxSizer(wx.HORIZONTAL)
+        row.Add(control, 0, wx.ALIGN_CENTER_VERTICAL)
+        row.Add(
+            make_help_button(parent, help_text, dialog_parent=self),
+            0,
+            wx.LEFT | wx.ALIGN_CENTER_VERTICAL,
+            border,
+        )
+        return row
 
     def _current_llm_settings(self) -> LLMSettings:
         return LLMSettings(


### PR DESCRIPTION
## Summary
- add inline help buttons for the LLM check controls and MCP management actions in the settings dialog
- centralize creation of help button rows inside the dialog to keep layout consistent
- localize the new hints in both English and Russian catalogs

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68c99f46bd448320a8377162ca64f820