### PR TITLE
Add timestamps to log console entries

### DIFF
--- a/app/ui/main_frame.py
+++ b/app/ui/main_frame.py
@@ -55,7 +55,12 @@ class WxLogHandler(logging.Handler):
         super().__init__()
         self._target = target
         self._max_chars = max_chars
-        self.setFormatter(logging.Formatter("%(levelname)s: %(message)s"))
+        self.setFormatter(
+            logging.Formatter(
+                "%(asctime)s %(levelname)s: %(message)s",
+                datefmt="%Y-%m-%d %H:%M:%S",
+            )
+        )
 
     @property
     def target(self) -> wx.TextCtrl:

--- a/tests/unit/test_wx_log_handler.py
+++ b/tests/unit/test_wx_log_handler.py
@@ -1,0 +1,50 @@
+"""Tests for :class:`app.ui.main_frame.WxLogHandler`."""
+
+import logging
+import time
+
+import pytest
+
+from app.ui.main_frame import WxLogHandler
+
+pytestmark = pytest.mark.unit
+
+
+class _StubTextCtrl:
+    """Minimal stub mimicking ``wx.TextCtrl`` interface for tests."""
+
+    def __init__(self) -> None:
+        self._buffer = ""
+
+    def AppendText(self, text: str) -> None:  # pragma: no cover - not exercised
+        self._buffer += text
+
+    def GetLastPosition(self) -> int:  # pragma: no cover - not exercised
+        return len(self._buffer)
+
+    def Remove(self, start: int, end: int) -> None:  # pragma: no cover - not exercised
+        del start, end
+
+    def IsBeingDeleted(self) -> bool:  # pragma: no cover - not exercised
+        return False
+
+
+def test_wx_log_handler_format_includes_timestamp() -> None:
+    """Formatter attached to handler should render human-friendly timestamp."""
+
+    handler = WxLogHandler(_StubTextCtrl())
+    formatter = handler.formatter
+    assert formatter is not None
+    formatter.converter = time.gmtime
+    record = logging.LogRecord(
+        name="cookareq",
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=42,
+        msg="sample message",
+        args=(),
+        exc_info=None,
+    )
+    record.created = 0
+    formatted = handler.format(record)
+    assert formatted == "1970-01-01 00:00:00 INFO: sample message"


### PR DESCRIPTION
## Summary
- prepend timestamp information to log console messages by updating the WxLogHandler formatter
- cover the formatter with a unit test to guarantee the timestamp layout

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68cb045a6b4483209922a4e347b55dd5