### PR TITLE
Fix agent chat regenerate button state

### DIFF
--- a/app/ui/agent_chat_panel/panel.py
+++ b/app/ui/agent_chat_panel/panel.py
@@ -1395,6 +1395,8 @@ class AgentChatPanel(wx.Panel):
             else 0.0
         )
         final_tokens: TokenCountResult | None = None
+        tool_results: list[Any] | None = None
+        should_render = False
         try:
             conversation_text, display_text, raw_result, tool_results = self._process_result(result)
             if not tool_results and handle.streamed_tool_results:
@@ -1442,8 +1444,7 @@ class AgentChatPanel(wx.Panel):
                 )
             handle.pending_entry = None
             handle.streamed_tool_results.clear()
-            self._render_transcript()
-            self._notify_tool_results(tool_results)
+            should_render = True
         finally:
             self._set_wait_state(False, final_tokens)
             if elapsed:
@@ -1452,6 +1453,10 @@ class AgentChatPanel(wx.Panel):
                     time=f"{minutes:02d}:{seconds:02d}",
                 )
                 self.status_label.SetLabel(label)
+
+        if should_render:
+            self._render_transcript()
+            self._notify_tool_results(tool_results)
 
     def _process_result(
         self, result: Any


### PR DESCRIPTION
## Summary
- ensure the agent chat transcript re-renders after clearing the wait state so the Regenerate button reflects availability
- defer transcript refresh and tool result notifications until after the panel leaves the busy state

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d3e9ce57208320a7a52cedff9a4a7b