### PR TITLE
Persist log level selection in user settings

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from copy import deepcopy
+import logging
 from pathlib import Path
 from typing import Any, Callable, Generic, Literal, Protocol, TypeVar
 
@@ -122,6 +123,7 @@ ConfigFieldName = Literal[
     "sort_column",
     "sort_ascending",
     "log_sash",
+    "log_level",
     "log_shown",
     "agent_chat_sash",
     "agent_chat_shown",
@@ -255,6 +257,11 @@ CONFIG_FIELD_SPECS: dict[ConfigFieldName, FieldSpec[Any]] = {
         key="log_sash",
         value_type=int,
         default=300,
+    ),
+    "log_level": FieldSpec(
+        key="log_level",
+        value_type=int,
+        default=logging.INFO,
     ),
     "log_shown": FieldSpec(
         key="log_shown",
@@ -594,6 +601,7 @@ class ConfigManager:
             language=self.get_language(),
             sort_column=sort_column,
             sort_ascending=sort_ascending,
+            log_level=self.get_log_level(),
         )
 
     def set_ui_settings(self, settings: UISettings) -> None:
@@ -608,6 +616,7 @@ class ConfigManager:
         sort_col = settings.sort_column
         sort_asc = settings.sort_ascending
         self.set_sort_settings(sort_col, sort_asc)
+        self.set_log_level(settings.log_level)
 
     def get_app_settings(self) -> AppSettings:
         """Return all application settings."""
@@ -656,6 +665,20 @@ class ConfigManager:
         """Persist whether log console is visible."""
 
         self.set_value("log_shown", shown)
+        self.flush()
+
+    def get_log_level(self) -> int:
+        """Return the minimum severity displayed in the log console."""
+
+        level = int(self.get_value("log_level"))
+        if level not in (logging.DEBUG, logging.INFO, logging.WARNING, logging.ERROR):
+            return logging.INFO
+        return level
+
+    def set_log_level(self, level: int) -> None:
+        """Persist minimum severity displayed in the log console."""
+
+        self.set_value("log_level", int(level))
         self.flush()
 
     # ------------------------------------------------------------------

--- a/app/settings.py
+++ b/app/settings.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 from pathlib import Path
 
 import tomllib
@@ -105,6 +106,7 @@ class UISettings(BaseModel):
     language: str | None = None
     sort_column: int = -1
     sort_ascending: bool = True
+    log_level: int = Field(default=logging.INFO)
 
 
 class AppSettings(BaseModel):

--- a/app/ui/main_frame.py
+++ b/app/ui/main_frame.py
@@ -290,14 +290,15 @@ class MainFrame(wx.Frame):
             (h for h in logger.handlers if isinstance(h, WxLogHandler)),
             None,
         )
+        saved_log_level = self.config.get_log_level()
         if existing:
             self.log_handler = existing
             self.log_handler.target = self.log_console
         else:
             self.log_handler = WxLogHandler(self.log_console)
-            self.log_handler.setLevel(logging.INFO)
             logger.addHandler(self.log_handler)
-        self._populate_log_level_choice(self.log_handler.level)
+        self.log_handler.setLevel(saved_log_level)
+        self._populate_log_level_choice(saved_log_level)
         self.log_level_choice.Bind(wx.EVT_CHOICE, self.on_change_log_level)
 
         sizer = wx.BoxSizer(wx.VERTICAL)
@@ -1463,6 +1464,7 @@ class MainFrame(wx.Frame):
             return
         level = self._log_level_values[selection]
         self.log_handler.setLevel(level)
+        self.config.set_log_level(level)
 
     def on_toggle_log_console(self, _event: wx.CommandEvent) -> None:
         """Toggle visibility of log console panel."""

--- a/tests/gui/test_gui.py
+++ b/tests/gui/test_gui.py
@@ -1,5 +1,8 @@
 """Tests for gui."""
 
+import logging
+from types import SimpleNamespace
+
 import pytest
 
 pytestmark = pytest.mark.gui
@@ -18,3 +21,34 @@ def test_gui_imports(wx_app):
     assert list_panel.GetParent() is frame
     assert editor_panel.GetParent() is frame
     assert callable(main)
+
+
+def test_log_level_persistence(wx_app, tmp_path):
+    pytest.importorskip("wx")
+    from app.config import ConfigManager
+    from app.ui.main_frame import MainFrame
+    from app.ui.requirement_model import RequirementModel
+
+    config_path = tmp_path / "cfg.ini"
+    config = ConfigManager(path=config_path)
+    config.set_log_level(logging.ERROR)
+
+    frame = MainFrame(None, config=config, model=RequirementModel())
+    try:
+        selection = frame.log_level_choice.GetSelection()
+        assert selection >= 0
+        assert frame._log_level_values[selection] == logging.ERROR
+
+        debug_index = frame._find_choice_index_for_level(logging.DEBUG)
+        assert debug_index >= 0
+        frame.log_level_choice.SetSelection(debug_index)
+        frame.on_change_log_level(SimpleNamespace(GetSelection=lambda: debug_index))
+
+        assert frame.log_handler.level == logging.DEBUG
+        assert config.get_log_level() == logging.DEBUG
+
+        reloaded = ConfigManager(path=config_path)
+        assert reloaded.get_log_level() == logging.DEBUG
+    finally:
+        frame.Destroy()
+        wx_app.Yield()

--- a/tests/unit/test_config_manager.py
+++ b/tests/unit/test_config_manager.py
@@ -1,5 +1,7 @@
 """Tests for config manager."""
 
+import logging
+
 import pytest
 
 from app.config import ConfigManager, DEFAULT_LIST_COLUMNS
@@ -65,6 +67,8 @@ def _recent_dirs_factory(tmp_path):
         ("llm_max_context_tokens", DEFAULT_MAX_CONTEXT_TOKENS),
         ("sort_column", -1),
         ("sort_ascending", True),
+        ("log_sash", 300),
+        ("log_level", logging.INFO),
         ("log_shown", False),
         ("win_w", 800),
         ("editor_sash_pos", 600),
@@ -119,6 +123,7 @@ def test_schema_default_values(tmp_path, wx_app, name, expected):
         pytest.param("sort_column", _const(5), _const(5), id="sort_column"),
         pytest.param("sort_ascending", _const(False), _const(False), id="sort_ascending"),
         pytest.param("log_sash", _const(512), _const(512), id="log_sash"),
+        pytest.param("log_level", _const(logging.ERROR), _const(logging.ERROR), id="log_level"),
         pytest.param("log_shown", _const(True), _const(True), id="log_shown"),
         pytest.param("win_w", _const(1024), _const(1024), id="win_w"),
         pytest.param("editor_sash_pos", _const(456), _const(456), id="editor_sash_pos"),
@@ -317,6 +322,7 @@ def test_app_settings_round_trip(tmp_path, wx_app):
             language="ru",
             sort_column=2,
             sort_ascending=False,
+            log_level=logging.WARNING,
         ),
     )
 


### PR DESCRIPTION
## Summary
- add the log level field to UI settings and configuration schema so it can be saved
- teach the main frame log console to load and persist the saved level
- extend unit and GUI tests to cover the new persistence behaviour

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68cae53423e08320802d99f0be70683f