### PR TITLE
Clarify RID usage in MCP system prompt and extend integration coverage

### DIFF
--- a/app/llm/spec.py
+++ b/app/llm/spec.py
@@ -35,7 +35,20 @@ SYSTEM_PROMPT = (
     "`list_requirements` accepts optional `page`, `per_page`, `status` and "
     "`labels`; `search_requirements` accepts `query`, `labels`, `status`, "
     "`page` and `per_page`. Status values: draft, in_review, approved, "
-    "baselined, retired. Labels must be arrays of strings."
+    "baselined, retired. Labels must be arrays of strings. When the user "
+    "references a requirement, always use its requirement identifier (RID) "
+    "exactly as shown in the workspace context using the `<prefix><number>` "
+    "format (case-sensitive). Never pass only the numeric `id`. Examples:\n"
+    "- Context entry \"SYS11 (id=11, prefix=SYS)\" and user request \"Напиши текст первого "
+    "требования\" → call `get_requirement` with {\"rid\": \"SYS11\"}.\n"
+    "- Context entry \"SYS3 (id=3, prefix=SYS)\" and user request \"Обнови статус SYS3 на "
+    "approved\" → call `patch_requirement` with {\"rid\": \"SYS3\", \"rev\": 1, \"patch\": "
+    "[{\"op\": \"replace\", \"path\": \"/status\", \"value\": \"approved\"}]}.\n"
+    "- Context entries \"HLR5 (id=5, prefix=HLR)\" and \"SYS11 (id=11, prefix=SYS)\" with user "
+    "request \"Свяжи SYS11 как дочернее от HLR5\" → call `link_requirements` with "
+    "{\"source_rid\": \"HLR5\", \"derived_rid\": \"SYS11\", \"link_type\": \"parent\", \"rev\": 1}.\n"
+    "- User request \"Найди требования с меткой UI\" → call `search_requirements` with "
+    "{\"labels\": [\"UI\"]}."
 )
 
 

--- a/tests/integration/test_mcp_text_commands.py
+++ b/tests/integration/test_mcp_text_commands.py
@@ -4,10 +4,21 @@ import json
 import logging
 from http.client import HTTPConnection
 from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
 
 import pytest
 
 from app.agent import LocalAgent
+from app.core.document_store import Document, save_document, save_item
+from app.core.model import (
+    Priority,
+    Requirement,
+    RequirementType,
+    Status,
+    Verification,
+    requirement_to_dict,
+)
 from app.log import logger
 from app.mcp.server import JsonlHandler
 from app.mcp.server import app as mcp_app
@@ -95,6 +106,139 @@ def test_run_command_error_logs(tmp_path: Path, monkeypatch, mcp_server) -> None
         "TOOL_RESULT",
         "ERROR",
     } <= events
