### PR TITLE
Fix chat bubble alignment flags

### DIFF
--- a/app/ui/widgets/chat_message.py
+++ b/app/ui/widgets/chat_message.py
@@ -279,9 +279,9 @@ class MessageBubble(wx.Panel):
         alignment_row = wx.BoxSizer(wx.HORIZONTAL)
         if align == "right":
             alignment_row.AddStretchSpacer()
-            alignment_row.Add(bubble, 0, wx.ALIGN_RIGHT)
+            alignment_row.Add(bubble, 0)
         else:
-            alignment_row.Add(bubble, 0, wx.ALIGN_LEFT)
+            alignment_row.Add(bubble, 0)
             alignment_row.AddStretchSpacer()
         outer.Add(alignment_row, 1, wx.EXPAND)
 


### PR DESCRIPTION
## Summary
- remove horizontal alignment flags from chat message bubble sizer to avoid wx assertion

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d3b99f3c4c8320bd9758c42353e92e