### PR TITLE
Simplify requirement cancel flow to reload current model state

### DIFF
--- a/app/ui/main_frame.py
+++ b/app/ui/main_frame.py
@@ -219,6 +219,7 @@ class MainFrame(wx.Frame):
             factory=lambda parent: EditorPanel(
                 parent,
                 on_save=self._on_editor_save,
+                on_discard=self._handle_editor_discard,
             ),
         )
         self.splitter.SplitVertically(self.list_container, self.editor_container, 300)
@@ -678,7 +679,7 @@ class MainFrame(wx.Frame):
         if not self.editor.is_dirty():
             return True
         if confirm(_("Discard unsaved changes?")):
-            self.editor.mark_clean()
+            self.editor.discard_changes()
             return True
         return False
 
@@ -846,6 +847,7 @@ class MainFrame(wx.Frame):
         self.editor = EditorPanel(
             self.editor_container,
             on_save=self._on_editor_save,
+            on_discard=self._handle_editor_discard,
         )
         editor_sizer = self.editor_container.GetSizer()
         if editor_sizer is not None:
@@ -1275,6 +1277,17 @@ class MainFrame(wx.Frame):
         if not self.docs_controller:
             return
         self._save_editor_contents(self.editor, doc_prefix=self.current_doc_prefix)
+
+    def _handle_editor_discard(self) -> bool:
+        """Reload currently selected requirement into the editor."""
+
+        if self._selected_requirement_id is None:
+            return False
+        requirement = self.model.get_by_id(self._selected_requirement_id)
+        if not requirement:
+            return False
+        self.editor.load(requirement)
+        return True
 
     def _open_detached_editor(self, requirement: Requirement) -> None:
         if not (self.docs_controller and self.current_dir):

--- a/tests/gui/test_editor_dirty.py
+++ b/tests/gui/test_editor_dirty.py
@@ -46,3 +46,68 @@ def test_editor_panel_mark_clean_resets_dirty(wx_app):
         assert panel.is_dirty() is True
     finally:
         frame.Destroy()
+
+
+def test_editor_panel_discard_changes_without_storage_restores_form_state(wx_app):
+    pytest.importorskip("wx")
+    import wx
+
+    from app.ui.editor_panel import EditorPanel
+
+    frame = wx.Frame(None)
+    try:
+        panel = EditorPanel(frame)
+        panel.fields["title"].ChangeValue("Original")
+        panel.notes_ctrl.ChangeValue("Base note")
+        panel.attachments = [{"path": "doc.txt", "note": "ref"}]
+        panel.mark_clean()
+
+        panel.fields["title"].ChangeValue("Changed")
+        panel.notes_ctrl.ChangeValue("New note")
+        panel.attachments.clear()
+        assert panel.is_dirty() is True
+
+        panel.discard_changes()
+
+        assert panel.fields["title"].GetValue() == "Original"
+        assert panel.notes_ctrl.GetValue() == "Base note"
+        assert panel.attachments == [{"path": "doc.txt", "note": "ref"}]
+        assert panel.is_dirty() is False
+    finally:
+        frame.Destroy()
+
+
+def test_editor_panel_discard_changes_uses_callback(wx_app):
+    pytest.importorskip("wx")
+    import wx
+
+    from app.ui.editor_panel import EditorPanel
+
+    frame = wx.Frame(None)
+    try:
+        handled: list[str] = []
+
+        def on_discard() -> bool:
+            handled.append(panel.fields["title"].GetValue())
+            panel.fields["title"].ChangeValue("Callback title")
+            panel.notes_ctrl.ChangeValue("Callback note")
+            panel.mark_clean()
+            return True
+
+        panel = EditorPanel(frame, on_discard=on_discard)
+        panel.fields["title"].ChangeValue("Original")
+        panel.notes_ctrl.ChangeValue("Note")
+        panel.mark_clean()
+
+        panel.fields["title"].ChangeValue("Dirty")
+        panel.notes_ctrl.ChangeValue("Dirty note")
+        assert panel.is_dirty() is True
+
+        panel.discard_changes()
+
+        assert handled == ["Dirty"]
+        assert panel.fields["title"].GetValue() == "Callback title"
+        assert panel.notes_ctrl.GetValue() == "Callback note"
+        assert panel.is_dirty() is False
+    finally:
+        frame.Destroy()


### PR DESCRIPTION
## Summary
- add an optional discard callback to `EditorPanel` and drop the disk reload logic in favour of either host-provided handling or the local snapshot fallback
- make `MainFrame` provide a discard handler that reloads the currently selected requirement so Cancel mirrors list selection
- update GUI tests to cover the callback path and confirm that the dirty confirmation reloads data from the model

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68cab91be6648320a3f4b3565956d43f