### PR TITLE
Revamp log console with level selection and rotated logs

### DIFF
--- a/app/locale/en/LC_MESSAGES/CookaReq.po
+++ b/app/locale/en/LC_MESSAGES/CookaReq.po
@@ -234,14 +234,26 @@ msgstr "Settings"
 msgid "Short title"
 msgstr "Short title"
 
-msgid "Show Error Console"
-msgstr "Show Error Console"
+msgid "Show Log Console"
+msgstr "Show Log Console"
 
 msgid "Show Agent Chat"
 msgstr "Show Agent Chat"
 
-msgid "Error Console"
-msgstr "Error Console"
+msgid "Log Console"
+msgstr "Log Console"
+
+msgid "Log Level"
+msgstr "Log Level"
+
+msgid "Debug"
+msgstr "Debug"
+
+msgid "Info"
+msgstr "Info"
+
+msgid "Warning"
+msgstr "Warning"
 
 msgid "Hierarchy"
 msgstr "Hierarchy"

--- a/app/locale/ru/LC_MESSAGES/CookaReq.po
+++ b/app/locale/ru/LC_MESSAGES/CookaReq.po
@@ -219,14 +219,26 @@ msgstr "В&ыход"
 msgid "&File"
 msgstr "&Файл"
 
-msgid "Show Error Console"
-msgstr "Показать консоль ошибок"
+msgid "Show Log Console"
+msgstr "Показать консоль логов"
 
 msgid "Show Agent Chat"
 msgstr "Показать чат с агентом"
 
-msgid "Error Console"
-msgstr "Консоль ошибок"
+msgid "Log Console"
+msgstr "Консоль логов"
+
+msgid "Log Level"
+msgstr "Уровень логов"
+
+msgid "Debug"
+msgstr "Отладка"
+
+msgid "Info"
+msgstr "Информация"
+
+msgid "Warning"
+msgstr "Предупреждение"
 
 msgid "Hierarchy"
 msgstr "Иерархия"

--- a/app/log.py
+++ b/app/log.py
@@ -4,12 +4,26 @@ from __future__ import annotations
 
 import json
 import logging
+import os
+import subprocess
+import sys
 from pathlib import Path
 from typing import Any
 
 from .util.time import utc_now_iso
 
+LOG_DIR_ENV = "COOKAREQ_LOG_DIR"
+_DEFAULT_HOME_DIR = ".cookareq"
+_DEFAULT_LOG_SUBDIR = "logs"
+_TEXT_LOG_NAME = "cookareq.log"
+_JSON_LOG_NAME = "cookareq.jsonl"
+_ROTATION_BACKUPS = 5
+
 logger = logging.getLogger("cookareq")
+
+_log_dir: Path | None = None
+_text_log_path: Path | None = None
+_json_log_path: Path | None = None
 
 
 class JsonlHandler(logging.Handler):
@@ -17,7 +31,7 @@ class JsonlHandler(logging.Handler):
 
     def __init__(self, filename: Path | str) -> None:
         """Create handler writing JSON lines to *filename*."""
-        super().__init__(level=logging.INFO)
+        super().__init__(level=logging.DEBUG)
         self.filename = Path(filename)
 
     def emit(self, record: logging.LogRecord) -> None:  # pragma: no cover - simple IO
@@ -28,20 +42,123 @@ class JsonlHandler(logging.Handler):
             data = {"message": record.getMessage(), "level": record.levelname}
         if "timestamp" not in data:
             data["timestamp"] = utc_now_iso()
+        self.filename.parent.mkdir(parents=True, exist_ok=True)
         with self.filename.open("a", encoding="utf-8") as fh:
             json.dump(data, fh, ensure_ascii=False)
             fh.write("\n")
 
 
-def configure_logging(level: int = logging.INFO) -> None:
+def _default_log_dir() -> Path:
+    """Return default directory for application logs."""
+
+    base = Path.home() / _DEFAULT_HOME_DIR
+    return base / _DEFAULT_LOG_SUBDIR
+
+
+def _resolve_log_dir(log_dir: str | Path | None) -> Path:
+    """Resolve effective log directory creating it if necessary."""
+
+    if log_dir is not None:
+        path = Path(log_dir).expanduser()
+    else:
+        env_dir = os.environ.get(LOG_DIR_ENV)
+        path = Path(env_dir).expanduser() if env_dir else _default_log_dir()
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def _rotate_log_file(path: Path, *, backups: int = _ROTATION_BACKUPS) -> None:
+    """Rotate ``path`` preserving up to ``backups`` previous generations."""
+
+    if backups <= 0:
+        path.unlink(missing_ok=True)
+        return
+
+    for index in range(backups, 0, -1):
+        rotated = path.with_name(f"{path.name}.{index}")
+        source = path if index == 1 else path.with_name(f"{path.name}.{index - 1}")
+        if not source.exists():
+            continue
+        if rotated.exists():
+            rotated.unlink()
+        source.rename(rotated)
+
+
+def configure_logging(level: int = logging.INFO, *, log_dir: str | Path | None = None) -> None:
     """Configure application logger once."""
