### PR TITLE
Default MCP base path to bundled requirements

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -11,7 +11,13 @@ from typing import Any, Callable, Generic, Literal, Protocol, TypeVar
 import wx
 
 from .llm.constants import DEFAULT_MAX_CONTEXT_TOKENS, DEFAULT_MAX_OUTPUT_TOKENS
-from .settings import AppSettings, LLMSettings, MCPSettings, UISettings
+from .settings import (
+    AppSettings,
+    LLMSettings,
+    MCPSettings,
+    UISettings,
+    default_requirements_path,
+)
 
 
 T = TypeVar("T")
@@ -188,7 +194,7 @@ CONFIG_FIELD_SPECS: dict[ConfigFieldName, FieldSpec[Any]] = {
     "mcp_base_path": FieldSpec(
         key="mcp_base_path",
         value_type=str,
-        default="",
+        default_factory=default_requirements_path,
     ),
     "mcp_require_token": FieldSpec(
         key="mcp_require_token",

--- a/app/settings.py
+++ b/app/settings.py
@@ -85,13 +85,23 @@ class LLMSettings(BaseModel):
         )
 
 
+def default_requirements_path() -> str:
+    """Return bundled requirements directory if present."""
+
+    try:
+        candidate = Path(__file__).resolve().parents[1] / "requirements"
+    except OSError:  # pragma: no cover - very defensive
+        return ""
+    return str(candidate) if candidate.is_dir() else ""
+
+
 class MCPSettings(BaseModel):
     """Settings for configuring the MCP server and client."""
 
     auto_start: bool = True
     host: str = "127.0.0.1"
     port: int = 59362
-    base_path: str = ""
+    base_path: str = Field(default_factory=default_requirements_path)
     require_token: bool = False
     token: str = ""
 

--- a/tests/unit/test_config_manager.py
+++ b/tests/unit/test_config_manager.py
@@ -11,7 +11,13 @@ from app.llm.constants import (
     MIN_MAX_CONTEXT_TOKENS,
     MIN_MAX_OUTPUT_TOKENS,
 )
-from app.settings import AppSettings, LLMSettings, MCPSettings, UISettings
+from app.settings import (
+    AppSettings,
+    LLMSettings,
+    MCPSettings,
+    UISettings,
+    default_requirements_path,
+)
 
 pytestmark = pytest.mark.unit
 
@@ -62,6 +68,7 @@ def _recent_dirs_factory(tmp_path):
         ("remember_sort", False),
         ("language", None),
         ("mcp_auto_start", True),
+        ("mcp_base_path", default_requirements_path()),
         ("mcp_port", 59362),
         ("llm_max_output_tokens", DEFAULT_MAX_OUTPUT_TOKENS),
         ("llm_max_context_tokens", DEFAULT_MAX_CONTEXT_TOKENS),
@@ -329,6 +336,20 @@ def test_app_settings_round_trip(tmp_path, wx_app):
     cfg.set_app_settings(app_settings)
     loaded = cfg.get_app_settings()
     assert loaded == app_settings
+
+
+def test_get_mcp_settings_uses_default_requirements(tmp_path, wx_app):
+    cfg = ConfigManager(app_name="TestApp", path=tmp_path / "cfg.ini")
+
+    settings = cfg.get_mcp_settings()
+
+    assert settings.base_path == default_requirements_path()
+
+
+def test_app_settings_default_uses_sample_requirements():
+    settings = AppSettings()
+
+    assert settings.mcp.base_path == default_requirements_path()
 
 
 def test_get_llm_settings_normalises_zero(tmp_path, wx_app):


### PR DESCRIPTION
## Summary
- expose a helper to resolve the bundled `requirements` directory and use it as the default MCP base path
- make the configuration manager surface the same default so the MCP server starts against real data even without explicit setup
- cover the new defaults with unit tests to guard against regressions

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68cb17b2154883209148fd03e23867ae