### PR TITLE
Refine MCP logging configuration

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -114,6 +114,7 @@ ConfigFieldName = Literal[
     "mcp_host",
     "mcp_port",
     "mcp_base_path",
+    "mcp_log_dir",
     "mcp_require_token",
     "mcp_token",
     "llm_base_url",
@@ -192,6 +193,13 @@ CONFIG_FIELD_SPECS: dict[ConfigFieldName, FieldSpec[Any]] = {
         key="mcp_base_path",
         value_type=str,
         default_factory=default_requirements_path,
+    ),
+    "mcp_log_dir": FieldSpec(
+        key="mcp_log_dir",
+        value_type=str | None,
+        default=None,
+        reader=_optional_string_reader,
+        writer=_optional_string_writer,
     ),
     "mcp_require_token": FieldSpec(
         key="mcp_require_token",
@@ -541,6 +549,7 @@ class ConfigManager:
             host=self.get_value("mcp_host"),
             port=self.get_value("mcp_port"),
             base_path=self.get_value("mcp_base_path"),
+            log_dir=self.get_value("mcp_log_dir"),
             require_token=self.get_value("mcp_require_token"),
             token=self.get_value("mcp_token"),
         )
@@ -552,6 +561,7 @@ class ConfigManager:
         self.set_value("mcp_host", settings.host)
         self.set_value("mcp_port", settings.port)
         self.set_value("mcp_base_path", settings.base_path)
+        self.set_value("mcp_log_dir", settings.log_dir)
         self.set_value("mcp_require_token", settings.require_token)
         self.set_value("mcp_token", settings.token)
         self.flush()

--- a/app/mcp/controller.py
+++ b/app/mcp/controller.py
@@ -37,7 +37,13 @@ class MCPController:
         """Launch the MCP server with ``settings``."""
 
         token = settings.token if settings.require_token else ""
-        start_server(settings.host, settings.port, settings.base_path, token)
+        start_server(
+            settings.host,
+            settings.port,
+            settings.base_path,
+            token,
+            log_dir=settings.log_dir,
+        )
 
     def stop(self) -> None:
         """Shut down the MCP server if running."""

--- a/app/mcp/server.py
+++ b/app/mcp/server.py
@@ -383,6 +383,8 @@ def start_server(
     port: int = 59362,
     base_path: str = "",
     token: str = "",
+    *,
+    log_dir: str | Path | None = None,
 ) -> None:
     """Start the HTTP server in a background thread.
 
@@ -391,6 +393,8 @@ def start_server(
         port: TCP port where the server listens.
         base_path: Base filesystem path available to the MCP server.
         token: Authorization token expected in the ``Authorization`` header.
+        log_dir: Directory where request logs are stored.  Defaults to the
+            application log directory under ``mcp`` when not provided.
     """
     global _uvicorn_server, _server_thread
 
@@ -400,7 +404,7 @@ def start_server(
 
     app.state.base_path = base_path
     app.state.expected_token = token
-    resolved_log_dir = _configure_request_logging(base_path or None)
+    resolved_log_dir = _configure_request_logging(log_dir)
     app.state.log_dir = str(resolved_log_dir)
     config = uvicorn.Config(app, host=host, port=port, log_level="info")
     _uvicorn_server = uvicorn.Server(config)

--- a/app/settings.py
+++ b/app/settings.py
@@ -85,8 +85,19 @@ class MCPSettings(BaseModel):
     host: str = "127.0.0.1"
     port: int = 59362
     base_path: str = Field(default_factory=default_requirements_path)
+    log_dir: str | None = None
     require_token: bool = False
     token: str = ""
+
+    @field_validator("log_dir", mode="before")
+    @classmethod
+    def _normalize_log_dir(cls, value: str | Path | None) -> str | None:
+        """Convert empty strings to ``None`` and normalise paths."""
+
+        if value is None:
+            return None
+        text = str(value).strip()
+        return text or None
 
 
 class UISettings(BaseModel):

--- a/app/ui/main_frame/settings.py
+++ b/app/ui/main_frame/settings.py
@@ -39,6 +39,7 @@ class MainFrameSettingsMixin:
             host=self.mcp_settings.host,
             port=self.mcp_settings.port,
             base_path=self.mcp_settings.base_path,
+            log_dir=self.mcp_settings.log_dir,
             require_token=self.mcp_settings.require_token,
             token=self.mcp_settings.token,
         )
@@ -57,6 +58,7 @@ class MainFrameSettingsMixin:
                 host,
                 port,
                 base_path,
+                log_dir,
                 require_token,
                 token,
             ) = dlg.get_values()
@@ -74,6 +76,7 @@ class MainFrameSettingsMixin:
                 host=host,
                 port=port,
                 base_path=base_path,
