### PR TITLE
Surface LLM context limit in settings UI

### DIFF
--- a/app/llm/constants.py
+++ b/app/llm/constants.py
@@ -1,6 +1,6 @@
 """Shared constants for LLM configuration limits."""
 
-DEFAULT_MAX_CONTEXT_TOKENS = 12000
+DEFAULT_MAX_CONTEXT_TOKENS = 131072
 """Maximum prompt size sent to the LLM when the user does not override it."""
 
 MIN_MAX_CONTEXT_TOKENS = 2000

--- a/app/ui/main_frame/settings.py
+++ b/app/ui/main_frame/settings.py
@@ -33,6 +33,7 @@ class MainFrameSettingsMixin:
             model=self.llm_settings.model,
             api_key=self.llm_settings.api_key or "",
             max_retries=self.llm_settings.max_retries,
+            max_context_tokens=self.llm_settings.max_context_tokens,
             timeout_minutes=self.llm_settings.timeout_minutes,
             stream=self.llm_settings.stream,
             auto_start=self.mcp_settings.auto_start,
@@ -52,6 +53,7 @@ class MainFrameSettingsMixin:
                 model,
                 api_key,
                 max_retries,
+                max_context_tokens,
                 timeout_minutes,
                 stream,
                 auto_start,
@@ -68,6 +70,7 @@ class MainFrameSettingsMixin:
                 model=model,
                 api_key=api_key or None,
                 max_retries=max_retries,
+                max_context_tokens=max_context_tokens,
                 timeout_minutes=timeout_minutes,
                 stream=stream,
             )

--- a/tests/gui/test_language_switch.py
+++ b/tests/gui/test_language_switch.py
@@ -45,6 +45,7 @@ def test_switch_to_russian_updates_ui(monkeypatch, wx_app, tmp_path):
                 frame.llm_settings.model,
                 frame.llm_settings.api_key or "",
                 frame.llm_settings.max_retries,
+                frame.llm_settings.max_context_tokens,
                 frame.llm_settings.timeout_minutes,
                 frame.llm_settings.stream,
                 frame.mcp_settings.auto_start,

--- a/tests/gui/test_settings_dialog.py
+++ b/tests/gui/test_settings_dialog.py
@@ -2,6 +2,8 @@
 
 import pytest
 
+from app.llm.constants import DEFAULT_MAX_CONTEXT_TOKENS
+
 pytestmark = [pytest.mark.gui, pytest.mark.integration, pytest.mark.gui_smoke]
 
 
@@ -28,6 +30,7 @@ def test_settings_dialog_returns_language(wx_app):
         model="gpt-test",
         api_key="key",
         max_retries=2,
+        max_context_tokens=DEFAULT_MAX_CONTEXT_TOKENS,
         timeout_minutes=30,
         stream=True,
         auto_start=True,
@@ -47,6 +50,7 @@ def test_settings_dialog_returns_language(wx_app):
         "gpt-test",
         "key",
         2,
+        DEFAULT_MAX_CONTEXT_TOKENS,
         30,
         True,
         True,
@@ -96,6 +100,7 @@ def test_mcp_start_stop_server(monkeypatch, wx_app):
         model="",
         api_key="",
         max_retries=3,
+        max_context_tokens=DEFAULT_MAX_CONTEXT_TOKENS,
         timeout_minutes=60,
         stream=False,
         auto_start=True,
@@ -174,6 +179,7 @@ def test_mcp_check_status(monkeypatch, wx_app):
         model="",
         api_key="",
         max_retries=3,
+        max_context_tokens=DEFAULT_MAX_CONTEXT_TOKENS,
         timeout_minutes=60,
         stream=False,
         auto_start=True,
@@ -243,6 +249,7 @@ def test_llm_agent_checks(monkeypatch, wx_app):
         model="gpt",
         api_key="key",
         max_retries=3,
+        max_context_tokens=DEFAULT_MAX_CONTEXT_TOKENS,
         timeout_minutes=30,
         stream=False,
         auto_start=True,
@@ -301,6 +308,7 @@ def test_llm_agent_check_failure_logs(monkeypatch, wx_app):
         model="gpt",
         api_key="key",
         max_retries=3,
+        max_context_tokens=DEFAULT_MAX_CONTEXT_TOKENS,
         timeout_minutes=30,
         stream=False,
         auto_start=True,
@@ -344,6 +352,7 @@ def test_settings_help_buttons(monkeypatch, wx_app):
         model="",
         api_key="",
         max_retries=3,
+        max_context_tokens=DEFAULT_MAX_CONTEXT_TOKENS,
         timeout_minutes=10,
         stream=False,
         auto_start=True,


### PR DESCRIPTION
## Summary
- raise the default LLM context budget to 131072 tokens
- expose the max context tokens setting in the LLM preferences page with validation and help text
- adjust GUI tests and helpers to account for the new dialog field

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d0686091b88320ae544c394d589ea2