### PR TITLE
Adjust chat bubble styling and fonts

### DIFF
--- a/app/ui/widgets/markdown_view.py
+++ b/app/ui/widgets/markdown_view.py
@@ -113,6 +113,12 @@ class MarkdownView(html.HtmlWindow):
         self.SetPage(html_markup)
         self._refresh_best_size()
 
+    def DoSetFont(self, font: wx.Font | None) -> bool:  # noqa: N802 - wx naming convention
+        changed = super().DoSetFont(font)
+        if changed:
+            self.SetMarkdown(self._markdown)
+        return changed
+
     def HasSelection(self) -> bool:  # noqa: N802 - wx naming convention
         return bool(self.SelectionToText())
 
@@ -249,6 +255,16 @@ class MarkdownContent(wx.Panel):
         sizer = wx.BoxSizer(wx.VERTICAL)
         sizer.Add(self._view, 1, wx.EXPAND)
         self.SetSizer(sizer)
+
+    def DoSetFont(self, font: wx.Font | None) -> bool:  # noqa: N802 - wx naming convention
+        changed = super().DoSetFont(font)
+        if changed:
+            effective = font if font is not None else self.GetFont()
+            if effective.IsOk():
+                self._view.SetFont(effective)
+            else:
+                self._view.SetFont(wx.NullFont)
+        return changed
 
     def HasSelection(self) -> bool:  # noqa: N802 - wx naming convention
         return self._view.HasSelection()


### PR DESCRIPTION
## Summary
- soften the user bubble colour and choose a higher-contrast foreground automatically
- tint agent responses with a gentle green and align bubble fonts across message types
- refresh markdown rendering when fonts change so selections and body text share the same size

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d1562339388320a25044060572bb6d