+
+    global _log_dir, _text_log_path, _json_log_path
 
     if logger.handlers:
         return
-    handler = logging.StreamHandler()
-    handler.setFormatter(logging.Formatter("%(levelname)s: %(message)s"))
-    logger.addHandler(handler)
-    logger.setLevel(level)
+
+    resolved_dir = _resolve_log_dir(log_dir).resolve()
+    _log_dir = resolved_dir
+    _text_log_path = resolved_dir / _TEXT_LOG_NAME
+    _json_log_path = resolved_dir / _JSON_LOG_NAME
+
+    _rotate_log_file(_text_log_path)
+    _rotate_log_file(_json_log_path)
+    _json_log_path.touch(exist_ok=True)
+
+    stream_handler = logging.StreamHandler()
+    stream_handler.setLevel(level)
+    stream_handler.setFormatter(logging.Formatter("%(levelname)s: %(message)s"))
+    logger.addHandler(stream_handler)
+
+    file_handler = logging.FileHandler(_text_log_path, encoding="utf-8")
+    file_handler.setLevel(logging.DEBUG)
+    file_handler.setFormatter(
+        logging.Formatter("%(asctime)s %(levelname)s %(name)s: %(message)s")
+    )
+    logger.addHandler(file_handler)
+
+    json_handler = JsonlHandler(_json_log_path)
+    json_handler.setLevel(logging.DEBUG)
+    logger.addHandler(json_handler)
+
+    logger.setLevel(logging.DEBUG)
 
 
-__all__ = ["JsonlHandler", "configure_logging", "logger"]
+def get_log_directory() -> Path:
+    """Return directory where CookaReq writes log files."""
+
+    if _log_dir is None:
+        configure_logging()
+    assert _log_dir is not None
+    return _log_dir
+
+
+def get_log_file_paths() -> tuple[Path, Path]:
+    """Return paths to text and JSONL log files, configuring logging if needed."""
+
+    if _text_log_path is None or _json_log_path is None:
+        configure_logging()
+    assert _text_log_path is not None
+    assert _json_log_path is not None
+    return _text_log_path, _json_log_path
+
+
+def open_log_directory() -> bool:
+    """Open the log directory in the system file browser."""
+
+    directory = get_log_directory()
+    try:  # pragma: no cover - platform-dependent side effect
+        if sys.platform.startswith("win"):
+            os.startfile(str(directory))  # type: ignore[attr-defined]
+            return True
+        if sys.platform == "darwin":
+            return subprocess.call(["open", str(directory)]) == 0
+        return subprocess.call(["xdg-open", str(directory)]) == 0
+    except Exception:  # pragma: no cover - best effort helper
+        return False
+
+
+__all__ = [
+    "JsonlHandler",
+    "configure_logging",
+    "get_log_directory",
+    "get_log_file_paths",
+    "logger",
+    "open_log_directory",
+]

--- a/app/ui/navigation.py
+++ b/app/ui/navigation.py
@@ -34,6 +34,7 @@ class Navigation:
         on_show_trace_matrix: Callable[[wx.Event], None],
         on_new_requirement: Callable[[wx.Event], None],
         on_run_command: Callable[[wx.Event], None],
+        on_open_logs: Callable[[wx.Event], None],
     ) -> None:
         """Initialize navigation menus and event handlers."""
         self.frame = frame
@@ -52,6 +53,7 @@ class Navigation:
         self.on_show_trace_matrix = on_show_trace_matrix
         self.on_new_requirement = on_new_requirement
         self.on_run_command = on_run_command
+        self.on_open_logs = on_open_logs
         self._recent_items: dict[int, Path] = {}
         self._column_items: dict[int, str] = {}
         self.menu_bar = wx.MenuBar()