+                log_dir=log_dir or None,
                 require_token=require_token,
                 token=token,
             )

--- a/app/ui/settings_dialog.py
+++ b/app/ui/settings_dialog.py
@@ -81,6 +81,10 @@ MCP_HELP: dict[str, str] = {
         "Base folder with requirements. Example: /tmp/reqs\n"
         "Required; the server serves files from this directory.",
     ),
+    "log_dir": _(
+        "Directory for MCP request logs. Example: /var/log/cookareq\n"
+        "Leave empty to store logs in the standard application log folder.",
+    ),
     "require_token": _(
         "When enabled, the server requires an authentication token.",
     ),
@@ -139,6 +143,7 @@ class SettingsDialog(wx.Dialog):
         host: str,
         port: int,
         base_path: str,
+        log_dir: str | None,
         require_token: bool,
         token: str,
     ) -> None:
@@ -344,6 +349,8 @@ class SettingsDialog(wx.Dialog):
         self._host = wx.TextCtrl(mcp, value=host)
         self._port = wx.SpinCtrl(mcp, min=1, max=65535, initial=port)
         self._base_path = wx.TextCtrl(mcp, value=base_path)
+        log_dir_value = str(log_dir) if log_dir else ""
+        self._log_dir = wx.TextCtrl(mcp, value=log_dir_value)
         self._require_token = wx.CheckBox(mcp, label=_("Require token"))
         self._require_token.SetValue(require_token)
         self._token = wx.TextCtrl(mcp, value=token)
@@ -422,6 +429,21 @@ class SettingsDialog(wx.Dialog):
             5,
         )
         mcp_sizer.Add(base_sz, 0, wx.ALL | wx.EXPAND, 5)
+        log_sz = wx.BoxSizer(wx.HORIZONTAL)
+        log_sz.Add(
+            wx.StaticText(mcp, label=_("Log directory")),
+            0,
+            wx.ALIGN_CENTER_VERTICAL | wx.RIGHT,
+            5,
+        )
+        log_sz.Add(self._log_dir, 1, wx.ALIGN_CENTER_VERTICAL)
+        log_sz.Add(
+            make_help_button(mcp, MCP_HELP["log_dir"], dialog_parent=self),
+            0,
+            wx.ALIGN_CENTER_VERTICAL | wx.LEFT,
+            5,
+        )
+        mcp_sizer.Add(log_sz, 0, wx.ALL | wx.EXPAND, 5)
         token_toggle_sz = wx.BoxSizer(wx.HORIZONTAL)
         token_toggle_sz.Add(self._require_token, 0, wx.ALIGN_CENTER_VERTICAL)
         token_toggle_sz.Add(
@@ -550,6 +572,7 @@ class SettingsDialog(wx.Dialog):
             host=self._host.GetValue(),
             port=self._port.GetValue(),
             base_path=self._base_path.GetValue(),
+            log_dir=self._log_dir.GetValue().strip() or None,
             require_token=self._require_token.GetValue(),
             token=self._token.GetValue(),
         )
@@ -685,6 +708,7 @@ class SettingsDialog(wx.Dialog):
         str,
         int,
         str,
+        str,
         bool,
         str,
     ]:
@@ -704,6 +728,7 @@ class SettingsDialog(wx.Dialog):
             self._host.GetValue(),
             self._port.GetValue(),
             self._base_path.GetValue(),
+            self._log_dir.GetValue().strip(),
             self._require_token.GetValue(),
             self._token.GetValue(),
         )

--- a/tests/gui/test_language_switch.py
+++ b/tests/gui/test_language_switch.py
@@ -51,6 +51,7 @@ def test_switch_to_russian_updates_ui(monkeypatch, wx_app, tmp_path):
                 frame.mcp_settings.host,
                 frame.mcp_settings.port,
                 frame.mcp_settings.base_path,
+                frame.mcp_settings.log_dir or "",
                 frame.mcp_settings.require_token,
                 frame.mcp_settings.token,
             )

--- a/tests/gui/test_settings_dialog.py
+++ b/tests/gui/test_settings_dialog.py
@@ -34,6 +34,7 @@ def test_settings_dialog_returns_language(wx_app):
         host="127.0.0.1",
         port=59362,
         base_path="/tmp",
+        log_dir="/logs",
         require_token=True,
         token="abc",
     )
@@ -52,6 +53,7 @@ def test_settings_dialog_returns_language(wx_app):
         "127.0.0.1",
         59362,
         "/tmp",
+        "/logs",
         True,
         "abc",
     )
@@ -100,6 +102,7 @@ def test_mcp_start_stop_server(monkeypatch, wx_app):
         host="localhost",
         port=8123,
         base_path="/tmp",
+        log_dir="",
         require_token=False,
         token="",
     )
