### PR TITLE
Add compact titles for main panels

### DIFF
--- a/app/locale/en/LC_MESSAGES/CookaReq.po
+++ b/app/locale/en/LC_MESSAGES/CookaReq.po
@@ -214,6 +214,18 @@ msgstr "Show Agent Chat"
 msgid "Error Console"
 msgstr "Error Console"
 
+msgid "Hierarchy"
+msgstr "Hierarchy"
+
+msgid "Requirements"
+msgstr "Requirements"
+
+msgid "Editor"
+msgstr "Editor"
+
+msgid "Agent Chat"
+msgstr "Agent Chat"
+
 msgid "Source"
 msgstr "Source"
 

--- a/app/locale/ru/LC_MESSAGES/CookaReq.po
+++ b/app/locale/ru/LC_MESSAGES/CookaReq.po
@@ -198,6 +198,18 @@ msgstr "Показать чат с агентом"
 msgid "Error Console"
 msgstr "Консоль ошибок"
 
+msgid "Hierarchy"
+msgstr "Иерархия"
+
+msgid "Requirements"
+msgstr "Требования"
+
+msgid "Editor"
+msgstr "Редактор"
+
+msgid "Agent Chat"
+msgstr "Чат с агентом"
+
 msgid "&View"
 msgstr "&Вид"
 


### PR DESCRIPTION
## Summary
- add compact section headers for the document tree, requirements list, editor, and agent chat areas
- refactor the main frame to wrap panes in reusable labeled containers and keep visibility helpers consistent
- update English and Russian translations for the new section labels

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68ca4ec8cfc4832094ed3e234ab071f0