### PR TITLE
Switch max token setting to numeric text input

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -9,6 +9,7 @@ from typing import Any, Callable, Generic, Literal, Protocol, TypeVar
 
 import wx
 
+from .llm.constants import DEFAULT_MAX_OUTPUT_TOKENS
 from .settings import AppSettings, LLMSettings, MCPSettings, UISettings
 
 
@@ -86,26 +87,6 @@ def _optional_string_writer(
     value: str | None,
 ) -> None:
     manager._cfg.Write(spec.key, "" if value is None else str(value))
-
-
-def _optional_int_reader(
-    manager: "ConfigManager",
-    spec: FieldSpec[int | None],
-    default: int | None,
-) -> int | None:
-    fallback = 0 if default is None else int(default)
-    value = manager._cfg.ReadInt(spec.key, fallback)
-    if value == 0 and default is None:
-        return None
-    return value
-
-
-def _optional_int_writer(
-    manager: "ConfigManager",
-    spec: FieldSpec[int | None],
-    value: int | None,
-) -> None:
-    manager._cfg.WriteInt(spec.key, 0 if value is None else int(value))
 
 
 def _llm_base_url_reader(
@@ -238,10 +219,8 @@ CONFIG_FIELD_SPECS: dict[ConfigFieldName, FieldSpec[Any]] = {
     ),
     "llm_max_output_tokens": FieldSpec(
         key="llm_max_output_tokens",
-        value_type=int | None,
-        default=None,
-        reader=_optional_int_reader,
-        writer=_optional_int_writer,
+        value_type=int,
+        default=DEFAULT_MAX_OUTPUT_TOKENS,
     ),
     "llm_timeout_minutes": FieldSpec(
         key="llm_timeout_minutes",

--- a/app/llm/__init__.py
+++ b/app/llm/__init__.py
@@ -1,5 +1,18 @@
 """LLM integration utilities."""
 
-from .client import LLMClient
+from typing import TYPE_CHECKING, Any
 
 __all__ = ["LLMClient"]
+
+if TYPE_CHECKING:  # pragma: no cover - typing helper
+    from .client import LLMClient as _LLMClient
+
+
+def __getattr__(name: str) -> Any:
+    """Lazily expose heavy modules to avoid import cycles."""
+
+    if name == "LLMClient":
+        from .client import LLMClient
+
+        return LLMClient
+    raise AttributeError(f"module 'app.llm' has no attribute {name!r}")

--- a/app/llm/client.py
+++ b/app/llm/client.py
@@ -8,6 +8,7 @@ from collections.abc import Mapping
 from typing import Any
 
 from ..settings import LLMSettings
+from .constants import DEFAULT_MAX_OUTPUT_TOKENS
 
 # ``OpenAI`` импортируется динамически в конструкторе, чтобы тесты могли
 # подменять ``openai.OpenAI`` до первого использования и тем самым избежать
@@ -15,11 +16,6 @@ from ..settings import LLMSettings
 from ..telemetry import log_event
 from .spec import SYSTEM_PROMPT, TOOLS
 from .validation import validate_tool_call
-
-# When конфигурация не задаёт явное ограничение, используем консервативный
-# дефолт, чтобы не отдавать бесконечно длинные ответы и не зависеть от
-# серверных настроек.
-DEFAULT_MAX_OUTPUT_TOKENS = 5000
 
 # When the backend does not require authentication, the official OpenAI client
 # still insists on a non-empty ``api_key``.  Using a harmless placeholder allows

--- a/app/llm/constants.py
+++ b/app/llm/constants.py
@@ -1,0 +1,7 @@
+"""Shared constants for LLM configuration limits."""
+
+DEFAULT_MAX_OUTPUT_TOKENS = 5000
+"""Fallback response length cap when the user does not configure one."""
+
+MIN_MAX_OUTPUT_TOKENS = 1000
+"""Lowest value accepted from the user for LLM responses."""

--- a/app/ui/main_frame.py
+++ b/app/ui/main_frame.py
@@ -263,7 +263,7 @@ class MainFrame(wx.Frame):
             model=self.llm_settings.model,
             api_key=self.llm_settings.api_key or "",
             max_retries=self.llm_settings.max_retries,
-            max_output_tokens=self.llm_settings.max_output_tokens or 0,
+            max_output_tokens=self.llm_settings.max_output_tokens,
             timeout_minutes=self.llm_settings.timeout_minutes,
             stream=self.llm_settings.stream,
             auto_start=self.mcp_settings.auto_start,
@@ -298,7 +298,7 @@ class MainFrame(wx.Frame):
                 model=model,
                 api_key=api_key or None,
                 max_retries=max_retries,
-                max_output_tokens=max_output_tokens or None,
+                max_output_tokens=max_output_tokens,
                 timeout_minutes=timeout_minutes,
                 stream=stream,
             )

--- a/tests/gui/test_language_switch.py
+++ b/tests/gui/test_language_switch.py
@@ -40,7 +40,7 @@ def test_switch_to_russian_updates_ui(monkeypatch, wx_app):
                 frame.llm_settings.model,
                 frame.llm_settings.api_key or "",
                 frame.llm_settings.max_retries,
-                frame.llm_settings.max_output_tokens or 0,
+                frame.llm_settings.max_output_tokens,
                 frame.llm_settings.timeout_minutes,
                 frame.llm_settings.stream,
                 frame.mcp_settings.auto_start,

--- a/tests/gui/test_settings_dialog.py
+++ b/tests/gui/test_settings_dialog.py
@@ -2,6 +2,8 @@
 
 import pytest
 
+from app.llm.constants import DEFAULT_MAX_OUTPUT_TOKENS, MIN_MAX_OUTPUT_TOKENS
+
 pytestmark = [pytest.mark.gui, pytest.mark.integration]
 
 
@@ -60,6 +62,54 @@ def test_settings_dialog_returns_language(wx_app):
     dlg.Destroy()
 
 
+def test_max_output_tokens_text_input(wx_app):
+    wx = pytest.importorskip("wx")
+    from app.ui.settings_dialog import SettingsDialog
+
+    dlg = SettingsDialog(
+        None,
+        open_last=False,
+        remember_sort=False,
+        language="en",
+        base_url="http://api",
+        model="gpt",
+        api_key="key",
+        max_retries=3,
+        max_output_tokens=DEFAULT_MAX_OUTPUT_TOKENS,
+        timeout_minutes=10,
+        stream=False,
+        auto_start=True,
+        host="localhost",
+        port=8123,
+        base_path="/tmp",
+        require_token=False,
+        token="",
+    )
+
+    assert isinstance(dlg._max_output_tokens, wx.TextCtrl)
+
+    dlg._max_output_tokens.SetValue("12abc")
+    wx.GetApp().Yield()
+    assert dlg._max_output_tokens.GetValue() == "12"
+
+    dlg._max_output_tokens.SetValue("")
+    wx.GetApp().Yield()
+    max_tokens = dlg.get_values()[7]
+    assert max_tokens == DEFAULT_MAX_OUTPUT_TOKENS
+
+    dlg._max_output_tokens.SetValue("500")
+    wx.GetApp().Yield()
+    max_tokens = dlg.get_values()[7]
+    assert max_tokens == MIN_MAX_OUTPUT_TOKENS
+
+    dlg._max_output_tokens.SetValue("7500")
+    wx.GetApp().Yield()
+    max_tokens = dlg.get_values()[7]
+    assert max_tokens == 7500
+
+    dlg.Destroy()
+
+
 def test_mcp_start_stop_server(monkeypatch, wx_app):
     wx = pytest.importorskip("wx")
     import app.ui.settings_dialog as sd
@@ -97,7 +147,7 @@ def test_mcp_start_stop_server(monkeypatch, wx_app):
         model="",
         api_key="",
         max_retries=3,
-        max_output_tokens=0,
+        max_output_tokens=DEFAULT_MAX_OUTPUT_TOKENS,
         timeout_minutes=60,
         stream=False,
         auto_start=True,
@@ -174,7 +224,7 @@ def test_mcp_check_status(monkeypatch, wx_app):
         model="",
         api_key="",
         max_retries=3,
-        max_output_tokens=0,
+        max_output_tokens=DEFAULT_MAX_OUTPUT_TOKENS,
         timeout_minutes=60,
         stream=False,
         auto_start=True,
@@ -240,7 +290,7 @@ def test_llm_agent_checks(monkeypatch, wx_app):
         model="gpt",
         api_key="key",
         max_retries=3,
-        max_output_tokens=0,
+        max_output_tokens=DEFAULT_MAX_OUTPUT_TOKENS,
         timeout_minutes=30,
         stream=False,
         auto_start=True,
@@ -281,7 +331,7 @@ def test_settings_help_buttons(monkeypatch, wx_app):
         model="",
         api_key="",
         max_retries=3,
-        max_output_tokens=0,
+        max_output_tokens=DEFAULT_MAX_OUTPUT_TOKENS,
         timeout_minutes=10,
         stream=False,
         auto_start=True,

--- a/tests/integration/test_llm_client.py
+++ b/tests/integration/test_llm_client.py
@@ -7,7 +7,8 @@ from types import SimpleNamespace
 
 import pytest
 
-from app.llm.client import DEFAULT_MAX_OUTPUT_TOKENS, NO_API_KEY, LLMClient
+from app.llm.client import NO_API_KEY, LLMClient
+from app.llm.constants import DEFAULT_MAX_OUTPUT_TOKENS, MIN_MAX_OUTPUT_TOKENS
 from app.log import logger
 from app.mcp.server import JsonlHandler
 from app.settings import LLMSettings
@@ -69,7 +70,7 @@ def test_check_llm(tmp_path: Path, monkeypatch) -> None:
 
 def test_check_llm_uses_configured_token_limit(tmp_path: Path, monkeypatch) -> None:
     settings = settings_with_llm(tmp_path)
-    settings.llm.max_output_tokens = 7
+    settings.llm.max_output_tokens = MIN_MAX_OUTPUT_TOKENS + 512
     captured: dict[str, object] = {}
 
     class FakeOpenAI:
@@ -85,7 +86,7 @@ def test_check_llm_uses_configured_token_limit(tmp_path: Path, monkeypatch) -> N
     monkeypatch.setattr("openai.OpenAI", FakeOpenAI)
     client = LLMClient(settings.llm)
     client.check_llm()
-    assert captured["max_output_tokens"] == 7
+    assert captured["max_output_tokens"] == MIN_MAX_OUTPUT_TOKENS + 512
 
 
 def test_check_llm_uses_default_when_no_limit(tmp_path: Path, monkeypatch) -> None:

--- a/tests/llm_utils.py
+++ b/tests/llm_utils.py
@@ -7,6 +7,7 @@ from types import SimpleNamespace
 
 import pytest
 
+from app.llm.constants import DEFAULT_MAX_OUTPUT_TOKENS
 from app.settings import AppSettings, load_app_settings
 
 
@@ -90,7 +91,7 @@ def settings_with_llm(tmp_path: Path, *, api_key: str = "dummy") -> AppSettings:
             "model": "qwen/qwen3-4b:free",
             "api_key": api_key,
             "max_retries": 3,
-            "max_output_tokens": 0,
+            "max_output_tokens": DEFAULT_MAX_OUTPUT_TOKENS,
             "timeout_minutes": 60,
             "stream": False,
         },
