### PR TITLE
Fix agent bubble markdown background

### DIFF
--- a/app/ui/widgets/markdown_view.py
+++ b/app/ui/widgets/markdown_view.py
@@ -158,6 +158,14 @@ class MarkdownView(html.HtmlWindow):
         font_size = _font_size(font)
         mono_face = _font_face(mono_font)
 
+        body_attributes = (
+            f" bgcolor=\"{background_hex}\""
+            f" text=\"{foreground_hex}\""
+            f" link=\"{foreground_hex}\""
+            f" vlink=\"{foreground_hex}\""
+            f" alink=\"{foreground_hex}\""
+        )
+
         return (
             "<!DOCTYPE html>"
             "<html>"
@@ -224,7 +232,7 @@ class MarkdownView(html.HtmlWindow):
             "}"
             "</style>"
             "</head>"
-            "<body>"
+            f"<body{body_attributes}>"
             f"{body_html}"
             "</body>"
             "</html>"

--- a/tests/gui/test_markdown_view.py
+++ b/tests/gui/test_markdown_view.py
@@ -1,0 +1,41 @@
+"""GUI regression tests for MarkdownView rendering."""
+
+from __future__ import annotations
+
+import pytest
+
+
+pytestmark = [pytest.mark.gui]
+
+
+def _colour_to_hex(colour) -> str:
+    return f"#{colour.Red():02x}{colour.Green():02x}{colour.Blue():02x}"
+
+
+def test_markdown_view_sets_html_body_attributes(wx_app):
+    wx = pytest.importorskip("wx")
+
+    background = wx.Colour(210, 238, 215)
+    foreground = wx.Colour(24, 48, 30)
+
+    frame = wx.Frame(None)
+    try:
+        from app.ui.widgets.markdown_view import MarkdownView
+
+        view = MarkdownView(
+            frame,
+            foreground_colour=foreground,
+            background_colour=background,
+        )
+
+        html = view._wrap_html("sample text")
+
+        background_hex = _colour_to_hex(background)
+        foreground_hex = _colour_to_hex(foreground)
+
+        assert f'bgcolor="{background_hex}"' in html
+        assert f'text="{foreground_hex}"' in html
+        assert f"background-color: {background_hex};" in html
+        assert f"color: {foreground_hex};" in html
+    finally:
+        frame.Destroy()


### PR DESCRIPTION
## Summary
- ensure the markdown renderer sets legacy HTML attributes so the agent bubble background inherits the green tint even when CSS is limited
- add a GUI regression test to confirm the generated markup keeps the expected body colour attributes

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d165e386e0832088a32ab4e27c9e5f