### PR TITLE
Show active document name in requirements pane header

### DIFF
--- a/app/locale/en/LC_MESSAGES/CookaReq.po
+++ b/app/locale/en/LC_MESSAGES/CookaReq.po
@@ -261,6 +261,9 @@ msgstr "Hierarchy"
 msgid "Requirements"
 msgstr "Requirements"
 
+msgid "Requirements - {document}"
+msgstr "Requirements - {document}"
+
 msgid "Editor"
 msgstr "Editor"
 

--- a/app/locale/ru/LC_MESSAGES/CookaReq.po
+++ b/app/locale/ru/LC_MESSAGES/CookaReq.po
@@ -246,6 +246,9 @@ msgstr "Иерархия"
 msgid "Requirements"
 msgstr "Требования"
 
+msgid "Requirements - {document}"
+msgstr "Требования - {document}"
+
 msgid "Editor"
 msgstr "Редактор"
 

--- a/app/ui/main_frame/sections.py
+++ b/app/ui/main_frame/sections.py
@@ -226,9 +226,12 @@ class MainFrameSectionsMixin:
         """Refresh captions for titled sections according to current locale."""
 
         self.doc_tree_label.SetLabel(_("Hierarchy"))
-        self.list_label.SetLabel(_("Requirements"))
         self.editor_label.SetLabel(_("Editor"))
         self.agent_label.SetLabel(_("Agent Chat"))
+        if hasattr(self, "_update_requirements_label"):
+            self._update_requirements_label()
+        else:  # pragma: no cover - defensive fallback if mixin missing
+            self.list_label.SetLabel(_("Requirements"))
         self.update_log_console_labels()
 
     def _confirm_discard_changes(self: "MainFrame") -> bool:


### PR DESCRIPTION
## Summary
- display the active document's prefix and title in the requirements pane header
- keep the caption updated when documents are loaded, switched or cleared
- add English and Russian localisation strings for the formatted header label

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68cf9141d7648320b883e10cd64eb8e9