### PR TITLE
Ensure main window destroys itself during shutdown

### DIFF
--- a/tests/gui/test_main_auxiliary_windows.py
+++ b/tests/gui/test_main_auxiliary_windows.py
@@ -59,5 +59,6 @@ def test_auxiliary_frames_closed_on_shutdown(monkeypatch, wx_app, tmp_path):
 
         assert message_calls == []
     finally:
-        frame.Destroy()
+        if not frame.IsBeingDeleted():
+            frame.Destroy()
         wx_app.Yield()


### PR DESCRIPTION
## Summary
- guard `MainFrame` shutdown against repeated close events and schedule an explicit frame destruction when wx finishes processing the close event
- destroy the frame immediately when `_on_close` is called without an event object so programmatic shutdown matches GUI behaviour
- adjust the auxiliary window test cleanup to account for the frame destroying itself during shutdown

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68cb063b36dc832091c4c415366527b7