### PR TITLE
Display agent conversation token usage

### DIFF
--- a/app/ui/main_frame/frame.py
+++ b/app/ui/main_frame/frame.py
@@ -233,6 +233,7 @@ class MainFrame(
                 agent_supplier=self._create_agent,
                 token_model_resolver=lambda: self.llm_settings.model,
                 context_provider=self._agent_context_messages,
+                context_window_resolver=lambda: self.llm_settings.max_context_tokens,
             ),
         )
         self._hide_agent_section()
@@ -314,6 +315,7 @@ class MainFrame(
                 agent_supplier=self._create_agent,
                 token_model_resolver=lambda: self.llm_settings.model,
                 context_provider=self._agent_context_messages,
+                context_window_resolver=lambda: self.llm_settings.max_context_tokens,
             )
             history_sash = self.config.get_agent_history_sash(
                 self.agent_panel.default_history_sash()


### PR DESCRIPTION
## Summary
- augment the agent conversation header with token statistics and context window usage
- track system, history, prompt, and context contributions to token counts during runs
- pass the LLM context limit into the chat panel and extend GUI tests to assert the new header output

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d0edf33ad083208e7dbef999debb46