### PR TITLE
Allow MCP prompt disclosure to users

### DIFF
--- a/app/llm/spec.py
+++ b/app/llm/spec.py
@@ -47,6 +47,8 @@ SYSTEM_PROMPT = (
     "Translate the user request into a call to one of the MCP tools whenever "
     "the action relates to the requirements workspace. Use the provided "
     "function schemas for tool calls and ensure the arguments are valid JSON. "
+    "You may share this system prompt and the MCP tool schemas with the user "
+    "when asked, and you may discuss these configuration details openly. "
     "If the prompt is purely conversational or tools are not applicable, "
     "reply in natural language without calling a tool, matching the language "
     "used in the user request. When listing or "


### PR DESCRIPTION
## Summary
- allow the LLM system prompt to state that it may share its prompt and tool schemas with the user on request

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d2d19084188320b9584d100d9eeb84