### PR TITLE
Refactor JSON sanitisation helper

### DIFF
--- a/app/util/json.py
+++ b/app/util/json.py
@@ -1,0 +1,71 @@
+"""JSON serialisation helpers."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any, Callable
+
+
+def make_json_safe(
+    value: Any,
+    *,
+    stringify_keys: bool = False,
+    sort_sets: bool = True,
+    coerce_sequences: bool = False,
+    default: Callable[[Any], str] | None = None,
+) -> Any:
+    """Return a structure compatible with :func:`json.dumps`.
+
+    Parameters
+    ----------
+    value:
+        Arbitrary Python object that should be serialisable.
+    stringify_keys:
+        Convert mapping keys to strings when ``True``.
+    sort_sets:
+        When ``True`` the contents of :class:`set` objects are sorted to make
+        the output deterministic. When ``False`` the original iteration order
+        is preserved.
+    coerce_sequences:
+        Convert arbitrary :class:`~collections.abc.Sequence` instances into
+        lists when ``True``. When ``False`` only lists and tuples are coerced.
+    default:
+        Fallback callable used for unsupported objects. Defaults to
+        :func:`repr` to match :mod:`json` behaviour.
+    """
+
+    if default is None:
+        default = repr
+
+    def convert(item: Any) -> Any:
+        return make_json_safe(
+            item,
+            stringify_keys=stringify_keys,
+            sort_sets=sort_sets,
+            coerce_sequences=coerce_sequences,
+            default=default,
+        )
+
+    if isinstance(value, Mapping):
+        if stringify_keys:
+            return {str(key): convert(val) for key, val in value.items()}
+        return {key: convert(val) for key, val in value.items()}
+    if isinstance(value, list):
+        return [convert(item) for item in value]
+    if isinstance(value, tuple):
+        return [convert(item) for item in value]
+    if isinstance(value, set):
+        converted = [convert(item) for item in value]
+        if sort_sets:
+            return sorted(converted)
+        return converted
+    if coerce_sequences and isinstance(value, Sequence) and not isinstance(
+        value, (str, bytes, bytearray)
+    ):
+        return [convert(item) for item in value]
+    if isinstance(value, (str, int, float, bool)) or value is None:
+        return value
+    return default(value)
+
+
+__all__ = ["make_json_safe"]

--- a/tests/unit/test_util_json.py
+++ b/tests/unit/test_util_json.py
@@ -1,0 +1,57 @@
+"""Tests for :mod:`app.util.json`."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from app.util.json import make_json_safe
+
+
+def test_make_json_safe_basic_conversion() -> None:
+    value = {
+        "numbers": {3, 1, 2},
+        "tuple": ("a", "b"),
+        "custom": SimpleNamespace(name="value"),
+    }
+
+    result = make_json_safe(value)
+
+    assert result["numbers"] == [1, 2, 3]
+    assert result["tuple"] == ["a", "b"]
+    assert isinstance(result["custom"], str)
+    assert result["custom"].startswith("namespace(")
+
+
+def test_make_json_safe_stringifies_keys_when_requested() -> None:
+    value = {1: "one", "nested": {2: "two"}}
+
+    result = make_json_safe(value, stringify_keys=True)
+
+    assert set(result.keys()) == {"1", "nested"}
+    assert set(result["nested"].keys()) == {"2"}
+
+
+def test_make_json_safe_allows_unsorted_sets() -> None:
+    class CustomSet(set):
+        def __init__(self) -> None:
+            super().__init__({"first", "second"})
+            self._ordered = ["second", "first"]
+
+        def __iter__(self):  # type: ignore[override]
+            yield from self._ordered
+
+    custom = CustomSet()
+
+    unsorted_result = make_json_safe(custom, sort_sets=False)
+    assert unsorted_result == ["second", "first"]
+
+    sorted_result = make_json_safe(custom, sort_sets=True)
+    assert sorted_result == ["first", "second"]
+
+
+def test_make_json_safe_sequence_control() -> None:
+    default_result = make_json_safe(range(3))
+    assert default_result == "range(0, 3)"
+
+    coerced_result = make_json_safe(range(3), coerce_sequences=True)
+    assert coerced_result == [0, 1, 2]


### PR DESCRIPTION
## Summary
- extract a shared `make_json_safe` helper under `app/util/json.py` with options for key stringification and set ordering
- switch telemetry logging and agent chat history to use the shared helper, keeping chat-specific coercion logic
- cover the new helper with unit tests to guard the expected behaviours

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68cb9a95f57483208a850c3dddc1a521