+
+
+def test_run_command_fetches_requirement_with_prefixed_rid(
+    tmp_path: Path, monkeypatch, mcp_server
+) -> None:
+    port = mcp_server
+    mcp_app.state.base_path = str(tmp_path)
+    settings = settings_with_mcp(
+        "127.0.0.1",
+        port,
+        str(tmp_path),
+        "",
+        tmp_path=tmp_path,
+    )
+
+    doc = Document(prefix="SYS", title="System")
+    doc_dir = tmp_path / "SYS"
+    save_document(doc_dir, doc)
+    requirement = Requirement(
+        id=11,
+        title="Первое требование",
+        statement="Содержимое первого требования.",
+        type=RequirementType.REQUIREMENT,
+        status=Status.APPROVED,
+        owner="owner",
+        priority=Priority.MEDIUM,
+        source="specification",
+        verification=Verification.ANALYSIS,
+    )
+    save_item(doc_dir, doc, requirement_to_dict(requirement))
+
+    responses = {
+        "Напиши текст первого требования": [
+            ("get_requirement", {"rid": "SYS11"}),
+            {"message": "Текст требования: Содержимое первого требования."},
+        ]
+    }
+    prepared: dict[str, list[Any]] = {
+        key: list(value) if isinstance(value, list) else [value]
+        for key, value in responses.items()
+    }
+    captured_messages: list[list[dict[str, Any]]] = []
+
+    class RecordingCompletions:
+        def create(self, *, messages, tools=None, **kwargs):
+            captured_messages.append(messages)
+            user_prompt = next(
+                (
+                    msg.get("content")
+                    for msg in reversed(messages)
+                    if msg.get("role") == "user"
+                ),
+                messages[-1].get("content"),
+            )
+            queue = prepared.get(user_prompt)
+            if queue is None:
+                queue = prepared.setdefault(user_prompt, [("list_requirements", {})])
+            result = queue.pop(0) if len(queue) > 1 else queue[0]
+            if isinstance(result, tuple):
+                name, args = result
+                return SimpleNamespace(
+                    choices=[
+                        SimpleNamespace(
+                            message=SimpleNamespace(
+                                tool_calls=[
+                                    SimpleNamespace(
+                                        id="call-1",
+                                        function=SimpleNamespace(
+                                            name=name,
+                                            arguments=json.dumps(args),
+                                        ),
+                                    )
+                                ],
+                                content=None,
+                            )
+                        )
+                    ]
+                )
+            if isinstance(result, dict) and "message" in result:
+                return SimpleNamespace(
+                    choices=[
+                        SimpleNamespace(
+                            message=SimpleNamespace(
+                                content=result["message"],
+                                tool_calls=None,
+                            )
+                        )
+                    ]
+                )
+            raise AssertionError(f"Unexpected mock response: {result!r}")
+
+    class RecordingChat:
+        def __init__(self) -> None:
+            self.completions = RecordingCompletions()
+
+    class RecordingOpenAI:
+        def __init__(self, *args, **kwargs) -> None:
+            self.chat = RecordingChat()
+
+    monkeypatch.setattr("openai.OpenAI", RecordingOpenAI)
+
+    client = LocalAgent(settings=settings, confirm=lambda _m: True)
+    context = [
+        {
+            "role": "system",
+            "content": (
+                "[Workspace context]\n"
+                "Active requirements list: SYS: Сист. треб.\n"
+                "Selected requirements (1):\n"
+                "- SYS11 (id=11, prefix=SYS) — Содержимое первого требования."
+            ),
+        }
+    ]
+    result = client.run_command(
+        "Напиши текст первого требования",
+        context=context,
+    )
+
+    assert result["ok"] is True, result
+    assert result["error"] is None
+    assert result["result"] == "Текст требования: Содержимое первого требования."
+    tool_results = result.get("tool_results")
+    assert isinstance(tool_results, list) and tool_results
+    first_tool = tool_results[0]
+    assert first_tool["tool_name"] == "get_requirement"
+    assert first_tool["tool_arguments"]["rid"] == "SYS11"
+    assert first_tool["result"]["rid"] == "SYS11"
+    assert first_tool["result"]["statement"] == "Содержимое первого требования."
+
+    assert captured_messages, "LLM mock should capture at least one request"
+    system_prompt = captured_messages[0][0]["content"]
+    assert "<prefix><number>" in system_prompt
+    assert "SYS11 (id=11, prefix=SYS)" in system_prompt
 
 
 def test_mcp_endpoint_direct_call(tmp_path: Path, mcp_server) -> None:


### PR DESCRIPTION
## Summary
- expand the MCP system prompt with explicit RID formatting guidance and case-sensitive examples covering multiple tools
- add an integration test that exercises a prefixed RID workflow for "Напиши текст первого требования" and verifies the prompt content is propagated to the LLM client

## Testing
- pytest -q tests/integration/test_mcp_text_commands.py --suite service

------
https://chatgpt.com/codex/tasks/task_e_68d1738d677083208c31216039693696