### PR TITLE
Allow MainFrame to accept custom MCP factory

### DIFF
--- a/app/ui/main_frame/frame.py
+++ b/app/ui/main_frame/frame.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import fields
 from importlib import resources
 from pathlib import Path
@@ -52,6 +53,7 @@ class MainFrame(
         *,
         config: ConfigManager | None = None,
         model: RequirementModel | None = None,
+        mcp_factory: Callable[[], MCPController] = MCPController,
     ) -> None:
         """Set up main application window and controllers."""
 
@@ -70,9 +72,7 @@ class MainFrame(
         self.sort_column, self.sort_ascending = self.config.get_sort_settings()
         self.llm_settings = self.config.get_llm_settings()
         self.mcp_settings = self.config.get_mcp_settings()
-        from . import MCPController as PackageMCPController
-
-        self.mcp = PackageMCPController()
+        self.mcp = mcp_factory()
         if self.mcp_settings.auto_start:
             self.mcp.start(self.mcp_settings)
         self.docs_controller: DocumentsController | None = None


### PR DESCRIPTION
## Summary
- add an optional `mcp_factory` argument to `MainFrame` so callers can supply a custom controller implementation
- update GUI tests to construct `MainFrame` with test doubles instead of monkeypatching module attributes

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68cfd505595c8320afbd76c7c5cc8085