### PR TITLE
Fix migrate_to_docs naming to match document layout

### DIFF
--- a/tests/unit/test_migrate_to_docs.py
+++ b/tests/unit/test_migrate_to_docs.py
@@ -48,6 +48,10 @@ def test_migrate_to_docs_basic(tmp_path: Path) -> None:
     hlr_item = tmp_path / "HLR" / "items" / "002.json"
     assert sys_item.is_file()
     assert hlr_item.is_file()
+    sys_names = [p.stem for p in (tmp_path / "SYS" / "items").glob("*.json")]
+    hlr_names = [p.stem for p in (tmp_path / "HLR" / "items").glob("*.json")]
+    assert all(name.isdigit() for name in sys_names)
+    assert all(name.isdigit() for name in hlr_names)
 
     sys_data = json.loads(sys_item.read_text(encoding="utf-8"))
     hlr_data = json.loads(hlr_item.read_text(encoding="utf-8"))


### PR DESCRIPTION
## Summary
- reuse document-store helpers in `migrate_to_docs` so migrated items are written via the canonical path logic and descriptors are persisted with `save_document`
- instantiate document definitions up-front to drop manual filename formatting and align with the layout that no longer embeds the prefix in item names
- extend the migration unit test to ensure generated item filenames are numeric-only stems

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68c9c3f811fc8320953a30126fbe63e8