@@ -110,7 +112,7 @@ class Navigation:
         )
         self.log_menu_item = view_menu.AppendCheckItem(
             wx.ID_ANY,
-            _("Show Error Console"),
+            _("Show Log Console"),
         )
         self.frame.Bind(wx.EVT_MENU, self.on_toggle_log_console, self.log_menu_item)
         self.agent_chat_menu_item = view_menu.AppendCheckItem(
@@ -128,6 +130,8 @@ class Navigation:
         cmd_item = tools_menu.Append(wx.ID_ANY, _("Open Agent Chat\tCtrl+K"))
         self.frame.Bind(wx.EVT_MENU, self.on_run_command, cmd_item)
         self.run_command_id = cmd_item.GetId()
+        logs_item = tools_menu.Append(wx.ID_ANY, _("Open Log Folder"))
+        self.frame.Bind(wx.EVT_MENU, self.on_open_logs, logs_item)
         menu_bar.Append(tools_menu, _("&Tools"))
         self.menu_bar = menu_bar
         self.frame.SetMenuBar(self.menu_bar)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -18,7 +18,7 @@
 - `settings.py` — pydantic-модели `AppSettings`, `LLMSettings`, `MCPSettings`, `UISettings` и функции загрузки конфигов из JSON/TOML.【F:app/settings.py†L1-L89】【F:app/settings.py†L118-L149】
 - `confirm.py` — регистрация и реализация подтверждающих диалогов (`set_confirm`, `confirm`, `wx_confirm`, `auto_confirm`).【F:app/confirm.py†L1-L31】
 - `i18n.py` — минималистичная загрузка `.po`-каталогов и сбор недостающих переводов через `flush_missing`.【F:app/i18n.py†L1-L120】
-- `log.py` и `telemetry.py` — настройка логирования (`configure_logging`, `JsonlHandler`) и структурированная телеметрия (`log_event`, санитайзинг чувствительных данных).【F:app/log.py†L1-L34】【F:app/telemetry.py†L1-L49】
+- `log.py` и `telemetry.py` — настройка логирования (`configure_logging`, `JsonlHandler`) с ротацией файлов при старте процесса и одновременной записью в поток, текстовый и JSONL-логи, управление каталогом логов (`get_log_directory`, `open_log_directory`) и структурированная телеметрия (`log_event`, санитайзинг чувствительных данных).【F:app/log.py†L1-L131】【F:app/telemetry.py†L1-L49】
 - `util/` — вспомогательные функции времени (`utc_now_iso`, `normalize_timestamp`) и другие мелкие утилиты.【F:app/util/time.py†L1-L27】
 - `resources/` и `locale/` — иконки приложения и каталоги перевода, используемые `MainFrame` и `init_locale`.
 
@@ -29,7 +29,7 @@
 - `label_presets.py` — наборы предустановленных меток и генератор пастельных цветов для них.【F:app/core/label_presets.py†L1-L39】
 
 ### `app/ui/`
-- `main_frame.py` — главное окно: собирает панели (`DocumentTree`, `ListPanel`, `EditorPanel`, `AgentChatPanel`), меню `Navigation`, настраивает `MCPController` и связку с `DocumentsController` для загрузки данных; хранит в конфиге состояние сворачиваемой панели документов и ширину раскрытого дерева.【F:app/ui/main_frame.py†L1-L207】【F:app/config.py†L272-L311】
+- `main_frame.py` — главное окно: собирает панели (`DocumentTree`, `ListPanel`, `EditorPanel`, `AgentChatPanel`), меню `Navigation`, настраивает `MCPController` и связку с `DocumentsController` для загрузки данных; хранит в конфиге состояние сворачиваемой панели документов и ширину раскрытого дерева, отображает консоль логов с выбором уровня и усечением хвоста при росте истории.【F:app/ui/main_frame.py†L1-L317】【F:app/config.py†L272-L311】
 - `controllers/documents.py` — `DocumentsController` загружает и кэширует документы/требования, проверяет уникальность ID, сохраняет файлы и управляет удалением.【F:app/ui/controllers/documents.py†L1-L134】
 - `requirement_model.py` — модель представления, применяющая фильтры и сортировки поверх списка `Requirement`, доступная всем панелям GUI.【F:app/ui/requirement_model.py†L1-L92】【F:app/ui/requirement_model.py†L114-L167】
 - Панели: `list_panel.py` (табличный список с фильтрами и контекстным меню), `editor_panel.py` (форма редактирования требования с валидацией и вложениями), `document_tree.py` (иерархия документов), `navigation.py` (меню и хоткеи), `agent_chat_panel.py` (чат с `LocalAgent`); отдельное плавающее окно редактирования — `detached_editor.py` (переносит `EditorPanel` в отдельный `wx.Frame`, когда основной редактор скрыт).【F:app/ui/list_panel.py†L1-L92】【F:app/ui/editor_panel.py†L1-L81】【F:app/ui/document_tree.py†L1-L83】【F:app/ui/navigation.py†L1-L107】【F:app/ui/agent_chat_panel.py†L1-L77】【F:app/ui/detached_editor.py†L1-L86】

--- a/tests/unit/test_logging_config.py
+++ b/tests/unit/test_logging_config.py
@@ -1,10 +1,18 @@
 """Tests for logging config."""
 
 import logging
+from pathlib import Path
 
 import pytest
 
-from app.log import configure_logging, logger
+import app.log as log_module
+from app.log import (
+    JsonlHandler,
+    configure_logging,
+    get_log_directory,
+    get_log_file_paths,
+    logger,
+)
 
 pytestmark = pytest.mark.unit
 
@@ -13,27 +21,106 @@ pytestmark = pytest.mark.unit
 def reset_logger() -> None:
     prev_handlers = list(logger.handlers)
     prev_level = logger.level
+    prev_state = (
+        log_module._log_dir,
+        log_module._text_log_path,
+        log_module._json_log_path,
+    )
     logger.handlers.clear()
     logger.setLevel(logging.NOTSET)
+    log_module._log_dir = None
+    log_module._text_log_path = None
+    log_module._json_log_path = None
     try:
         yield
     finally:
+        for handler in logger.handlers:
+            handler.close()
         logger.handlers.clear()
         logger.handlers.extend(prev_handlers)
         logger.setLevel(prev_level)
+        (
+            log_module._log_dir,
+            log_module._text_log_path,
+            log_module._json_log_path,
+        ) = prev_state
 
 
-def test_configure_logging_adds_handler_once(reset_logger: None) -> None:
+@pytest.fixture
+def log_dir_env(monkeypatch, tmp_path: Path) -> Path:
+    path = tmp_path / "logs"
+    monkeypatch.setenv("COOKAREQ_LOG_DIR", str(path))
+    return path
+
+
+def test_configure_logging_attaches_handlers_once(
+    reset_logger: None, log_dir_env: Path
+) -> None:
     configure_logging()
-    assert len(logger.handlers) == 1
-    first_handler = logger.handlers[0]
+    handlers = list(logger.handlers)
+    assert len(handlers) == 3
+    stream_handlers = [
+        h
+        for h in handlers
+        if isinstance(h, logging.StreamHandler)
+        and not isinstance(h, logging.FileHandler)
+    ]
+    file_handlers = [h for h in handlers if isinstance(h, logging.FileHandler)]
+    json_handlers = [h for h in handlers if isinstance(h, JsonlHandler)]
+    assert len(stream_handlers) == 1
+    assert len(file_handlers) == 1
+    assert len(json_handlers) == 1
     configure_logging()
-    assert len(logger.handlers) == 1
-    assert logger.handlers[0] is first_handler
+    assert logger.handlers == handlers
 
 
-def test_configure_logging_sets_level(reset_logger: None) -> None:
+def test_configure_logging_sets_console_level(
+    reset_logger: None, log_dir_env: Path
+) -> None:
     configure_logging(level=logging.DEBUG)
     assert logger.level == logging.DEBUG
+    stream_handler = next(
+        h
+        for h in logger.handlers
+        if isinstance(h, logging.StreamHandler)
+        and not isinstance(h, logging.FileHandler)
+    )
+    assert stream_handler.level == logging.DEBUG
     configure_logging(level=logging.WARNING)
     assert logger.level == logging.DEBUG
+    assert stream_handler.level == logging.DEBUG
+
+
+def test_log_directory_and_files_created(
+    reset_logger: None, log_dir_env: Path
+) -> None:
+    configure_logging()
+    directory = get_log_directory()
+    assert directory == log_dir_env
+    assert directory.exists()
+    text_path, json_path = get_log_file_paths()
+    assert text_path.parent == directory
+    assert json_path.parent == directory
+    assert text_path.name.endswith(".log")
+    assert json_path.name.endswith(".jsonl")
+
+
+def test_configure_logging_rotates_previous_run(
+    reset_logger: None, log_dir_env: Path
+) -> None:
+    text_path = log_dir_env / log_module._TEXT_LOG_NAME
+    json_path = log_dir_env / log_module._JSON_LOG_NAME
+    text_path.parent.mkdir(parents=True, exist_ok=True)
+    text_path.write_text("old text log", encoding="utf-8")
+    json_path.write_text("{\"message\": \"old json\"}\n", encoding="utf-8")
+
+    configure_logging()
+
+    rotated_text = log_dir_env / f"{log_module._TEXT_LOG_NAME}.1"
+    rotated_json = log_dir_env / f"{log_module._JSON_LOG_NAME}.1"
+    assert rotated_text.exists()
+    assert rotated_json.exists()
+    assert rotated_text.read_text(encoding="utf-8") == "old text log"
+    assert rotated_json.read_text(encoding="utf-8") == "{\"message\": \"old json\"}\n"
+    assert text_path.exists()
+    assert json_path.exists()


### PR DESCRIPTION
## Summary
- rotate CookaReq text and JSON logs on startup while keeping structured handlers at DEBUG
- redesign the GUI log console with level selector, large-buffer trimming, and updated labels/translations
- document the new logging behaviour and extend logging unit tests to cover rotation and handler levels

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68cad592e52c8320968becd23fd235c2