### PR TITLE
Fix user chat bubble alignment

### DIFF
--- a/app/ui/widgets/chat_message.py
+++ b/app/ui/widgets/chat_message.py
@@ -232,7 +232,7 @@ class MessageBubble(wx.Panel):
                 self._selection_checker = has_selection
                 self._selection_getter = text_ctrl.GetStringSelection
         else:
-            text_align_flag = wx.ALIGN_RIGHT if align == "right" else 0
+            text_align_flag = wx.ALIGN_LEFT
             self._text = wx.StaticText(bubble, label=display_text, style=text_align_flag)
             self._text.SetForegroundColour(bubble_fg)
             self._text.SetBackgroundColour(bubble_bg)


### PR DESCRIPTION
## Summary
- keep user message bubbles left-aligned to avoid overly compressed text rendering

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d3cf4986448320b9cfc23bb29a8bd9