@@ -122,7 +123,7 @@ def settings_with_mcp(
             "model": "qwen/qwen3-4b:free",
             "api_key": api_key,
             "max_retries": 3,
-            "max_output_tokens": 0,
+            "max_output_tokens": DEFAULT_MAX_OUTPUT_TOKENS,
             "timeout_minutes": 60,
             "stream": False,
         },

--- a/tests/unit/test_config_manager.py
+++ b/tests/unit/test_config_manager.py
@@ -3,6 +3,7 @@
 import pytest
 
 from app.config import ConfigManager, DEFAULT_LIST_COLUMNS
+from app.llm.constants import DEFAULT_MAX_OUTPUT_TOKENS, MIN_MAX_OUTPUT_TOKENS
 from app.settings import AppSettings, LLMSettings, MCPSettings, UISettings
 
 pytestmark = pytest.mark.unit
@@ -55,7 +56,7 @@ def _recent_dirs_factory(tmp_path):
         ("language", None),
         ("mcp_auto_start", True),
         ("mcp_port", 59362),
-        ("llm_max_output_tokens", None),
+        ("llm_max_output_tokens", DEFAULT_MAX_OUTPUT_TOKENS),
         ("sort_column", -1),
         ("sort_ascending", True),
         ("log_shown", False),
@@ -88,8 +89,18 @@ def test_schema_default_values(tmp_path, wx_app, name, expected):
         pytest.param("llm_api_key", _const("secret"), _const("secret"), id="llm_api_key"),
         pytest.param("llm_api_key", _const(None), _const(None), id="llm_api_key-none"),
         pytest.param("llm_max_retries", _const(7), _const(7), id="llm_max_retries"),
