### PR TITLE
Fix agent chat activity indicator layout

### DIFF
--- a/app/ui/agent_chat_panel.py
+++ b/app/ui/agent_chat_panel.py
@@ -617,6 +617,17 @@ class AgentChatPanel(wx.Panel):
         self.input.SetFocus()
 
     # ------------------------------------------------------------------
+    def _refresh_bottom_panel_layout(self) -> None:
+        """Request layout update for controls hosted in the bottom panel."""
+
+        panel = self._bottom_panel
+        if panel is None:
+            return
+        panel.Layout()
+        panel.SendSizeEvent()
+        self.Layout()
+
+    # ------------------------------------------------------------------
     def _set_wait_state(
         self,
         active: bool,
@@ -637,6 +648,7 @@ class AgentChatPanel(wx.Panel):
             self._start_time = time.monotonic()
             self.activity.Show()
             self.activity.Start()
+            self._refresh_bottom_panel_layout()
             self._update_status(0.0)
             self._timer.Start(100)
         else:
@@ -647,6 +659,7 @@ class AgentChatPanel(wx.Panel):
             self._timer.Stop()
             self.activity.Stop()
             self.activity.Hide()
+            self._refresh_bottom_panel_layout()
             self.status_label.SetLabel(_("Ready"))
             self._start_time = None
             self.input.SetFocus()

--- a/tests/gui/test_agent_chat_panel.py
+++ b/tests/gui/test_agent_chat_panel.py
@@ -169,6 +169,27 @@ def test_agent_chat_panel_stop_cancels_generation(tmp_path, wx_app):
         pool.shutdown(wait=True, cancel_futures=True)
 
 
+def test_agent_chat_panel_activity_indicator_layout(tmp_path, wx_app):
+    class IdleAgent:
+        def run_command(self, text, *, history=None, cancellation=None):  # pragma: no cover - defensive
+            return {"ok": True, "error": None, "result": text}
+
+    wx, frame, panel = create_panel(tmp_path, wx_app, IdleAgent())
+
+    try:
+        panel._set_wait_state(True)
+        flush_wx_events(wx)
+
+        activity_pos = panel.activity.GetPosition()
+        status_pos = panel.status_label.GetPosition()
+        indicator_height = max(1, panel.activity.GetSize().GetHeight())
+
+        assert abs(activity_pos.y - status_pos.y) <= indicator_height
+    finally:
+        panel._set_wait_state(False)
+        destroy_panel(frame, panel)
+
+
 def test_agent_chat_panel_shuts_down_executor_pool_on_destroy(tmp_path, wx_app):
     class DummyAgent:
         def run_command(self, text, *, history=None, cancellation=None):  # pragma: no cover - defensive


### PR DESCRIPTION
## Summary
- refresh the bottom pane layout whenever the agent activity indicator is shown or hidden so the spinner stays next to the status text
- add a regression GUI test that verifies the activity indicator lines up with the status label

## Testing
- pytest -q tests/gui/test_gui.py tests/gui/test_list_panel_gui.py tests/gui/test_agent_chat_panel.py

------
https://chatgpt.com/codex/tasks/task_e_68d0071321348320aa039706747b5242