### PR TITLE
Refine agent log request formatting

### DIFF
--- a/app/locale/en/LC_MESSAGES/CookaReq.po
+++ b/app/locale/en/LC_MESSAGES/CookaReq.po
@@ -1316,6 +1316,9 @@ msgstr "Agent → LLM history messages:"
 msgid "Agent → LLM compiled request:"
 msgstr "Agent → LLM compiled request:"
 
+msgid "Tool specifications are sent as a separate payload and therefore do not appear inside the compiled request messages."
+msgstr "Tool specifications are sent as a separate payload and therefore do not appear inside the compiled request messages."
+
 msgid "LLM system prompt:"
 msgstr "LLM system prompt:"
 

--- a/app/locale/ru/LC_MESSAGES/CookaReq.po
+++ b/app/locale/ru/LC_MESSAGES/CookaReq.po
@@ -1332,6 +1332,9 @@ msgstr "Агент → LLM: сообщения истории"
 msgid "Agent → LLM compiled request:"
 msgstr "Агент → LLM: итоговый запрос"
 
+msgid "Tool specifications are sent as a separate payload and therefore do not appear inside the compiled request messages."
+msgstr "Спецификации инструментов передаются отдельным параметром, поэтому их не видно внутри сообщений собранного запроса."
+
 msgid "LLM system prompt:"
 msgstr "Системный промпт LLM:"
 

--- a/app/ui/agent_chat_panel.py
+++ b/app/ui/agent_chat_panel.py
@@ -1899,19 +1899,10 @@ class AgentChatPanel(wx.Panel):
                 )
             )
             prompt_text = normalize_for_display(entry.prompt)
-            lines.append(_("User → Agent prompt:"))
-            if prompt_text:
-                lines.append(indent_block(prompt_text))
-            else:
-                lines.append(indent_block(_("(empty)")))
             context_snapshot = [
                 dict(message) for message in (entry.context_messages or ())
             ]
-            lines.append(_("Agent context messages included in LLM request:"))
-            lines.append(indent_block(format_message_list(context_snapshot)))
             history_messages = gather_history_messages(index - 1)
-            lines.append(_("Agent → LLM history messages:"))
-            lines.append(indent_block(format_message_list(history_messages)))
             llm_request_messages: list[dict[str, Any]] = [
                 {"role": "system", "content": SYSTEM_PROMPT},
                 *history_messages,
@@ -1920,6 +1911,12 @@ class AgentChatPanel(wx.Panel):
             ]
             lines.append(_("Agent → LLM compiled request:"))
             lines.append(indent_block(format_message_list(llm_request_messages)))
+            if TOOLS:
+                lines.append(
+                    _(
+                        "Tool specifications are sent as a separate payload and therefore do not appear inside the compiled request messages."
+                    )
+                )
             lines.append(
                 _("Response timestamp: {timestamp}").format(
                     timestamp=format_timestamp(entry.response_at)


### PR DESCRIPTION
## Summary
- remove duplicate prompt/context sections from agent conversation logs and rely on the compiled request block
- clarify via localized note that tool specifications are provided separately and therefore absent from the compiled request view

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d12f10857c8320a7e3193d321d07fe