### PR TITLE
Fix deletion confirmation dialog and menu behaviour

### DIFF
--- a/app/confirm.py
+++ b/app/confirm.py
@@ -23,18 +23,30 @@ def confirm(message: str) -> bool:
 
 def wx_confirm(message: str) -> bool:
     """GUI confirmation dialog using wxWidgets."""
+
     import wx  # type: ignore
 
     from .i18n import _
 
-    return (
-        wx.MessageBox(
-            message,
-            _("Confirm"),
-            style=wx.YES_NO | wx.ICON_WARNING,
-        )
-        == wx.YES
-    )
+    try:
+        parent = wx.GetActiveWindow()
+    except AttributeError:  # pragma: no cover - stubs may omit helper
+        parent = None
+    if not parent:
+        try:
+            windows = wx.GetTopLevelWindows()
+        except AttributeError:  # pragma: no cover - stubs may omit helper
+            windows = []
+        parent = windows[0] if windows else None
+
+    style = wx.YES_NO | wx.NO_DEFAULT | wx.ICON_WARNING
+    dialog = wx.MessageDialog(parent, message, _("Confirm"), style=style)
+    try:
+        result = dialog.ShowModal()
+    finally:
+        dialog.Destroy()
+
+    return result in {wx.ID_YES, wx.YES, wx.ID_OK, wx.OK}
 
 
 def auto_confirm(_message: str) -> bool:

--- a/app/ui/list_panel.py
+++ b/app/ui/list_panel.py
@@ -111,6 +111,7 @@ class ListPanel(wx.Panel, ColumnSorterMixin):
         self._sort_ascending = True
         self._docs_controller = docs_controller
         self._current_doc_prefix: str | None = None
+        self._context_menu_open = False
         self._setup_columns()
         sizer.Add(btn_row, 0, wx.ALL, 5)
         sizer.Add(self.list, 1, wx.EXPAND | wx.ALL, 5)
@@ -786,9 +787,18 @@ class ListPanel(wx.Panel, ColumnSorterMixin):
 
     # context menu ----------------------------------------------------
     def _popup_context_menu(self, index: int, column: int | None) -> None:
+        if self._context_menu_open:
+            return
         menu, _, _, _ = self._create_context_menu(index, column)
-        self.PopupMenu(menu)
-        menu.Destroy()
+        if not menu.GetMenuItemCount():
+            menu.Destroy()
+            return
+        self._context_menu_open = True
+        try:
+            self.PopupMenu(menu)
+        finally:
+            menu.Destroy()
+            self._context_menu_open = False
 
     def _on_right_click(self, event: ListEvent) -> None:  # pragma: no cover - GUI event
         x, y = event.GetPoint()


### PR DESCRIPTION
## Summary
- replace the wx-based confirmation dialog with a MessageDialog that honours Yes/OK responses across platforms
- prevent duplicate context menu popups by tracking the popup state in the requirements list panel
- extend the confirmation dialog test to exercise the new dialog workflow and cross-platform return codes

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68ca8dd4b8948320a3a7862468cc8562