### PR TITLE
Add pastel tool call bubbles with per-tool palette

### DIFF
--- a/app/ui/agent_chat_panel/panel.py
+++ b/app/ui/agent_chat_panel/panel.py
@@ -1750,9 +1750,8 @@ class AgentChatPanel(wx.Panel):
                         if can_regenerate
                         else None
                     )
-                    tool_summary_md = render_tool_summaries_markdown(
-                        summarize_tool_results(entry.tool_results)
-                    )
+                    tool_summaries = summarize_tool_results(entry.tool_results)
+                    tool_summary_md = render_tool_summaries_markdown(tool_summaries)
                     response_text = entry.display_response or entry.response
                     if tool_summary_md:
                         base_response = (response_text or "").strip()
@@ -1768,6 +1767,7 @@ class AgentChatPanel(wx.Panel):
                         response_timestamp=self._format_entry_timestamp(entry.response_at),
                         on_regenerate=on_regenerate,
                         regenerate_enabled=not self._is_running,
+                        tool_summaries=tool_summaries,
                     )
                     panel.Bind(wx.EVT_COLLAPSIBLEPANE_CHANGED, self._on_transcript_pane_toggled)
                     self._transcript_sizer.Add(panel, 0, wx.EXPAND)

--- a/app/ui/agent_chat_panel/tool_summaries.py
+++ b/app/ui/agent_chat_panel/tool_summaries.py
@@ -53,25 +53,31 @@ def summarize_tool_payload(
     )
 
 
+def render_tool_summary_markdown(summary: ToolCallSummary) -> str:
+    base = _("Tool call {index}: {tool} — {status}")
+    heading = base.format(
+        index=summary.index,
+        tool=f"**{summary.tool_name}**",
+        status=summary.status,
+    )
+    heading = normalize_for_display(heading)
+    lines = ["> 🔧 " + heading]
+    for bullet in summary.bullet_lines:
+        if bullet:
+            lines.append("> • " + normalize_for_display(bullet))
+    return "\n".join(lines)
+
+
 def render_tool_summaries_markdown(
     summaries: Sequence[ToolCallSummary],
 ) -> str:
     if not summaries:
         return ""
-    base = _("Tool call {index}: {tool} — {status}")
     blocks: list[str] = []
     for summary in summaries:
-        heading = base.format(
-            index=summary.index,
-            tool=f"**{summary.tool_name}**",
-            status=summary.status,
-        )
-        heading = normalize_for_display(heading)
-        lines = ["> 🔧 " + heading]
-        for bullet in summary.bullet_lines:
-            if bullet:
-                lines.append("> • " + normalize_for_display(bullet))
-        blocks.append("\n".join(lines))
+        block = render_tool_summary_markdown(summary)
+        if block:
+            blocks.append(block)
     return "\n\n".join(blocks)
 
 
@@ -629,6 +635,7 @@ __all__ = [
     "ToolCallSummary",
     "summarize_tool_results",
     "summarize_tool_payload",
+    "render_tool_summary_markdown",
     "render_tool_summaries_markdown",
     "render_tool_summaries_plain",
     "extract_error_message",


### PR DESCRIPTION
## Summary
- render MCP tool summaries as dedicated message bubbles using a deterministic pastel palette per tool name
- reuse markdown formatting via a new helper so tool call blocks can be shared between transcript text and UI
- keep transcript text unchanged while visually distinguishing tool calls from regular agent replies

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d42bbd942c8320af9704f9672db9db