### PR TITLE
Add masked env loader utility for tests

### DIFF
--- a/app/ui/settings_dialog.py
+++ b/app/ui/settings_dialog.py
@@ -7,6 +7,7 @@ from importlib import resources
 import wx
 
 from ..i18n import _
+from ..log import logger
 from ..llm.client import LLMClient
 from ..llm.constants import DEFAULT_MAX_OUTPUT_TOKENS, MIN_MAX_OUTPUT_TOKENS
 from ..mcp.client import MCPClient
@@ -708,6 +709,13 @@ class SettingsDialog(wx.Dialog):
             button.Enable(True)
             status_label.SetLabel(_("ok") if ok else _("error"))
             status_label.SetToolTip(tooltip if tooltip else None)
+            if not ok:
+                label_getter = getattr(button, "GetLabelText", None)
+                button_label = (
+                    label_getter() if callable(label_getter) else button.GetLabel()
+                )
+                message = tooltip or _("Unknown error")
+                logger.warning("%s failed: %s", button_label, message)
 
         def worker() -> None:
             try:

--- a/tests/env_utils.py
+++ b/tests/env_utils.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Iterable, Optional
+
+
+class SecretEnvValue:
+    """Container for secrets that hides their value in repr/str output.
+
+    Tests can safely pass the secret further through the object, calling
+    :meth:`get_secret_value` when the actual string is required.  Any implicit
+    conversion to ``str`` (for example, when interpolated in logs) will be
+    masked to avoid accidental disclosure of sensitive data during debugging
+    or in CI logs.
+    """
+
+    __slots__ = ("_name", "__value")
+
+    def __init__(self, name: str, value: str) -> None:
+        if not name:
+            raise ValueError("SecretEnvValue requires a non-empty variable name")
+        if value is None or value == "":
+            raise ValueError("SecretEnvValue requires a non-empty value")
+        self._name = name
+        self.__value = value
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    def get_secret_value(self) -> str:
+        return self.__value
+
+    def __bool__(self) -> bool:  # pragma: no cover - trivial
+        return True
+
+    def __repr__(self) -> str:  # pragma: no cover - trivial
+        return f"<SecretEnvValue {self._name}=***>"
+
+    __str__ = __repr__
+
+    def __format__(self, format_spec: str) -> str:  # pragma: no cover - trivial
+        return str(self)
+
+
+def load_secret_from_env(
+    variable_name: str,
+    *,
+    search_from: Path | str | None = None,
+    env_file_name: str = ".env",
+) -> Optional[SecretEnvValue]:
+    """Load a secret from the environment or the nearest ``.env`` file.
+
+    Parameters
+    ----------
+    variable_name:
+        Name of the environment variable to look up.
+    search_from:
+        Starting path for searching ``.env`` files in parent directories.
+        When ``None`` (default) the current working directory is used.
+    env_file_name:
+        Allows overriding the name of the dotenv file during tests.
+    """
+
+    value = os.getenv(variable_name)
+    if value:
+        return SecretEnvValue(variable_name, value)
+
+    search_root = _normalise_search_root(search_from)
+    for env_path in _iter_env_paths(search_root, env_file_name):
+        value = _extract_from_env_file(env_path, variable_name)
+        if value:
+            return SecretEnvValue(variable_name, value)
+    return None
+
+
+def _normalise_search_root(search_from: Path | str | None) -> Path:
+    if search_from is None:
+        return Path.cwd()
+    path = Path(search_from)
+    return path if path.is_dir() else path.parent
+
+
+def _iter_env_paths(root: Path, env_file_name: str) -> Iterable[Path]:
+    for directory in (root, *root.parents):
+        env_path = directory / env_file_name
+        if env_path.is_file():
+            yield env_path
+
+
+def _extract_from_env_file(env_path: Path, variable_name: str) -> Optional[str]:
+    try:
+        content = env_path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+
+    for raw_line in content.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line.startswith("export "):
+            line = line[len("export ") :].lstrip()
+        if "=" not in line:
+            continue
+        name, raw_value = line.split("=", 1)
+        if name.strip() != variable_name:
+            continue
+        raw_value = raw_value.strip()
+        if not raw_value:
+            return None
+        is_double_quoted = raw_value.startswith("\"") and raw_value.endswith("\"")
+        is_single_quoted = raw_value.startswith("'") and raw_value.endswith("'")
+        if is_double_quoted or is_single_quoted:
+            value = raw_value[1:-1]
+        else:
+            value = raw_value.split("#", 1)[0].rstrip()
+        return value
+    return None

