### PR TITLE
Expand MCP list/search tool schemas and validation tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Commands that modify data validate input JSON and labels before saving. If valid
 
 ## MCP Integration
 
-CookaReq includes an MCP server that exposes requirement tools to external agents and the built-in LocalAgent. Available tools cover reading, searching and mutating requirements (`list_requirements`, `get_requirement`, `search_requirements`, `create_requirement`, `patch_requirement`, `delete_requirement`, `link_requirements`). Search-related tools accept a `labels` parameter to filter results. The LocalAgent combines these tools with an LLM client and is accessible from the GUI command dialog or the CLI `check` command.
+CookaReq includes an MCP server that exposes requirement tools to external agents and the built-in LocalAgent. Available tools cover reading, searching and mutating requirements (`list_requirements`, `get_requirement`, `search_requirements`, `create_requirement`, `patch_requirement`, `delete_requirement`, `link_requirements`). Listing and search tools support filtering and pagination via `labels`, `status`, `page`, `per_page` and, for search, an optional `query` string. The LocalAgent combines these tools with an LLM client and is accessible from the GUI command dialog or the CLI `check` command.
 
 ## Requirements Repository
 

--- a/tests/unit/test_llm_validation.py
+++ b/tests/unit/test_llm_validation.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from types import MappingProxyType
+
+import pytest
+
+from app.llm.validation import ToolValidationError, validate_tool_call
+
+
+def test_validate_tool_call_accepts_list_filters():
+    arguments = MappingProxyType(
+        {
+            "page": 2,
+            "per_page": 25,
+            "status": "approved",
+            "labels": ["ui", "ux"],
+        }
+    )
+
+    result = validate_tool_call("list_requirements", arguments)
+
+    assert result == {
+        "page": 2,
+        "per_page": 25,
+        "status": "approved",
+        "labels": ["ui", "ux"],
+    }
+    assert isinstance(result, dict)
+
+
+def test_validate_tool_call_accepts_search_filters_with_nulls():
+    arguments = {
+        "query": None,
+        "labels": None,
+        "status": None,
+        "page": 3,
+        "per_page": 10,
+    }
+
+    result = validate_tool_call("search_requirements", arguments)
+
+    assert result == arguments
+
+
+@pytest.mark.parametrize(
+    "arguments,expected_message",
+    [
+        (
+            {"status": "invalid"},
+            "Invalid arguments for list_requirements",
+        ),
+        (
+            {"page": 0},
+            "Invalid arguments for list_requirements",
+        ),
+        (
+            {"unknown": 1},
+            "Invalid arguments for list_requirements",
+        ),
+    ],
+)
+def test_validate_tool_call_rejects_invalid_list_filters(arguments, expected_message):
+    with pytest.raises(ToolValidationError) as exc:
+        validate_tool_call("list_requirements", arguments)
+
+    assert expected_message in str(exc.value)
+
+
+def test_validate_tool_call_rejects_invalid_search_status():
+    with pytest.raises(ToolValidationError) as exc:
+        validate_tool_call("search_requirements", {"status": "unknown"})
+
+    assert "Invalid arguments for search_requirements" in str(exc.value)


### PR DESCRIPTION
## Summary
- allow the LLM schemas for `list_requirements` and `search_requirements` to express pagination, status and label filters that the MCP server already supports, while keeping unknown arguments rejected
- extend the shared system prompt and README hints so operators know about the richer filter set
- cover the new arguments with unit tests around `validate_tool_call`

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68c9b945f53c8320b52b8d5fa4e4550f