### PR TITLE
Stop validating legacy digits metadata in document loader

### DIFF
--- a/app/core/document_store/documents.py
+++ b/app/core/document_store/documents.py
@@ -49,15 +49,6 @@ def load_document(directory: str | Path) -> Document:
         allow_freeform=labels_data.get("allowFreeform", False),
         defs=defs,
     )
-    digits_raw = data.get("digits")
-    if digits_raw not in (None, ""):
-        try:
-            digits_value = int(digits_raw)
-        except (TypeError, ValueError) as exc:
-            raise ValidationError("digits must be an integer") from exc
-        if digits_value <= 0:
-            raise ValidationError("digits must be positive")
-
     return Document(
         prefix=prefix,
         title=data.get("title", prefix),

--- a/tests/unit/test_doc_store.py
+++ b/tests/unit/test_doc_store.py
@@ -50,6 +50,24 @@ def test_document_store_roundtrip(tmp_path: Path):
     assert data["statement"] == "Second"
 
 
+def test_load_document_ignores_legacy_digits_field(tmp_path: Path) -> None:
+    doc_dir = tmp_path / "SYS"
+    doc_dir.mkdir()
+    doc_path = doc_dir / "document.json"
+    with doc_path.open("w", encoding="utf-8") as fh:
+        json.dump({"title": "System", "digits": "00foo"}, fh)
+
+    loaded = load_document(doc_dir)
+
+    assert loaded.title == "System"
+    assert not hasattr(loaded, "digits")
+
+    save_document(doc_dir, loaded)
+
+    stored = json.loads(doc_path.read_text(encoding="utf-8"))
+    assert "digits" not in stored
+
+
 def test_load_item_accepts_arbitrarily_padded_filenames(tmp_path: Path):
     doc_dir = tmp_path / "SYS"
     doc = Document(prefix="SYS", title="System")


### PR DESCRIPTION
## Summary
- remove the legacy digits field validation from `load_document` so old configs no longer error
- add a regression test to ensure legacy digits metadata is ignored and stripped on save

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68ca69eb3db88320887c36a3ff7a7afb