### PR TITLE
Show blank editor when no requirement is selected

### DIFF
--- a/app/ui/main_frame.py
+++ b/app/ui/main_frame.py
@@ -232,7 +232,7 @@ class MainFrame(wx.Frame):
         )
         self._doc_tree_collapsed = False
         self._doc_tree_saved_sash = self.doc_splitter.GetSashPosition()
-        self._hide_editor_panel()
+        self._clear_editor_panel()
 
         self.log_panel = wx.Panel(self.main_splitter)
         log_sizer = wx.BoxSizer(wx.VERTICAL)
@@ -617,6 +617,17 @@ class MainFrame(wx.Frame):
         self.editor.Hide()
         self.editor_container.Hide()
 
+    def _clear_editor_panel(self) -> None:
+        """Reset editor contents and reflect current visibility setting."""
+
+        if not getattr(self, "editor", None):
+            return
+        self.editor.new_requirement()
+        if self._is_editor_visible():
+            self._show_editor_panel()
+        else:
+            self._hide_editor_panel()
+
     def _is_editor_visible(self) -> bool:
         """Return ``True`` when the main editor pane is enabled."""
 
@@ -976,7 +987,7 @@ class MainFrame(wx.Frame):
         if self.remember_sort and self.sort_column != -1:
             self.panel.sort(self.sort_column, self.sort_ascending)
         self._selected_requirement_id = None
-        self._hide_editor_panel()
+        self._clear_editor_panel()
 
     def _show_directory_error(self, path: Path, error: Exception) -> None:
         """Display error message for a failed directory load."""
@@ -1018,7 +1029,7 @@ class MainFrame(wx.Frame):
             self.editor.update_labels_list([])
             self.panel.update_labels_list([])
             self._selected_requirement_id = None
-            self._hide_editor_panel()
+            self._clear_editor_panel()
 
     def _load_document_contents(self, prefix: str) -> bool:
         """Load items and labels for ``prefix`` and update the views."""
@@ -1038,7 +1049,7 @@ class MainFrame(wx.Frame):
             self.editor.update_labels_list([], False)
             self.panel.update_labels_list([])
             self._selected_requirement_id = None
-            self._hide_editor_panel()
+            self._clear_editor_panel()
             self.splitter.UpdateSize()
             return False
         labels, freeform = self.docs_controller.collect_labels(prefix)
@@ -1046,7 +1057,7 @@ class MainFrame(wx.Frame):
         self.editor.update_labels_list(labels, freeform)
         self.panel.update_labels_list(labels)
         self._selected_requirement_id = None
-        self._hide_editor_panel()
+        self._clear_editor_panel()
         self.splitter.UpdateSize()
         return True
 
@@ -1681,7 +1692,7 @@ class MainFrame(wx.Frame):
 
         self._selected_requirement_id = None
         self.panel.recalc_derived_map(self.model.get_all())
-        self._hide_editor_panel()
+        self._clear_editor_panel()
         self.splitter.UpdateSize()
         labels, freeform = self.docs_controller.collect_labels(
             self.current_doc_prefix

--- a/tests/gui/test_main_clone_derive.py
+++ b/tests/gui/test_main_clone_derive.py
@@ -151,7 +151,9 @@ def test_delete_many_removes_requirements(monkeypatch, wx_app, tmp_path):
         assert frame.model.get_by_id(3) is None
         assert frame.panel.list.GetItemCount() == 1
         assert frame._selected_requirement_id is None
-        assert not frame.editor.IsShown()
+        assert frame.editor.IsShown()
+        assert frame.editor.fields["id"].GetValue() == ""
+        assert frame.editor.fields["title"].GetValue() == ""
         assert "message" in captured
         assert "Delete 2 requirements" in captured["message"]
         assert "Second" in captured["message"]


### PR DESCRIPTION
## Summary
- keep the requirement editor visible and reset it to a clean state whenever no item is selected
- add a helper to clear the editor and reuse it from directory refresh, document loads, and deletions
- update GUI tests to expect the blank editor instead of a hidden panel after mass deletion

## Testing
- pytest -q


------
https://chatgpt.com/codex/tasks/task_e_68ca72681a4c832094a1e587acd2362a