### PR TITLE
Add chat confirmation preferences

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -132,6 +132,7 @@ ConfigFieldName = Literal[
     "agent_chat_sash",
     "agent_chat_shown",
     "agent_history_sash",
+    "agent_confirm_mode",
     "win_w",
     "win_h",
     "win_x",
@@ -288,6 +289,11 @@ CONFIG_FIELD_SPECS: dict[ConfigFieldName, FieldSpec[Any]] = {
         key="agent_history_sash",
         value_type=int,
         default=320,
+    ),
+    "agent_confirm_mode": FieldSpec(
+        key="agent_confirm_mode",
+        value_type=str,
+        default="prompt",
     ),
     "editor_shown": FieldSpec(
         key="editor_shown",
@@ -723,10 +729,26 @@ class ConfigManager:
 
         return self.get_value("agent_history_sash", default=default)
 
+    def get_agent_confirm_mode(self) -> str:
+        """Return persisted confirmation preference for agent operations."""
+
+        value = str(self.get_value("agent_confirm_mode", default="prompt"))
+        if value not in {"prompt", "never"}:
+            return "prompt"
+        return value
+
     def set_agent_history_sash(self, pos: int) -> None:
         """Persist width of the chat history list."""
 
         self.set_value("agent_history_sash", pos)
+        self.flush()
+
+    def set_agent_confirm_mode(self, mode: str) -> None:
+        """Persist confirmation preference for agent operations."""
+
+        if mode not in {"prompt", "never"}:
+            mode = "prompt"
+        self.set_value("agent_confirm_mode", mode)
         self.flush()
 
     # ------------------------------------------------------------------

--- a/app/confirm.py
+++ b/app/confirm.py
@@ -338,7 +338,7 @@ def wx_confirm_requirement_update(
         always_btn = wx.Button(
             dialog,
             wx.ID_APPLY,
-            label=_("Always for this session (all requirements)"),
+            label=_("Always until restart (all requirements)"),
         )
         no_btn.SetDefault()
         no_btn.SetFocus()

--- a/app/locale/en/LC_MESSAGES/CookaReq.po
+++ b/app/locale/en/LC_MESSAGES/CookaReq.po
@@ -568,8 +568,8 @@ msgstr "{index}. {op} ({details})"
 msgid "Confirm requirement update"
 msgstr "Confirm requirement update"
 
-msgid "Always for this session (all requirements)"
-msgstr "Always for this session (all requirements)"
+msgid "Always until restart (all requirements)"
+msgstr "Always until restart (all requirements)"
 
 msgid "Verifies"
 msgstr "Verifies"
@@ -1511,3 +1511,15 @@ msgstr "not recorded"
 
 msgid "this chat"
 msgstr "this chat"
+
+msgid "Ask every time"
+msgstr "Ask every time"
+
+msgid "Skip for this chat"
+msgstr "Skip for this chat"
+
+msgid "Never ask"
+msgstr "Never ask"
+
+msgid "Requirement confirmations"
+msgstr "Requirement confirmations"

--- a/app/locale/ru/LC_MESSAGES/CookaReq.po
+++ b/app/locale/ru/LC_MESSAGES/CookaReq.po
@@ -576,8 +576,8 @@ msgstr "{index}. {op} ({details})"
 msgid "Confirm requirement update"
 msgstr "Подтвердите обновление требования"
 
-msgid "Always for this session (all requirements)"
-msgstr "Всегда для этой сессии для всех требований"
+msgid "Always until restart (all requirements)"
+msgstr "Всегда до перезапуска (для всех требований)"
 
 msgid "Verifies"
 msgstr "Проверяет"
@@ -1527,3 +1527,15 @@ msgstr "не записано"
 
 msgid "this chat"
 msgstr "этот чат"
+
+msgid "Ask every time"
+msgstr "Запрашивать каждый раз"
+
+msgid "Skip for this chat"
+msgstr "Не запрашивать для этого чата"
+
+msgid "Never ask"
+msgstr "Не запрашивать никогда"
+
+msgid "Requirement confirmations"
+msgstr "Подтверждения требований"

--- a/app/ui/main_frame/agent.py
+++ b/app/ui/main_frame/agent.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Callable
 
 import wx
 
 from ...agent import LocalAgent
+from ...confirm import ConfirmDecision, RequirementUpdatePrompt
 from ...settings import AppSettings
 
 if TYPE_CHECKING:  # pragma: no cover - import for type checking only
@@ -16,13 +17,26 @@ if TYPE_CHECKING:  # pragma: no cover - import for type checking only
 class MainFrameAgentMixin:
     """Provide agent chat integration and shortcuts."""
 
-    def _create_agent(self: "MainFrame") -> LocalAgent:
+    def _create_agent(
+        self: "MainFrame",
+        *,
+        confirm_override: Callable[[str], bool] | None = None,
+        confirm_requirement_update_override: Callable[
+            [RequirementUpdatePrompt], ConfirmDecision
+        ]
+        | None = None,
+    ) -> LocalAgent:
         """Construct ``LocalAgent`` using current settings."""
 
         from . import confirm
 
         settings = AppSettings(llm=self.llm_settings, mcp=self.mcp_settings)
-        return LocalAgent(settings=settings, confirm=confirm)
+        confirm_callback = confirm_override or confirm
+        return LocalAgent(
+            settings=settings,
+            confirm=confirm_callback,
+            confirm_requirement_update=confirm_requirement_update_override,
+        )
 
     def _selected_requirement_ids_for_agent(self: "MainFrame") -> list[int]:
         ids: list[int] = []

--- a/app/ui/main_frame/frame.py
+++ b/app/ui/main_frame/frame.py
@@ -233,6 +233,8 @@ class MainFrame(
                 token_model_resolver=lambda: self.llm_settings.model,
                 context_provider=self._agent_context_messages,
                 context_window_resolver=lambda: self.llm_settings.max_context_tokens,
+                confirm_preference=self.config.get_agent_confirm_mode(),
+                persist_confirm_preference=self.config.set_agent_confirm_mode,
             ),
         )
         self._hide_agent_section()
@@ -320,6 +322,8 @@ class MainFrame(
                 token_model_resolver=lambda: self.llm_settings.model,
                 context_provider=self._agent_context_messages,
                 context_window_resolver=lambda: self.llm_settings.max_context_tokens,
+                confirm_preference=self.config.get_agent_confirm_mode(),
+                persist_confirm_preference=self.config.set_agent_confirm_mode,
             )
             history_sash = self.config.get_agent_history_sash(
                 self.agent_panel.default_history_sash()


### PR DESCRIPTION
## Summary
- add a confirmation preference manager to the agent chat panel with a new dropdown to pick per-chat or global behaviour
- persist the global choice in the configuration and update the MCP confirmation wiring to honour overrides
- refresh localisation strings, including the requirement update dialog label, and cover the new logic with a GUI test

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d1bce909cc8320807cef92d6b8b447