### PR TITLE
Unify requirement column width metadata

### DIFF
--- a/app/columns.py
+++ b/app/columns.py
@@ -1,0 +1,91 @@
+"""Shared column metadata reused by GUI and configuration."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import fields
+from types import MappingProxyType
+
+from .core.model import Requirement
+
+# Columns exposed via the View → Columns menu and persisted in UI settings.
+# ``title`` is always shown and therefore excluded from the toggleable list.
+_BASE_EXCLUDES = {"title", "labels"}
+_EXTRA_COLUMNS = ("labels", "derived_from", "derived_count")
+
+
+def _build_available_columns() -> list[str]:
+    names = [
+        field.name for field in fields(Requirement) if field.name not in _BASE_EXCLUDES
+    ]
+    for extra in _EXTRA_COLUMNS:
+        if extra not in names:
+            names.append(extra)
+    return names
+
+
+AVAILABLE_COLUMNS: tuple[str, ...] = tuple(_build_available_columns())
+_AVAILABLE_COLUMN_SET = set(AVAILABLE_COLUMNS)
+
+DEFAULT_LIST_COLUMNS: tuple[str, ...] = tuple(
+    name
+    for name in (
+        "labels",
+        "id",
+        "derived_from",
+        "status",
+        "priority",
+        "type",
+        "owner",
+    )
+    if name in _AVAILABLE_COLUMN_SET
+)
+
+
+DEFAULT_COLUMN_WIDTH = 160
+_DEFAULT_COLUMN_WIDTHS: dict[str, int] = {
+    "title": 340,
+    "labels": 200,
+    "id": 90,
+    "status": 140,
+    "priority": 130,
+    "type": 150,
+    "owner": 180,
+    "doc_prefix": 140,
+    "rid": 150,
+    "derived_count": 120,
+    "derived_from": 260,
+    "modified_at": 180,
+}
+DEFAULT_COLUMN_WIDTHS = MappingProxyType(_DEFAULT_COLUMN_WIDTHS)
+
+
+def available_columns() -> list[str]:
+    """Return toggleable columns for requirement lists."""
+
+    return list(AVAILABLE_COLUMNS)
+
+
+def sanitize_columns(columns: Sequence[str]) -> list[str]:
+    """Filter ``columns`` to valid, unique entries preserving order."""
+
+    seen: set[str] = set()
+    sanitized: list[str] = []
+    for name in columns:
+        if name in _AVAILABLE_COLUMN_SET and name not in seen:
+            sanitized.append(name)
+            seen.add(name)
+    return sanitized
+
+
+def default_column_width(field: str) -> int:
+    """Return a sensible default width for ``field`` in requirement lists."""
+
+    width = _DEFAULT_COLUMN_WIDTHS.get(field)
+    if width is not None:
+        return width
+    if field.endswith("_at"):
+        return 180
+    if field in {"revision", "id", "doc_prefix", "derived_count"}:
+        return 90
+    return DEFAULT_COLUMN_WIDTH

--- a/app/config.py
+++ b/app/config.py
@@ -13,6 +13,7 @@ from typing import Any, ClassVar, Literal, Protocol
 
 import wx
 
+from .columns import sanitize_columns
 from .settings import AppSettings, LLMSettings, MCPSettings, UISettings
 
 
@@ -245,10 +246,10 @@ class ConfigManager:
         self._raw["col_order"] = [str(field) for field in fields]
 
     def get_columns(self) -> list[str]:
-        return list(self.get_value("list_columns"))
+        return sanitize_columns(self.get_value("list_columns"))
 
     def set_columns(self, fields: list[str]) -> None:
-        self.set_value("list_columns", list(fields))
+        self.set_value("list_columns", sanitize_columns(fields))
         self.flush()
 
     # ------------------------------------------------------------------

--- a/app/settings.py
+++ b/app/settings.py
@@ -10,23 +10,13 @@ from typing import Literal
 import tomllib
 from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator
 
+from .columns import DEFAULT_LIST_COLUMNS as BASE_DEFAULT_LIST_COLUMNS
 from .llm.constants import (
     DEFAULT_LLM_BASE_URL,
     DEFAULT_LLM_MODEL,
     DEFAULT_MAX_CONTEXT_TOKENS,
     MIN_MAX_CONTEXT_TOKENS,
 )
-
-
-DEFAULT_LIST_COLUMNS: list[str] = [
-    "labels",
-    "id",
-    "derived_from",
-    "status",
-    "priority",
-    "type",
-    "owner",
-]
 
 
 class LLMSettings(BaseModel):
@@ -114,6 +104,9 @@ class MCPSettings(BaseModel):
             return None
         text = str(value).strip()
         return text or None
+
+
+DEFAULT_LIST_COLUMNS = list(BASE_DEFAULT_LIST_COLUMNS)
 
 
 class UISettings(BaseModel):

--- a/app/ui/list_panel.py
+++ b/app/ui/list_panel.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING
 import wx
 from wx.lib.mixins.listctrl import ColumnSorterMixin
 
+from .. import columns
 from ..core.document_store import LabelDef, label_color, load_item, parse_rid, stable_color
 from ..core.model import Requirement
 from ..i18n import _
@@ -33,21 +34,6 @@ class ListPanel(wx.Panel, ColumnSorterMixin):
 
     MIN_COL_WIDTH = 50
     MAX_COL_WIDTH = 1000
-    DEFAULT_COLUMN_WIDTH = 160
-    DEFAULT_COLUMN_WIDTHS: dict[str, int] = {
-        "title": 340,
-        "labels": 200,
-        "id": 90,
-        "status": 140,
-        "priority": 130,
-        "type": 150,
-        "owner": 180,
-        "doc_prefix": 140,
-        "rid": 150,
-        "derived_count": 120,
-        "derived_from": 260,
-        "modified_at": 180,
-    }
 
     def __init__(
         self,
@@ -426,14 +412,7 @@ class ListPanel(wx.Panel, ColumnSorterMixin):
     def _default_column_width(self, field: str) -> int:
         """Return sensible default width for a given column field."""
 
-        width = self.DEFAULT_COLUMN_WIDTHS.get(field)
-        if width is not None:
-            return width
-        if field.endswith("_at"):
-            return 180
-        if field in {"revision", "id", "doc_prefix", "derived_count"}:
-            return 90
-        return self.DEFAULT_COLUMN_WIDTH
+        return columns.default_column_width(field)
 
     def load_column_order(self, config: ConfigManager) -> None:
         """Restore column ordering from config."""

--- a/app/ui/main_frame/frame.py
+++ b/app/ui/main_frame/frame.py
@@ -3,15 +3,14 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from dataclasses import fields
 from importlib import resources
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 import wx
 
+from ...columns import available_columns
 from ...config import ConfigManager
-from ...core.model import Requirement
 from ...i18n import _
 from ...mcp.controller import MCPController
 from ..requirement_model import RequirementModel
@@ -59,11 +58,7 @@ class MainFrame(
         self._base_title = "CookaReq"
         self.config = config if config is not None else ConfigManager()
         self.model = model if model is not None else RequirementModel()
-        self.available_fields = [
-            f.name for f in fields(Requirement) if f.name not in {"title", "labels"}
-        ]
-        self.available_fields.append("labels")
-        self.available_fields.append("derived_count")
+        self.available_fields = available_columns()
         self.selected_fields = self.config.get_columns()
         self.auto_open_last = self.config.get_auto_open_last()
         self.remember_sort = self.config.get_remember_sort()

--- a/tests/gui/test_gui.py
+++ b/tests/gui/test_gui.py
@@ -29,6 +29,34 @@ def test_gui_imports(wx_app, tmp_path):
     assert callable(main)
 
 
+def test_view_menu_lists_derived_from_column(wx_app, tmp_path):
+    pytest.importorskip("wx")
+    from app.config import ConfigManager
+    from app.settings import MCPSettings
+    from app.ui.main_frame import MainFrame
+
+    config = ConfigManager(path=tmp_path / "columns.ini")
+    config.set_mcp_settings(MCPSettings(auto_start=False))
+
+    frame = MainFrame(None, config=config)
+    try:
+        assert "derived_from" in frame.available_fields
+        derived_items = [
+            item_id
+            for item_id, field in frame.navigation._column_items.items()
+            if field == "derived_from"
+        ]
+        assert derived_items, "Derived from column should appear in the Columns menu"
+        for item_id in derived_items:
+            menu_item = frame.navigation.menu_bar.FindItemById(item_id)
+            assert menu_item is not None
+            assert menu_item.IsCheckable()
+            assert menu_item.IsChecked()
+    finally:
+        frame.Destroy()
+        wx_app.Yield()
+
+
 def test_log_level_persistence(wx_app, tmp_path):
     pytest.importorskip("wx")
     from app.config import ConfigManager

--- a/tests/gui/test_list_panel.py
+++ b/tests/gui/test_list_panel.py
@@ -6,6 +6,7 @@ import types
 
 import pytest
 
+from app import columns
 from app.core.document_store import Document, item_path, save_document, save_item
 from app.core.model import (
     Priority,
@@ -379,16 +380,15 @@ def test_reorder_columns(stubbed_list_panel_env):
 def test_load_column_widths_assigns_defaults(stubbed_list_panel_env):
     env = stubbed_list_panel_env
     panel = env.create_panel()
-    list_panel_cls = env.list_panel_cls
     panel.set_columns(["labels", "id", "status", "priority"])
 
     config = types.SimpleNamespace(read_int=lambda key, default: -1)
     panel.load_column_widths(config)
 
     assert panel.list._col_widths == {
-        0: list_panel_cls.DEFAULT_COLUMN_WIDTHS["labels"],
-        1: list_panel_cls.DEFAULT_COLUMN_WIDTHS["title"],
-        2: list_panel_cls.DEFAULT_COLUMN_WIDTHS["id"],
-        3: list_panel_cls.DEFAULT_COLUMN_WIDTHS["status"],
-        4: list_panel_cls.DEFAULT_COLUMN_WIDTHS["priority"],
+        0: columns.default_column_width("labels"),
+        1: columns.default_column_width("title"),
+        2: columns.default_column_width("id"),
+        3: columns.default_column_width("status"),
+        4: columns.default_column_width("priority"),
     }

--- a/tests/unit/test_config_manager.py
+++ b/tests/unit/test_config_manager.py
@@ -149,6 +149,22 @@ def test_schema_round_trip(tmp_path, wx_app, name, value_factory, expected_facto
     assert cfg.get_value(name) == expected_factory(tmp_path)
 
 
+def test_set_columns_sanitizes_invalid_and_duplicates(tmp_path, wx_app):
+    cfg = ConfigManager(app_name="TestApp", path=tmp_path / "cfg.ini")
+
+    cfg.set_columns(["id", "bogus", "derived_from", "id"])
+
+    assert cfg.get_columns() == ["id", "derived_from"]
+
+
+def test_get_columns_filters_unknown_entries(tmp_path, wx_app):
+    cfg = ConfigManager(app_name="TestApp", path=tmp_path / "cfg.ini")
+
+    cfg.set_value("list_columns", ["invalid", "labels", "id", "labels"])
+
+    assert cfg.get_columns() == ["labels", "id"]
+
+
 def test_schema_override_default(tmp_path, wx_app):
     cfg = ConfigManager(app_name="TestApp", path=tmp_path / "cfg.ini")
 


### PR DESCRIPTION
## Summary
- move the default column width table and heuristics into `app/columns.py` so GUI and configuration rely on a single source
- update `ListPanel` to call the shared helper when computing column widths
- adjust the GUI test to assert defaults via the shared helper

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68d3bb3baa04832095b880e9c89c3378