### PR TITLE
Improve agent log readability for LLM and MCP exchanges

### DIFF
--- a/app/locale/en/LC_MESSAGES/CookaReq.po
+++ b/app/locale/en/LC_MESSAGES/CookaReq.po
@@ -1307,11 +1307,14 @@ msgstr ""
 msgid "Entries: {count}"
 msgstr "Entries: {count}"
 
-msgid "History sent to LLM:"
-msgstr "History sent to LLM:"
+msgid "Agent context messages included in LLM request:"
+msgstr "Agent context messages included in LLM request:"
 
-msgid "LLM request messages:"
-msgstr "LLM request messages:"
+msgid "Agent → LLM history messages:"
+msgstr "Agent → LLM history messages:"
+
+msgid "Agent → LLM compiled request:"
+msgstr "Agent → LLM compiled request:"
 
 msgid "LLM system prompt:"
 msgstr "LLM system prompt:"
@@ -1364,14 +1367,23 @@ msgstr "Open Log Folder"
 msgid "Prompt timestamp: {timestamp}"
 msgstr "Prompt timestamp: {timestamp}"
 
-msgid "Prompt:"
-msgstr "Prompt:"
+msgid "LLM → Agent final message:"
+msgstr "LLM → Agent final message:"
 
-msgid "Prompt: (empty)"
-msgstr "Prompt: (empty)"
+msgid "User → Agent prompt:"
+msgstr "User → Agent prompt:"
 
-msgid "Raw result payload:"
-msgstr "Raw result payload:"
+msgid "Agent → User response:"
+msgstr "Agent → User response:"
+
+msgid "Agent stored response payload:"
+msgstr "Agent stored response payload:"
+
+msgid "Agent reported error payload:"
+msgstr "Agent reported error payload:"
+
+msgid "Agent raw result payload:"
+msgstr "Agent raw result payload:"
 
 msgid "Regenerate"
 msgstr "Regenerate"
@@ -1385,8 +1397,8 @@ msgstr "Restart response generation"
 msgid "Show Hierarchy"
 msgstr "Show Hierarchy"
 
-msgid "Stored response payload:"
-msgstr "Stored response payload:"
+msgid "LLM ↔ MCP tool exchanges:"
+msgstr "LLM ↔ MCP tool exchanges:"
 
 msgid "Success"
 msgstr "Success"
@@ -1416,8 +1428,23 @@ msgstr "Today {time}"
 msgid "Tokens: {count}"
 msgstr "Tokens: {count}"
 
-msgid "Tool calls:"
-msgstr "Tool calls:"
+msgid "  Tool call {index}: {name} — Status: {status}"
+msgstr "  Tool call {index}: {name} — Status: {status}"
+
+msgid "    LLM tool call ID: {value}"
+msgstr "    LLM tool call ID: {value}"
+
+msgid "    LLM → MCP arguments:"
+msgstr "    LLM → MCP arguments:"
+
+msgid "    MCP → Agent result payload:"
+msgstr "    MCP → Agent result payload:"
+
+msgid "    MCP → Agent error payload:"
+msgstr "    MCP → Agent error payload:"
+
+msgid "    Additional fields:"
+msgstr "    Additional fields:"
 
 msgid "Unknown"
 msgstr "Unknown"

--- a/app/locale/ru/LC_MESSAGES/CookaReq.po
+++ b/app/locale/ru/LC_MESSAGES/CookaReq.po
@@ -1323,11 +1323,14 @@ msgstr ""
 msgid "Entries: {count}"
 msgstr "Записей: {count}"
 
-msgid "History sent to LLM:"
-msgstr "История, отправленная LLM:"
+msgid "Agent context messages included in LLM request:"
+msgstr "Контекстные сообщения агента, добавленные к запросу LLM:"
 
-msgid "LLM request messages:"
-msgstr "Сообщения запроса к LLM:"
+msgid "Agent → LLM history messages:"
+msgstr "Агент → LLM: сообщения истории"
+
+msgid "Agent → LLM compiled request:"
+msgstr "Агент → LLM: итоговый запрос"
 
 msgid "LLM system prompt:"
 msgstr "Системный промпт LLM:"
@@ -1380,14 +1383,23 @@ msgstr "Открыть папку с логами"
 msgid "Prompt timestamp: {timestamp}"
 msgstr "Время промпта: {timestamp}"
 
-msgid "Prompt:"
-msgstr "Промпт:"
+msgid "LLM → Agent final message:"
+msgstr "LLM → Агент: итоговое сообщение"
 
-msgid "Prompt: (empty)"
-msgstr "Промпт: (пусто)"
+msgid "User → Agent prompt:"
+msgstr "Пользователь → Агент: запрос"
 
-msgid "Raw result payload:"
-msgstr "Сырые данные результата:"
+msgid "Agent → User response:"
+msgstr "Агент → Пользователь: ответ"
+
+msgid "Agent stored response payload:"
+msgstr "Сохранённый ответ агента:"
+
+msgid "Agent reported error payload:"
+msgstr "Сообщённая агентом ошибка:"
+
+msgid "Agent raw result payload:"
+msgstr "Сырой итоговый пакет агента:"
 
 msgid "Regenerate"
 msgstr "Перегенерить"
@@ -1401,8 +1413,8 @@ msgstr "Запустить генерацию ответа заново"
 msgid "Show Hierarchy"
 msgstr "Показать иерархию"
 
-msgid "Stored response payload:"
-msgstr "Сохранённый ответ:"
+msgid "LLM ↔ MCP tool exchanges:"
+msgstr "Обмен инструментов между LLM и MCP:"
 
 msgid "Success"
 msgstr "Успешно"
@@ -1432,8 +1444,23 @@ msgstr "Сегодня {time}"
 msgid "Tokens: {count}"
 msgstr "Токенов: {count}"
 
-msgid "Tool calls:"
-msgstr "Вызовы инструментов:"
+msgid "  Tool call {index}: {name} — Status: {status}"
+msgstr "  Вызов инструмента {index}: {name} — Статус: {status}"
+
+msgid "    LLM tool call ID: {value}"
+msgstr "    Идентификатор вызова инструмента LLM: {value}"
+
+msgid "    LLM → MCP arguments:"
+msgstr "    LLM → MCP: аргументы"
+
+msgid "    MCP → Agent result payload:"
+msgstr "    MCP → Агент: результат"
+
+msgid "    MCP → Agent error payload:"
+msgstr "    MCP → Агент: ошибка"
+
+msgid "    Additional fields:"
+msgstr "    Дополнительные поля:"
 
 msgid "Unknown"
 msgstr "Неизвестно"


### PR DESCRIPTION
## Summary
- clarify the transcript log export by labelling prompts, LLM requests, responses, and MCP tool exchanges with explicit directions
- surface MCP error payloads separately from the raw agent result and format tool call sections with request/response blocks
- update English and Russian localisations to reflect the new terminology used in the exported logs

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d10e67c6f88320a4c97a574edc9f1c