### PR TITLE
Add detailed debug logging for LLM and MCP traffic

### DIFF
--- a/app/telemetry.py
+++ b/app/telemetry.py
@@ -3,11 +3,28 @@
 from __future__ import annotations
 
 import json
+import logging
 import time
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from typing import Any
 
 from .log import logger
+
+
+def _make_json_safe(value: Any) -> Any:
+    """Convert ``value`` into a JSON-serialisable structure."""
+
+    if isinstance(value, Mapping):
+        return {k: _make_json_safe(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_make_json_safe(v) for v in value]
+    if isinstance(value, tuple):
+        return [_make_json_safe(v) for v in value]
+    if isinstance(value, set):
+        return sorted(_make_json_safe(v) for v in value)
+    if isinstance(value, (str, int, float, bool)) or value is None:
+        return value
+    return repr(value)
 
 # Keys that should be redacted when logging
 SENSITIVE_KEYS = {
@@ -66,9 +83,10 @@ def log_event(
     data: dict[str, Any] = {"event": event}
     if payload:
         sanitized = sanitize(dict(payload))
-        data["payload"] = sanitized
+        safe_payload = _make_json_safe(sanitized)
+        data["payload"] = safe_payload
         data["size_bytes"] = len(
-            json.dumps(sanitized, ensure_ascii=False).encode("utf-8"),
+            json.dumps(safe_payload, ensure_ascii=False).encode("utf-8"),
         )
     else:
         data["payload"] = {}
@@ -76,3 +94,31 @@ def log_event(
     if start_time is not None:
         data["duration_ms"] = int((time.monotonic() - start_time) * 1000)
     logger.info(event, extra={"json": data})
+
+
+def log_debug_payload(
+    event: str,
+    payload: Mapping[str, Any] | Sequence[Any] | str | None = None,
+) -> None:
+    """Emit debug-level log entry with full payload details."""
+
+    if not logger.isEnabledFor(logging.DEBUG):
+        return
+
+    record: dict[str, Any] = {"event": event, "level": "DEBUG"}
+    if payload is None:
+        safe_payload: Any = {}
+    elif isinstance(payload, Mapping):
+        safe_payload = _make_json_safe(sanitize(dict(payload)))
+    elif isinstance(payload, Sequence) and not isinstance(
+        payload, (str, bytes, bytearray)
+    ):
+        safe_payload = _make_json_safe(_sanitize_value(list(payload)))
+    else:
+        safe_payload = _make_json_safe(payload)
+    if payload is not None:
+        record["payload"] = safe_payload
+    message = event
+    if payload is not None:
+        message = f"{event} {json.dumps(safe_payload, ensure_ascii=False)}"
+    logger.debug(message, extra={"json": record})


### PR DESCRIPTION
## Summary
- add structured debug logging helper that records full payloads when debug logging is enabled
- log outbound and inbound payloads for LLM and MCP clients with direction metadata
- extend telemetry unit tests to cover the new debug logging behaviour

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68cae819029c8320a511735495dd4f63