--- a/tests/integration/test_llm_openrouter_integration.py
+++ b/tests/integration/test_llm_openrouter_integration.py
@@ -1,9 +1,9 @@
-import os
 from pathlib import Path
 
 import pytest
 
 from app.llm.client import LLMClient
+from tests.env_utils import load_secret_from_env
 from tests.llm_utils import require_real_llm_tests_flag, settings_with_llm
 
 REQUIRES_REAL_LLM = True
@@ -12,15 +12,8 @@ pytestmark = [pytest.mark.integration, pytest.mark.real_llm]
 
 
 def _load_openrouter_key() -> str | None:
-    key = os.getenv("OPEN_ROUTER")
-    if key:
-        return key
-    env_path = Path(__file__).resolve().parents[1] / ".env"
-    if env_path.exists():
-        for line in env_path.read_text().splitlines():
-            if line.startswith("OPEN_ROUTER="):
-                return line.split("=", 1)[1].strip()
-    return None
+    secret = load_secret_from_env("OPEN_ROUTER", search_from=Path(__file__).resolve())
+    return secret.get_secret_value() if secret else None
 
 
 def test_openrouter_check_llm(tmp_path):

--- a/tests/unit/test_env_utils.py
+++ b/tests/unit/test_env_utils.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import pytest
+
+from tests.env_utils import SecretEnvValue, load_secret_from_env
+
+
+def test_loads_from_environment_overrides_dotenv(monkeypatch, tmp_path):
+    env_path = tmp_path / ".env"
+    env_path.write_text("OPEN_ROUTER=from-file\n", encoding="utf-8")
+    monkeypatch.setenv("OPEN_ROUTER", "from-env")
+
+    secret = load_secret_from_env("OPEN_ROUTER", search_from=tmp_path)
+
+    assert isinstance(secret, SecretEnvValue)
+    assert secret.get_secret_value() == "from-env"
+
+
+def test_loads_from_nearest_dotenv(monkeypatch, tmp_path):
+    monkeypatch.delenv("OPEN_ROUTER", raising=False)
+    nested = tmp_path / "nested" / "child"
+    nested.mkdir(parents=True)
+    env_path = tmp_path / ".env"
+    env_path.write_text("OPEN_ROUTER=from-dotenv\n", encoding="utf-8")
+
+    secret = load_secret_from_env("OPEN_ROUTER", search_from=nested)
+
+    assert secret is not None
+    assert secret.get_secret_value() == "from-dotenv"
+
+
+@pytest.mark.parametrize(
+    "line,expected",
+    [
+        ("OPEN_ROUTER=plain", "plain"),
+        ("OPEN_ROUTER='single-quoted'", "single-quoted"),
+        ("OPEN_ROUTER=\"double-quoted\"", "double-quoted"),
+        ("export OPEN_ROUTER=exported", "exported"),
+        ("OPEN_ROUTER=value # comment", "value"),
+        ("OPEN_ROUTER=\"quoted # comment\"", "quoted # comment"),
+    ],
+)
+def test_parses_supported_line_formats(monkeypatch, tmp_path, line, expected):
+    monkeypatch.delenv("OPEN_ROUTER", raising=False)
+    env_path = tmp_path / ".env"
+    env_path.write_text(f"{line}\n", encoding="utf-8")
+
+    secret = load_secret_from_env("OPEN_ROUTER", search_from=tmp_path)
+
+    assert secret is not None
+    assert secret.get_secret_value() == expected
+
+
+def test_secret_repr_masks_value(monkeypatch, tmp_path):
+    monkeypatch.setenv("OPEN_ROUTER", "top-secret")
+
+    secret = load_secret_from_env("OPEN_ROUTER", search_from=tmp_path)
+
+    assert secret is not None
+    assert "top-secret" not in str(secret)
+    assert secret.get_secret_value() == "top-secret"


### PR DESCRIPTION
## Summary
- add a reusable tests.env_utils helper that loads secrets from env or parent .env files while masking their repr
- update the OpenRouter integration test to use the new loader
- cover the helper with unit tests for environment precedence, search order, and quoting/comment parsing

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68c9d16cf0148320b4bdb7c58d87ba8b