@@ -115,9 +118,10 @@ def test_mcp_start_stop_server(monkeypatch, wx_app):
         settings.host,
         settings.port,
         settings.base_path,
+        settings.log_dir,
         settings.require_token,
         settings.token,
-    ) == ("localhost", 8123, "/tmp", False, "")
+    ) == ("localhost", 8123, "/tmp", None, False, "")
     assert not dlg._start.IsEnabled()
     assert dlg._stop.IsEnabled()
     assert dlg._status.GetLabel() == f"{sd._('Status')}: {sd._('running')}"
@@ -176,6 +180,7 @@ def test_mcp_check_status(monkeypatch, wx_app):
         host="localhost",
         port=8123,
         base_path="/tmp",
+        log_dir="",
         require_token=True,
         token="abc",
     )
@@ -244,6 +249,7 @@ def test_llm_agent_checks(monkeypatch, wx_app):
         host="localhost",
         port=59362,
         base_path="/tmp",
+        log_dir="",
         require_token=False,
         token="",
     )
@@ -301,6 +307,7 @@ def test_llm_agent_check_failure_logs(monkeypatch, wx_app):
         host="localhost",
         port=59362,
         base_path="/tmp",
+        log_dir="",
         require_token=False,
         token="",
     )
@@ -343,6 +350,7 @@ def test_settings_help_buttons(monkeypatch, wx_app):
         host="localhost",
         port=8000,
         base_path="/tmp",
+        log_dir="",
         require_token=False,
         token="",
     )

--- a/tests/integration/test_mcp_controller.py
+++ b/tests/integration/test_mcp_controller.py
@@ -78,12 +78,17 @@ def test_controller_start_stop(monkeypatch):
 
     calls = []
 
-    monkeypatch.setattr(
-        "app.mcp.controller.start_server",
-        lambda host, port, base_path, token: calls.append(
-            ("start", host, port, base_path, token),
-        ),
-    )
+    def fake_start(
+        host,
+        port,
+        base_path,
+        token,
+        *,
+        log_dir=None,
+    ) -> None:
+        calls.append(("start", host, port, base_path, token, log_dir))
+
+    monkeypatch.setattr("app.mcp.controller.start_server", fake_start)
     monkeypatch.setattr(
         "app.mcp.controller.stop_server",
         lambda: calls.append(("stop",)),
@@ -93,4 +98,7 @@ def test_controller_start_stop(monkeypatch):
     settings = MCPSettings(host="localhost", port=8123, base_path="/tmp", token="")
     ctrl.start(settings)
     ctrl.stop()
-    assert calls == [("start", "localhost", 8123, "/tmp", ""), ("stop",)]
+    assert calls == [
+        ("start", "localhost", 8123, "/tmp", "", None),
+        ("stop",),
+    ]

--- a/tests/integration/test_mcp_server.py
+++ b/tests/integration/test_mcp_server.py
@@ -66,3 +66,17 @@ def test_default_log_directory_used_when_base_path_missing():
         assert log_dir == expected
     finally:
         stop_server()
+
+
+def test_base_path_does_not_override_log_directory(tmp_path: Path):
+    port = 8130
+    stop_server()
+    start_server(port=port, base_path=str(tmp_path))
+    try:
+        _wait_until_ready(port)
+        log_dir = Path(mcp_app.state.log_dir)
+        expected = get_log_directory() / "mcp"
+        assert log_dir == expected
+        assert log_dir != tmp_path
+    finally:
+        stop_server()

--- a/tests/unit/test_config_manager.py
+++ b/tests/unit/test_config_manager.py
@@ -256,6 +256,7 @@ def test_app_settings_round_trip(tmp_path, wx_app):
             host="1.2.3.4",
             port=9999,
             base_path="/m",
+            log_dir="/logs",
             require_token=True,
             token="t",
         ),
@@ -282,12 +283,14 @@ def test_get_mcp_settings_uses_default_requirements(tmp_path, wx_app):
     settings = cfg.get_mcp_settings()
 
     assert settings.base_path == default_requirements_path()
+    assert settings.log_dir is None
 
 
 def test_app_settings_default_uses_sample_requirements():
     settings = AppSettings()
 
     assert settings.mcp.base_path == default_requirements_path()
+    assert settings.mcp.log_dir is None
 
 
 def test_get_llm_settings_normalises_context_zero(tmp_path, wx_app):


### PR DESCRIPTION
## Summary
- add an explicit `log_dir` option to MCP settings, normalize it, and persist it through the config manager
- allow the MCP server and controller to accept a custom log directory while defaulting to the standard log folder
- expose the log directory in the settings dialog and update integration/unit tests to reflect the new behavior and state reporting

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68cfd52a68248320b7c6493b22a4e794