### PR TITLE
Expose LLM tool validation context in diagnostics

### DIFF
--- a/app/mcp/utils.py
+++ b/app/mcp/utils.py
@@ -170,5 +170,17 @@ def exception_to_mcp_error(exc: BaseException) -> dict[str, Any]:
 
     code = map_exception_to_error_code(exc)
     message = str(exc) or type(exc).__name__
-    details = {"type": type(exc).__name__}
+    details: dict[str, Any] = {"type": type(exc).__name__}
+    llm_message = getattr(exc, "llm_message", None)
+    if llm_message is not None:
+        details["llm_message"] = str(llm_message)
+    llm_tool_calls = getattr(exc, "llm_tool_calls", None)
+    if llm_tool_calls:
+        serialized_calls: list[Any] = []
+        for call in llm_tool_calls:
+            if isinstance(call, Mapping):
+                serialized_calls.append(dict(call))
+            else:
+                serialized_calls.append(call)
+        details["llm_tool_calls"] = serialized_calls
     return mcp_error(code, message, details)

--- a/tests/test_agent_log_diagnostics.py
+++ b/tests/test_agent_log_diagnostics.py
@@ -71,3 +71,43 @@ def test_build_entry_diagnostic_omits_duplicate_stored_response():
     )
 
     assert diagnostic["agent_stored_response"] is None
+
+
+def test_build_entry_diagnostic_includes_llm_details():
+    diagnostic = AgentChatPanel._build_entry_diagnostic(
+        prompt="generate",
+        prompt_at="2025-01-02T00:00:00Z",
+        response_at="2025-01-02T00:00:05Z",
+        display_response="validation error",
+        stored_response="validation error",
+        raw_result={
+            "ok": False,
+            "error": {
+                "code": "VALIDATION_ERROR",
+                "message": "Invalid arguments",
+                "details": {
+                    "type": "ToolValidationError",
+                    "llm_message": "Подготавливаю требование",
+                    "llm_tool_calls": [
+                        {
+                            "id": "call-0",
+                            "type": "function",
+                            "function": {
+                                "name": "create_requirement",
+                                "arguments": "{\"prefix\": \"SYS\", \"data\": {\"title\": \"Req\"}}",
+                            },
+                        }
+                    ],
+                },
+            },
+        },
+        tool_results=None,
+        history_snapshot=None,
+        context_snapshot=None,
+    )
+
+    assert diagnostic["llm_final_message"] == "Подготавливаю требование"
+    planned = diagnostic["llm_tool_calls"]
+    assert isinstance(planned, list)
+    assert planned
+    assert planned[0]["function"]["name"] == "create_requirement"


### PR DESCRIPTION
## Summary
- capture the assistant message and normalised tool call payloads when MCP tool validation fails so logs include the inbound context and the exception carries it forward
- enrich MCP error mapping and transcript diagnostics to surface stored LLM details, displaying planned tool calls in the transcript log when validation errors occur
- cover the regression with integration, unit and GUI tests for the LLM client, LocalAgent and transcript formatting

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d167c9e30c8320a8432326c742bcb0