### PR TITLE
Add CLI command to edit requirements in place

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ Subcommands:
 - `doc delete <root> <PREFIX> [--dry-run]` — delete a document
 
 - `item add <root> <PREFIX> --title T --statement S [--labels L1,L2]` — add a requirement to a document
+- `item edit <root> <RID> [--title T --status S --statement S ...]` — update a requirement in place without changing its RID.
+  Supports the same optional flags as `item add` (`--title`, `--statement`, `--type`, `--status`, `--owner`, `--priority`,
+  `--source`, `--verification`, `--acceptance`, `--conditions`, `--rationale`, `--assumptions`, `--modified-at`, `--approved-at`,
+  `--notes`, `--attachments`, `--labels`, `--links`, `--data`).
 - `item move <root> <RID> <NEW_PREFIX>` — move a requirement to another document
 - `item delete <root> <RID> [--dry-run]` — delete a requirement and update references
 


### PR DESCRIPTION
## Summary
- add an `item edit` subcommand that reuses the payload builder to update requirements without changing their RID
- share option registration between `item add` and `item edit` so both expose the same flags
- cover the new command with a unit test and document it in the CLI section of the README

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68c9bc45b8dc83209a5ce31aedd4d0bd