### PR TITLE
Add detailed layout diagnostics for splitters

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -21,7 +21,6 @@ from .settings import (
 
 
 T = TypeVar("T")
-layout_logger = logging.getLogger("cookareq.ui.layout")
 DEFAULT_LIST_COLUMNS: list[str] = [
     "labels",
     "id",
@@ -803,13 +802,6 @@ class ConfigManager:
         """Restore window geometry and splitter positions."""
         w = self.get_value("win_w")
         h = self.get_value("win_h")
-        layout_logger.info(
-            "restore_layout:start size_raw=(%s, %s) pos_raw=(%s, %s)",
-            w,
-            h,
-            self.get_value("win_x"),
-            self.get_value("win_y"),
-        )
         w = max(400, min(w, 3000))
         h = max(300, min(h, 2000))
         frame.SetSize((w, h))
@@ -817,16 +809,8 @@ class ConfigManager:
         y = self.get_value("win_y")
         if x != -1 and y != -1:
             frame.SetPosition((x, y))
-            layout_logger.info(
-                "restore_layout:apply window_size=%s window_pos=%s",
-                tuple(frame.GetSize()),
-                tuple(frame.GetPosition()),
-            )
         else:
             frame.Centre()
-            layout_logger.info(
-                "restore_layout:apply window_size=%s centered", tuple(frame.GetSize())
-            )
         # Ensure layout calculations are performed even if the frame is not shown yet.
         # ``wx.Yield`` has been observed to segfault when called in quick succession
         # during automated tests, so prefer processing the pending events directly.
@@ -837,9 +821,6 @@ class ConfigManager:
         client_size = frame.GetClientSize()
         if client_size.width <= 1 or client_size.height <= 1:
             client_size = wx.Size(w, h)
-        layout_logger.info(
-            "restore_layout:client_size width=%s height=%s", client_size.width, client_size.height
-        )
         main_splitter.SetSize(client_size)
         doc_splitter.SetSize(client_size)
         doc_min = max(doc_splitter.GetMinimumPaneSize(), 100)
@@ -847,14 +828,6 @@ class ConfigManager:
         stored_doc_sash = self.get_value("sash_pos")
         doc_sash = max(doc_min, min(stored_doc_sash, doc_max))
         doc_splitter.SetSashPosition(doc_sash)
-        layout_logger.info(
-            "restore_layout:doc_splitter stored=%s applied=%s bounds=(%s,%s) min_pane=%s",
-            stored_doc_sash,
-            doc_sash,
-            doc_min,
-            doc_max,
-            doc_splitter.GetMinimumPaneSize(),
-        )
         if editor_splitter is not None and editor_splitter.IsSplit():
             editor_default = editor_splitter.GetSashPosition()
             editor_min = max(editor_splitter.GetMinimumPaneSize(), 100)
@@ -866,14 +839,6 @@ class ConfigManager:
             editor_sash = max(editor_min, min(stored_editor_sash, editor_max))
             editor_splitter.SetSize(wx.Size(available_width, client_size.height))
             editor_splitter.SetSashPosition(editor_sash)
-            layout_logger.info(
-                "restore_layout:editor_splitter stored=%s applied=%s bounds=(%s,%s) available_width=%s",
-                stored_editor_sash,
-                editor_sash,
-                editor_min,
-                editor_max,
-                available_width,
-            )
         panel.load_column_widths(self)
         panel.load_column_order(self)
         log_shown = self.get_value("log_shown")
@@ -883,17 +848,11 @@ class ConfigManager:
             main_splitter.SplitHorizontally(doc_splitter, log_console, log_sash)
             if log_menu_item:
                 log_menu_item.Check(True)
-            layout_logger.info(
-                "restore_layout:log_console shown sash=%s min_height=%s",
-                log_sash,
-                log_console.GetMinHeight() if hasattr(log_console, "GetMinHeight") else None,
-            )
         else:
             main_splitter.Initialize(doc_splitter)
             log_console.Hide()
             if log_menu_item:
                 log_menu_item.Check(False)
-            layout_logger.info("restore_layout:log_console hidden")
 
     def save_layout(
         self,
@@ -952,18 +911,4 @@ class ConfigManager:
             self.set_value("agent_history_sash", agent_history_sash)
         panel.save_column_widths(self)
         panel.save_column_order(self)
-        layout_logger.info(
-            "save_layout snapshot: size=%s pos=%s doc_tree_shown=%s doc_tree_sash=%s agent_chat_shown=%s agent_chat_sash=%s agent_history_sash=%s log_shown=%s log_sash=%s editor_shown=%s editor_sash=%s",
-            (w, h),
-            (x, y),
-            bool(doc_tree_shown),
-            sash_to_store,
-            bool(agent_chat_shown) if agent_splitter is not None else None,
-            agent_chat_sash if agent_splitter is not None else None,
-            agent_history_sash,
-            main_splitter.IsSplit(),
-            main_splitter.GetSashPosition() if main_splitter.IsSplit() else None,
-            editor_splitter.IsSplit() if editor_splitter is not None else None,
-            editor_splitter.GetSashPosition() if editor_splitter is not None and editor_splitter.IsSplit() else None,
-        )
         self.flush()

--- a/app/config.py
+++ b/app/config.py
@@ -778,25 +778,13 @@ class ConfigManager:
     def get_doc_tree_sash(self, default: int) -> int:
         """Return stored width of the hierarchy splitter."""
 
-        value: int
-        if self.has_value("sash_pos"):
-            value = int(self.get_value("sash_pos", default=default))
-        else:
-            try:
-                value = int(self._cfg.ReadInt("doc_tree_saved_sash", default))
-            except Exception:  # pragma: no cover - defensive fallback
-                value = int(default)
+        value = int(self.get_value("sash_pos", default=default))
         return max(value, 0)
 
     def set_doc_tree_sash(self, pos: int) -> None:
         """Persist width of the hierarchy splitter."""
 
         self.set_value("sash_pos", pos)
-        try:
-            if self._cfg.HasEntry("doc_tree_saved_sash"):
-                self._cfg.DeleteEntry("doc_tree_saved_sash")
-        except Exception:  # pragma: no cover - defensive compatibility cleanup
-            pass
         self.flush()
 
     # ------------------------------------------------------------------

--- a/app/ui/agent_chat_panel.py
+++ b/app/ui/agent_chat_panel.py
@@ -34,7 +34,6 @@ from .widgets.chat_message import TranscriptMessagePanel
 
 
 logger = logging.getLogger("cookareq.ui.agent_chat_panel")
-layout_logger = logging.getLogger("cookareq.ui.layout")
 
 
 try:  # pragma: no cover - import only used for typing
@@ -549,7 +548,6 @@ class AgentChatPanel(wx.Panel):
         self._history_sash_goal = target
         self._history_last_sash = max(target, 0)
         self._history_sash_dirty = True
-        self._log_history_layout("apply-request", requested=target)
         self._apply_history_sash_if_ready()
 
     @property
@@ -587,11 +585,6 @@ class AgentChatPanel(wx.Panel):
         if not self._history_sash_dirty and abs(current - target) <= 1:
             return
         self._history_sash_dirty = True
-        self._log_history_layout(
-            "splitter-resize",
-            current=current,
-            target=target,
-        )
         self._apply_history_sash_if_ready()
 
     def _on_history_sash_changed(self, event: wx.SplitterEvent) -> None:
@@ -608,7 +601,6 @@ class AgentChatPanel(wx.Panel):
         self._history_last_sash = max(pos, 0)
         self._history_sash_goal = pos
         self._history_sash_dirty = False
-        self._log_history_layout("user-adjust", new_position=pos)
         event.Skip()
 
     def _apply_history_sash_if_ready(self) -> None:
@@ -617,28 +609,19 @@ class AgentChatPanel(wx.Panel):
         target = self._history_sash_goal
         if target is None:
             self._history_sash_dirty = False
-            self._log_history_layout("apply-if-ready-skip", reason="no-target")
             return
         splitter = getattr(self, "_horizontal_splitter", None)
         if splitter is None or not splitter.IsSplit():
-            self._log_history_layout("apply-if-ready-wait", reason="splitter-unavailable")
             return
         size = splitter.GetClientSize()
         if size.width <= 0:
-            self._log_history_layout(
-                "apply-if-ready-wait",
-                reason="no-width",
-                splitter_size=(size.width, size.height),
-            )
             return
         minimum = splitter.GetMinimumPaneSize()
         desired = max(target, minimum)
         if not self._attempt_set_history_sash(desired):
             self._history_sash_dirty = True
-            self._log_history_layout("apply-if-ready-retry", desired=desired)
             return
         self._history_sash_dirty = False
-        self._log_history_layout("apply-if-ready-success", desired=desired)
         wx.CallAfter(self._verify_history_sash_after_apply)
 
     def _attempt_set_history_sash(self, target: int) -> bool:
@@ -646,11 +629,6 @@ class AgentChatPanel(wx.Panel):
 
         splitter = getattr(self, "_horizontal_splitter", None)
         if splitter is None or not splitter.IsSplit():
-            self._log_history_layout(
-                "attempt-set-skip",
-                target=target,
-                reason="splitter-unavailable",
-            )
             return False
         self._history_sash_internal_adjust += 1
         splitter.SetSashPosition(target)
@@ -658,12 +636,6 @@ class AgentChatPanel(wx.Panel):
         wx.CallAfter(self._release_history_sash_adjust)
         self._history_last_sash = max(actual, 0)
         success = abs(actual - target) <= 1
-        self._log_history_layout(
-            "attempt-set",
-            target=target,
-            actual=actual,
-            success=success,
-        )
         return success
 
     def _release_history_sash_adjust(self) -> None:
@@ -686,45 +658,9 @@ class AgentChatPanel(wx.Panel):
         self._history_last_sash = max(current, 0)
         expected = max(target, splitter.GetMinimumPaneSize())
         if abs(current - expected) <= 1:
-            self._log_history_layout(
-                "verify-success",
-                expected=expected,
-                current=current,
-            )
             return
         self._history_sash_dirty = True
-        self._log_history_layout(
-            "verify-mismatch",
-            expected=expected,
-            current=current,
-        )
         self._apply_history_sash_if_ready()
-
-    def _log_history_layout(self, stage: str, **extra: Any) -> None:
-        """Emit diagnostic log entries describing history sash state."""
-
-        splitter = getattr(self, "_horizontal_splitter", None)
-        state: dict[str, Any] = {
-            "stage": stage,
-            "goal": self._history_sash_goal,
-            "last": self._history_last_sash,
-            "dirty": self._history_sash_dirty,
-            "internal_adjust": getattr(self, "_history_sash_internal_adjust", 0),
-        }
-        if splitter is not None and not splitter.IsBeingDeleted():
-            size = splitter.GetClientSize()
-            state.update(
-                {
-                    "splitter_is_split": splitter.IsSplit(),
-                    "splitter_size": (size.width, size.height),
-                    "splitter_min": splitter.GetMinimumPaneSize(),
-                    "splitter_sash": splitter.GetSashPosition(),
-                }
-            )
-        else:
-            state["splitter"] = "unavailable"
-        state.update(extra)
-        layout_logger.info("agent history layout: %s", state)
 
     def _on_send(self, _event: wx.Event) -> None:
         """Send prompt to agent."""

--- a/app/ui/main_frame/frame.py
+++ b/app/ui/main_frame/frame.py
@@ -392,6 +392,11 @@ class MainFrame(
             old_agent_panel = self.agent_panel
             agent_was_split = self.agent_splitter.IsSplit()
             sash_pos = self.agent_splitter.GetSashPosition() if agent_was_split else None
+            vertical_sash: int | None = None
+            if hasattr(old_agent_panel, "vertical_sash"):
+                vertical_value = old_agent_panel.vertical_sash  # type: ignore[attr-defined]
+                if isinstance(vertical_value, int) and vertical_value > 0:
+                    vertical_sash = vertical_value
             self.agent_panel = AgentChatPanel(
                 self.agent_container,
                 agent_supplier=self._create_agent,
@@ -403,6 +408,8 @@ class MainFrame(
                 self.agent_panel.default_history_sash()
             )
             self.agent_panel.apply_history_sash(history_sash)
+            if vertical_sash is not None:
+                self.agent_panel.apply_vertical_sash(vertical_sash)
             agent_sizer = self.agent_container.GetSizer()
             if agent_sizer is not None:
                 agent_sizer.Replace(old_agent_panel, self.agent_panel)

--- a/app/ui/main_frame/frame.py
+++ b/app/ui/main_frame/frame.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import logging
 from collections.abc import Callable
 from dataclasses import fields
 from importlib import resources
@@ -33,10 +32,6 @@ from ..navigation import Navigation
 
 if TYPE_CHECKING:  # pragma: no cover - import for type checking only
     from .controllers import DocumentsController
-
-
-layout_logger = logging.getLogger("cookareq.ui.layout")
-
 
 class MainFrame(
     MainFrameRequirementsMixin,
@@ -125,84 +120,6 @@ class MainFrame(
             path = Path(self.recent_dirs[0])
             if path.exists():
                 self._load_directory(path)
-
-    def _log_splitter_snapshot(self, stage: str) -> None:
-        """Emit diagnostic information about splitter geometry."""
-
-        if not getattr(self, "doc_splitter", None):
-            return
-        if self.IsBeingDeleted():  # pragma: no cover - defensive GUI guard
-            return
-
-        def _size(window: wx.Window | None) -> tuple[int, int] | None:
-            if window is None or window.IsBeingDeleted():
-                return None
-            size = window.GetClientSize()
-            return (size.width, size.height)
-
-        try:
-            snapshot: dict[str, object] = {
-                "stage": stage,
-                "frame": {
-                    "size": tuple(self.GetSize()),
-                    "client": tuple(self.GetClientSize()),
-                    "position": tuple(self.GetPosition()),
-                    "shown": self.IsShown(),
-                },
-                "doc_splitter": {
-                    "is_split": self.doc_splitter.IsSplit(),
-                    "sash": self.doc_splitter.GetSashPosition(),
-                    "min": self.doc_splitter.GetMinimumPaneSize(),
-                    "size": _size(self.doc_splitter),
-                    "last_cached": getattr(self, "_doc_tree_last_sash", None),
-                    "menu_checked": bool(
-                        self.hierarchy_menu_item
-                        and self.hierarchy_menu_item.IsChecked()
-                    ),
-                },
-                "agent_splitter": {
-                    "is_split": self.agent_splitter.IsSplit(),
-                    "sash": self.agent_splitter.GetSashPosition(),
-                    "min": self.agent_splitter.GetMinimumPaneSize(),
-                    "size": _size(self.agent_splitter),
-                    "last_cached": getattr(self, "_agent_last_sash", None),
-                    "menu_checked": bool(
-                        self.agent_chat_menu_item
-                        and self.agent_chat_menu_item.IsChecked()
-                    ),
-                },
-                "editor_splitter": {
-                    "is_split": self.splitter.IsSplit(),
-                    "sash": self.splitter.GetSashPosition(),
-                    "min": self.splitter.GetMinimumPaneSize(),
-                    "size": _size(self.splitter),
-                    "menu_checked": bool(
-                        self.editor_menu_item
-                        and self.editor_menu_item.IsChecked()
-                    ),
-                },
-                "main_splitter": {
-                    "is_split": self.main_splitter.IsSplit(),
-                    "sash": self.main_splitter.GetSashPosition()
-                    if self.main_splitter.IsSplit()
-                    else None,
-                    "size": _size(self.main_splitter),
-                },
-            }
-            agent_panel = getattr(self, "agent_panel", None)
-            if agent_panel is not None:
-                history_goal = getattr(agent_panel, "_history_sash_goal", None)
-                history_dirty = getattr(agent_panel, "_history_sash_dirty", None)
-                snapshot["agent_history"] = {
-                    "current": agent_panel.history_sash,
-                    "goal": history_goal,
-                    "dirty": history_dirty,
-                }
-        except Exception:  # pragma: no cover - defensive logging path
-            layout_logger.exception("Failed to build layout snapshot for %s", stage)
-            return
-
-        layout_logger.info("layout snapshot: %s", snapshot)
 
     # ------------------------------------------------------------------
     # initialization helpers

--- a/app/ui/main_frame/sections.py
+++ b/app/ui/main_frame/sections.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import logging
 from collections.abc import Callable, Sequence
 from typing import TYPE_CHECKING
 
@@ -14,9 +13,6 @@ from ..widgets import SectionContainer
 
 if TYPE_CHECKING:  # pragma: no cover - import for type checking only
     from .frame import MainFrame
-
-
-layout_logger = logging.getLogger("cookareq.ui.layout")
 
 
 class MainFrameSectionsMixin:
@@ -345,16 +341,6 @@ class MainFrameSectionsMixin:
         history_sash = self.config.get_agent_history_sash(
             self.agent_panel.default_history_sash()
         )
-        layout_logger.info(
-            "main_frame layout config: doc_tree_last=%s agent_last=%s history_requested=%s flags={hierarchy:%s,agent:%s,editor:%s,log:%s}",
-            self._doc_tree_last_sash,
-            self._agent_last_sash,
-            history_sash,
-            self.config.get_doc_tree_shown(),
-            self.config.get_agent_chat_shown(),
-            self.config.get_editor_shown(),
-            self.config.get_value("log_shown"),
-        )
         self.agent_panel.apply_history_sash(history_sash)
         if self.hierarchy_menu_item:
             self.hierarchy_menu_item.Check(self.config.get_doc_tree_shown())
@@ -365,15 +351,6 @@ class MainFrameSectionsMixin:
         if self.agent_chat_menu_item:
             self.agent_chat_menu_item.Check(self.config.get_agent_chat_shown())
             self._apply_agent_chat_visibility(persist=False)
-        if hasattr(self, "_log_splitter_snapshot"):
-            try:
-                self._log_splitter_snapshot("after-load-layout")
-            except Exception:  # pragma: no cover - defensive logging
-                layout_logger.exception("Failed to capture initial layout snapshot")
-            else:
-                wx.CallLater(200, self._log_splitter_snapshot, "post-load-200ms")
-                wx.CallLater(1000, self._log_splitter_snapshot, "post-load-1s")
-                wx.CallLater(3000, self._log_splitter_snapshot, "post-load-3s")
 
     def _save_layout(self: "MainFrame") -> None:
         """Persist window geometry, splitter, console, and column widths."""

--- a/app/ui/main_frame/sections.py
+++ b/app/ui/main_frame/sections.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Callable, Sequence
 from typing import TYPE_CHECKING
 
@@ -13,6 +14,9 @@ from ..widgets import SectionContainer
 
 if TYPE_CHECKING:  # pragma: no cover - import for type checking only
     from .frame import MainFrame
+
+
+layout_logger = logging.getLogger("cookareq.ui.layout")
 
 
 class MainFrameSectionsMixin:
@@ -341,6 +345,16 @@ class MainFrameSectionsMixin:
         history_sash = self.config.get_agent_history_sash(
             self.agent_panel.default_history_sash()
         )
+        layout_logger.info(
+            "main_frame layout config: doc_tree_last=%s agent_last=%s history_requested=%s flags={hierarchy:%s,agent:%s,editor:%s,log:%s}",
+            self._doc_tree_last_sash,
+            self._agent_last_sash,
+            history_sash,
+            self.config.get_doc_tree_shown(),
+            self.config.get_agent_chat_shown(),
+            self.config.get_editor_shown(),
+            self.config.get_value("log_shown"),
+        )
         self.agent_panel.apply_history_sash(history_sash)
         if self.hierarchy_menu_item:
             self.hierarchy_menu_item.Check(self.config.get_doc_tree_shown())
@@ -351,6 +365,15 @@ class MainFrameSectionsMixin:
         if self.agent_chat_menu_item:
             self.agent_chat_menu_item.Check(self.config.get_agent_chat_shown())
             self._apply_agent_chat_visibility(persist=False)
+        if hasattr(self, "_log_splitter_snapshot"):
+            try:
+                self._log_splitter_snapshot("after-load-layout")
+            except Exception:  # pragma: no cover - defensive logging
+                layout_logger.exception("Failed to capture initial layout snapshot")
+            else:
+                wx.CallLater(200, self._log_splitter_snapshot, "post-load-200ms")
+                wx.CallLater(1000, self._log_splitter_snapshot, "post-load-1s")
+                wx.CallLater(3000, self._log_splitter_snapshot, "post-load-3s")
 
     def _save_layout(self: "MainFrame") -> None:
         """Persist window geometry, splitter, console, and column widths."""

--- a/app/ui/main_frame/settings.py
+++ b/app/ui/main_frame/settings.py
@@ -46,9 +46,9 @@ class MainFrameSettingsMixin:
         )
         if dlg.ShowModal() == wx.ID_OK:
             (
-                self.auto_open_last,
-                self.remember_sort,
-                self.language,
+                auto_open_last,
+                remember_sort,
+                language,
                 base_url,
                 model,
                 api_key,
@@ -64,6 +64,11 @@ class MainFrameSettingsMixin:
                 require_token,
                 token,
             ) = dlg.get_values()
+            previous_language = self.language
+            language_changed = previous_language != language
+            self.auto_open_last = auto_open_last
+            self.remember_sort = remember_sort
+            self.language = language
             previous_mcp = self.mcp_settings
             self.llm_settings = LLMSettings(
                 base_url=base_url,
@@ -103,5 +108,6 @@ class MainFrameSettingsMixin:
             elif self.mcp_settings.auto_start and server_config_changed:
                 self.mcp.stop()
                 self.mcp.start(self.mcp_settings)
-            self._apply_language()
+            if language_changed:
+                self._apply_language()
         dlg.Destroy()

--- a/tests/unit/test_config_manager.py
+++ b/tests/unit/test_config_manager.py
@@ -435,25 +435,23 @@ def test_save_layout_tracks_doc_tree_collapse(tmp_path, wx_app):
     assert cfg.get_doc_tree_sash(100) == 250
 
 
-def test_get_doc_tree_sash_prefers_explicit_entry(tmp_path, wx_app):
+def test_get_doc_tree_sash_ignores_legacy_entry(tmp_path, wx_app):
     cfg = ConfigManager(app_name="TestApp", path=tmp_path / "cfg_doc.ini")
 
     cfg.set_value("sash_pos", 221)
     cfg.write_int("doc_tree_saved_sash", 1125)
     cfg.flush()
 
-    assert cfg.has_value("sash_pos") is True
-    assert cfg.get_doc_tree_sash(221) == 221
+    assert cfg.get_doc_tree_sash(99) == 221
 
 
-def test_get_doc_tree_sash_falls_back_to_legacy(tmp_path, wx_app):
+def test_get_doc_tree_sash_defaults_without_modern_key(tmp_path, wx_app):
     cfg = ConfigManager(app_name="TestApp", path=tmp_path / "cfg_doc.ini")
 
     cfg.write_int("doc_tree_saved_sash", 777)
     cfg.flush()
 
-    assert cfg.has_value("sash_pos") is False
-    assert cfg.get_doc_tree_sash(123) == 777
+    assert cfg.get_doc_tree_sash(123) == 123
 
 
 def test_save_layout_tracks_agent_history(tmp_path, wx_app):

--- a/tests/unit/test_config_manager.py
+++ b/tests/unit/test_config_manager.py
@@ -435,6 +435,27 @@ def test_save_layout_tracks_doc_tree_collapse(tmp_path, wx_app):
     assert cfg.get_doc_tree_sash(100) == 250
 
 
+def test_get_doc_tree_sash_prefers_explicit_entry(tmp_path, wx_app):
+    cfg = ConfigManager(app_name="TestApp", path=tmp_path / "cfg_doc.ini")
+
+    cfg.set_value("sash_pos", 221)
+    cfg.write_int("doc_tree_saved_sash", 1125)
+    cfg.flush()
+
+    assert cfg.has_value("sash_pos") is True
+    assert cfg.get_doc_tree_sash(221) == 221
+
+
+def test_get_doc_tree_sash_falls_back_to_legacy(tmp_path, wx_app):
+    cfg = ConfigManager(app_name="TestApp", path=tmp_path / "cfg_doc.ini")
+
+    cfg.write_int("doc_tree_saved_sash", 777)
+    cfg.flush()
+
+    assert cfg.has_value("sash_pos") is False
+    assert cfg.get_doc_tree_sash(123) == 777
+
+
 def test_save_layout_tracks_agent_history(tmp_path, wx_app):
     wx = pytest.importorskip("wx")
     cfg = ConfigManager(app_name="TestApp", path=tmp_path / "cfg_agent.ini")


### PR DESCRIPTION
## Summary
- add detailed logging in ConfigManager restore/save helpers to record sash positions and window geometry
- instrument MainFrame layout loading with splitter snapshots and delayed probes
- expose agent chat history sash state transitions through structured log entries

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d1161243d08320a9647a890a28780e