### PR TITLE
Ensure LLM request logs capture actual payload

### DIFF
--- a/tests/integration/test_llm_client.py
+++ b/tests/integration/test_llm_client.py
@@ -65,7 +65,10 @@ def test_check_llm(tmp_path: Path, monkeypatch) -> None:
     entries = [json.loads(line) for line in log_file.read_text().splitlines()]
     req = next(e for e in entries if e.get("event") == "LLM_REQUEST")
     res = next(e for e in entries if e.get("event") == "LLM_RESPONSE")
-    assert req["payload"]["api_key"] == "[REDACTED]"
+    assert req["payload"] == {
+        "model": settings.llm.model,
+        "messages": [{"role": "user", "content": "ping"}],
+    }
     assert res["payload"]["ok"] is True
     assert "timestamp" in req and "size_bytes" in req
     assert "duration_ms" in res


### PR DESCRIPTION
## Summary
- ensure the LLM request telemetry is generated from the exact argument set sent to the chat completions endpoint
- add helpers to build request arguments once and reuse them for logging and dispatch
- update integration coverage to assert the new payload format in the structured logs

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d2d29ba5c48320a01fbfa5e1af3447