-        pytest.param("llm_max_output_tokens", _const(128), _const(128), id="llm_max_output_tokens"),
-        pytest.param("llm_max_output_tokens", _const(None), _const(None), id="llm_max_output_tokens-none"),
+        pytest.param(
+            "llm_max_output_tokens",
+            _const(MIN_MAX_OUTPUT_TOKENS),
+            _const(MIN_MAX_OUTPUT_TOKENS),
+            id="llm_max_output_tokens-min",
+        ),
+        pytest.param(
+            "llm_max_output_tokens",
+            _const(8192),
+            _const(8192),
+            id="llm_max_output_tokens-custom",
+        ),
         pytest.param("llm_timeout_minutes", _const(12), _const(12), id="llm_timeout"),
         pytest.param("llm_stream", _const(True), _const(True), id="llm_stream"),
         pytest.param("sort_column", _const(5), _const(5), id="sort_column"),
@@ -205,7 +216,7 @@ def test_app_settings_round_trip(tmp_path, wx_app):
             model="gpt",
             api_key="k",
             max_retries=2,
-            max_output_tokens=100,
+            max_output_tokens=2000,
             timeout_minutes=42,
             stream=False,
         ),
@@ -231,6 +242,26 @@ def test_app_settings_round_trip(tmp_path, wx_app):
     cfg.set_app_settings(app_settings)
     loaded = cfg.get_app_settings()
     assert loaded == app_settings
+
+
+def test_get_llm_settings_normalises_zero(tmp_path, wx_app):
+    cfg = ConfigManager(app_name="TestApp", path=tmp_path / "cfg.ini")
+
+    cfg.set_value("llm_max_output_tokens", 0)
+    cfg.flush()
+
+    settings = cfg.get_llm_settings()
+    assert settings.max_output_tokens == DEFAULT_MAX_OUTPUT_TOKENS
+
+
+def test_get_llm_settings_enforces_min(tmp_path, wx_app):
+    cfg = ConfigManager(app_name="TestApp", path=tmp_path / "cfg.ini")
+
+    cfg.set_value("llm_max_output_tokens", 250)
+    cfg.flush()
+
+    settings = cfg.get_llm_settings()
+    assert settings.max_output_tokens == MIN_MAX_OUTPUT_TOKENS
 
 
 def test_sort_settings_round_trip(tmp_path, wx_app):


### PR DESCRIPTION
## Summary
- replace the LLM max output token spin control with a digit-only text box that keeps defaults and minimums intact
- normalize and read the token limit through helper methods used by both dialog reads and live validation
- extend GUI tests to cover the new text input behaviour, including blank, clamped and cleaned values

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68c9a44a91208320aa0f5b3efb03491b