### PR TITLE
Support chat history context for local agent

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -9,7 +9,7 @@ from typing import Any, Callable, Generic, Literal, Protocol, TypeVar
 
 import wx
 
-from .llm.constants import DEFAULT_MAX_OUTPUT_TOKENS
+from .llm.constants import DEFAULT_MAX_CONTEXT_TOKENS, DEFAULT_MAX_OUTPUT_TOKENS
 from .settings import AppSettings, LLMSettings, MCPSettings, UISettings
 
 
@@ -115,6 +115,7 @@ ConfigFieldName = Literal[
     "llm_api_key",
     "llm_max_retries",
     "llm_max_output_tokens",
+    "llm_max_context_tokens",
     "llm_timeout_minutes",
     "llm_stream",
     "sort_column",
@@ -221,6 +222,11 @@ CONFIG_FIELD_SPECS: dict[ConfigFieldName, FieldSpec[Any]] = {
         key="llm_max_output_tokens",
         value_type=int,
         default=DEFAULT_MAX_OUTPUT_TOKENS,
+    ),
+    "llm_max_context_tokens": FieldSpec(
+        key="llm_max_context_tokens",
+        value_type=int,
+        default=DEFAULT_MAX_CONTEXT_TOKENS,
     ),
     "llm_timeout_minutes": FieldSpec(
         key="llm_timeout_minutes",
@@ -538,6 +544,7 @@ class ConfigManager:
             api_key=self.get_value("llm_api_key"),
             max_retries=self.get_value("llm_max_retries"),
             max_output_tokens=self.get_value("llm_max_output_tokens"),
+            max_context_tokens=self.get_value("llm_max_context_tokens"),
             timeout_minutes=self.get_value("llm_timeout_minutes"),
             stream=self.get_value("llm_stream"),
         )
@@ -550,6 +557,7 @@ class ConfigManager:
         self.set_value("llm_api_key", settings.api_key)
         self.set_value("llm_max_retries", settings.max_retries)
         self.set_value("llm_max_output_tokens", settings.max_output_tokens)
+        self.set_value("llm_max_context_tokens", settings.max_context_tokens)
         self.set_value("llm_timeout_minutes", settings.timeout_minutes)
         self.set_value("llm_stream", settings.stream)
         self.flush()

--- a/app/llm/constants.py
+++ b/app/llm/constants.py
@@ -5,3 +5,9 @@ DEFAULT_MAX_OUTPUT_TOKENS = 5000
 
 MIN_MAX_OUTPUT_TOKENS = 1000
 """Lowest value accepted from the user for LLM responses."""
+
+DEFAULT_MAX_CONTEXT_TOKENS = 12000
+"""Maximum prompt size sent to the LLM when the user does not override it."""
+
+MIN_MAX_CONTEXT_TOKENS = 2000
+"""Lower bound for the prompt context size accepted from configuration."""

--- a/tests/gui/test_agent_chat_panel.py
+++ b/tests/gui/test_agent_chat_panel.py
@@ -26,7 +26,7 @@ def destroy_panel(frame, panel):
 
 def test_agent_chat_panel_sends_and_saves_history(tmp_path, wx_app):
     class DummyAgent:
-        def run_command(self, text):
+        def run_command(self, text, *, history=None):
             return {"ok": True, "error": None, "result": {"echo": text}}
 
     wx, frame, panel = create_panel(tmp_path, wx_app, DummyAgent())
@@ -56,7 +56,7 @@ def test_agent_chat_panel_sends_and_saves_history(tmp_path, wx_app):
 
 def test_agent_chat_panel_handles_error(tmp_path, wx_app):
     class FailingAgent:
-        def run_command(self, text):
+        def run_command(self, text, *, history=None):
             return {"ok": False, "error": {"code": "FAIL", "message": "bad"}}
 
     wx, frame, panel = create_panel(tmp_path, wx_app, FailingAgent())
@@ -73,7 +73,7 @@ def test_agent_chat_panel_handles_error(tmp_path, wx_app):
 
 def test_agent_chat_panel_persists_between_instances(tmp_path, wx_app):
     class EchoAgent:
-        def run_command(self, text):
+        def run_command(self, text, *, history=None):
             return {"ok": True, "error": None, "result": text}
 
     wx, frame1, panel1 = create_panel(tmp_path, wx_app, EchoAgent())
@@ -95,10 +95,69 @@ def test_agent_chat_panel_handles_invalid_history(tmp_path, wx_app):
     bad_file.write_text("{not json}")
 
     class DummyAgent:
-        def run_command(self, text):
+        def run_command(self, text, *, history=None):
             return {"ok": True, "error": None, "result": {}}
 
     frame = wx.Frame(None)
     panel = AgentChatPanel(frame, agent_supplier=lambda: DummyAgent(), history_path=bad_file)
     assert panel.history == []
+    destroy_panel(frame, panel)
+
+
+def test_agent_chat_panel_provides_history_context(tmp_path, wx_app):
+    class RecordingAgent:
+        def __init__(self) -> None:
+            self.calls: list[dict[str, object]] = []
+
+        def run_command(self, text, *, history=None):
+            recorded_history = list(history or [])
+            self.calls.append({"text": text, "history": recorded_history})
+            return {"ok": True, "error": None, "result": f"answer {len(self.calls)}"}
+
+    agent = RecordingAgent()
+    wx, frame, panel = create_panel(tmp_path, wx_app, agent)
+
+    panel.input.SetValue("first question")
+    panel._on_send(None)
+    assert agent.calls[0]["history"] == []
+    first_response = panel.history[0].response
+
+    panel.input.SetValue("second question")
+    panel._on_send(None)
+
+    expected_history = [
+        {"role": "user", "content": "first question"},
+        {"role": "assistant", "content": first_response},
+    ]
+    assert agent.calls[1]["history"] == expected_history
+
+    destroy_panel(frame, panel)
+
+
+def test_agent_chat_panel_clear_history_resets_context(tmp_path, wx_app):
+    class RecordingAgent:
+        def __init__(self) -> None:
+            self.calls: list[dict[str, object]] = []
+
+        def run_command(self, text, *, history=None):
+            recorded_history = list(history or [])
+            self.calls.append({"text": text, "history": recorded_history})
+            return {"ok": True, "error": None, "result": f"answer {len(self.calls)}"}
+
+    agent = RecordingAgent()
+    wx, frame, panel = create_panel(tmp_path, wx_app, agent)
+
+    panel.input.SetValue("keep this")
+    panel._on_send(None)
+    assert agent.calls[0]["history"] == []
+
+    panel._on_clear_history(None)
+    assert panel.history == []
+    assert panel.history_list.GetCount() == 0
+    assert "Start chatting" in panel.transcript.GetValue()
+
+    panel.input.SetValue("after clear")
+    panel._on_send(None)
+    assert agent.calls[-1]["history"] == []
+
     destroy_panel(frame, panel)

--- a/tests/integration/test_llm_client.py
+++ b/tests/integration/test_llm_client.py
@@ -11,6 +11,7 @@ import pytest
 
 from app.llm.client import NO_API_KEY, LLMClient
 from app.llm.constants import DEFAULT_MAX_OUTPUT_TOKENS, MIN_MAX_OUTPUT_TOKENS
+from app.llm.spec import SYSTEM_PROMPT
 from app.log import logger
 from app.mcp.server import JsonlHandler
 from app.settings import LLMSettings
@@ -112,6 +113,106 @@ def test_check_llm_uses_default_when_no_limit(tmp_path: Path, monkeypatch) -> No
     assert captured["max_output_tokens"] == DEFAULT_MAX_OUTPUT_TOKENS
 
 
+def test_parse_command_includes_history(tmp_path: Path, monkeypatch) -> None:
+    settings = settings_with_llm(tmp_path)
+    captured: dict[str, object] = {}
+
+    class FakeOpenAI:
+        def __init__(self, *a, **k):  # pragma: no cover - simple container
+            def create(*, model, messages, tools=None, **kwargs):  # noqa: ANN001
+                captured["messages"] = messages
+                return SimpleNamespace(
+                    choices=[
+                        SimpleNamespace(
+                            message=SimpleNamespace(
+                                tool_calls=[
+                                    SimpleNamespace(
+                                        function=SimpleNamespace(
+                                            name="list_requirements",
+                                            arguments="{}",
+                                        )
+                                    )
+                                ]
+                            )
+                        )
+                    ]
+                )
+
+            self.chat = SimpleNamespace(
+                completions=SimpleNamespace(create=create)
+            )
+
+    monkeypatch.setattr("openai.OpenAI", FakeOpenAI)
+    client = LLMClient(settings.llm)
+    history = [
+        {"role": "user", "content": "hello"},
+        {"role": "assistant", "content": "hi"},
+        {"role": "system", "content": "drop me"},
+    ]
+    tool, args = client.parse_command("follow up", history=history)
+    assert tool == "list_requirements"
+    assert args == {}
+    messages = captured["messages"]
+    assert messages[0] == {"role": "system", "content": SYSTEM_PROMPT}
+    assert messages[-1] == {"role": "user", "content": "follow up"}
+    assert messages[1:-1] == [
+        {"role": "user", "content": "hello"},
+        {"role": "assistant", "content": "hi"},
+    ]
+
+
+def test_parse_command_trims_history_by_tokens(tmp_path: Path, monkeypatch) -> None:
+    settings = settings_with_llm(tmp_path)
+    captured: dict[str, object] = {}
+
+    class FakeOpenAI:
+        def __init__(self, *a, **k):  # pragma: no cover - simple container
+            def create(*, model, messages, **kwargs):  # noqa: ANN001
+                captured["messages"] = messages
+                return SimpleNamespace(
+                    choices=[
+                        SimpleNamespace(
+                            message=SimpleNamespace(
+                                tool_calls=[
+                                    SimpleNamespace(
+                                        function=SimpleNamespace(
+                                            name="list_requirements",
+                                            arguments="{}",
+                                        )
+                                    )
+                                ]
+                            )
+                        )
+                    ]
+                )
+
+            self.chat = SimpleNamespace(
+                completions=SimpleNamespace(create=create)
+            )
+
+    monkeypatch.setattr("openai.OpenAI", FakeOpenAI)
+    monkeypatch.setattr(LLMClient, "_resolved_max_context_tokens", lambda self: 4)
+    monkeypatch.setattr(LLMClient, "_count_tokens", staticmethod(lambda text: 1 if text else 0))
+    client = LLMClient(settings.llm)
+    history = [
+        {"role": "user", "content": "h1"},
+        {"role": "assistant", "content": "a1"},
+        {"role": "user", "content": "h2"},
+        {"role": "assistant", "content": "a2"},
+    ]
+    tool, args = client.parse_command("latest", history=history)
+    assert tool == "list_requirements"
+    assert args == {}
+    messages = captured["messages"]
+    # With the patched token counter each message costs 1 token. Limit reserves
+    # 2 tokens for system prompt and current user message, leaving room for two
+    # entries from history.
+    assert messages[1:-1] == [
+        {"role": "user", "content": "h2"},
+        {"role": "assistant", "content": "a2"},
+    ]
+
+
 def test_parse_command_uses_default_when_no_limit(tmp_path: Path, monkeypatch) -> None:
     settings = settings_with_llm(tmp_path)
     settings.llm.max_output_tokens = None
@@ -178,6 +279,7 @@ def test_parse_command_async(tmp_path: Path, monkeypatch) -> None:
     responses = {"anything": ("list_requirements", {"per_page": 2})}
     monkeypatch.setattr("openai.OpenAI", make_openai_mock(responses))
     client = LLMClient(settings.llm)
-    tool, args = asyncio.run(client.parse_command_async("anything"))
+    history = [{"role": "user", "content": "earlier"}]
+    tool, args = asyncio.run(client.parse_command_async("anything", history=history))
     assert tool == "list_requirements"
     assert args == {"per_page": 2}


### PR DESCRIPTION
## Summary
- pass accumulated chat history from the agent chat panel into LocalAgent and LLM calls while trimming context
- add a button to clear chat history and configuration support for maximum context tokens
- extend GUI, integration, and unit tests to cover history propagation and resets

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68c9bb1031208320af49ed40f061e508