### PR TITLE
Add diagnostics for ignored agent tool results

### DIFF
--- a/app/ui/main_frame/documents.py
+++ b/app/ui/main_frame/documents.py
@@ -105,29 +105,40 @@ class MainFrameDocumentsMixin:
             return str(path)
 
     def _sync_mcp_base_path(self: "MainFrame", path: Path) -> None:
-        """Persist MCP base path and restart server when needed."""
+        """Persist MCP base path and keep the running server in sync."""
 
         new_base_path = self._normalise_directory_path(path)
         if self.mcp_settings.base_path == new_base_path:
             return
+
+        was_running = False
+        try:
+            was_running = bool(self.mcp.is_running())
+        except Exception:  # pragma: no cover - controller must not crash UI
+            logger.exception("Failed to query MCP server status before restart")
+
         auto_start = self.mcp_settings.auto_start
         self.mcp_settings = self.mcp_settings.model_copy(
             update={"base_path": new_base_path}
         )
         self.config.set_mcp_settings(self.mcp_settings)
-        if auto_start:
-            try:
-                self.mcp.stop()
-            except Exception:  # pragma: no cover - controller must not crash UI
-                logger.exception(
-                    "Failed to stop MCP server before applying new base path"
-                )
-            try:
-                self.mcp.start(self.mcp_settings)
-            except Exception:  # pragma: no cover - controller must not crash UI
-                logger.exception(
-                    "Failed to start MCP server after applying new base path"
-                )
+
+        if not (auto_start or was_running):
+            return
+
+        try:
+            self.mcp.stop()
+        except Exception:  # pragma: no cover - controller must not crash UI
+            logger.exception(
+                "Failed to stop MCP server before applying new base path"
+            )
+
+        try:
+            self.mcp.start(self.mcp_settings)
+        except Exception:  # pragma: no cover - controller must not crash UI
+            logger.exception(
+                "Failed to start MCP server after applying new base path"
+            )
 
     def _load_directory(self: "MainFrame", path: Path) -> None:
         """Load requirements from ``path`` and update recent list."""

--- a/tests/unit/document_store/test_items_module.py
+++ b/tests/unit/document_store/test_items_module.py
@@ -102,6 +102,29 @@ def test_create_update_and_delete_requirement(
     assert not item_path(tmp_path / "SYS", _document, 1).exists()
 
 
+def test_update_accepts_mixed_case_rid(tmp_path: Path, _document: Document) -> None:
+    docs = load_documents(tmp_path)
+
+    created = create_requirement(
+        tmp_path,
+        prefix="SYS",
+        data=_base_payload(),
+        docs=docs,
+    )
+
+    updated = update_requirement_field(
+        tmp_path,
+        created.rid.lower(),
+        field="status",
+        value="approved",
+        docs=docs,
+    )
+
+    assert updated.rid == created.rid
+    assert updated.status.value == "approved"
+    assert updated.revision == created.revision + 1
+
+
 def test_update_requirement_field_rejects_unknown_status(
     tmp_path: Path, _document: Document
 ) -> None:

--- a/tests/unit/document_store/test_links_module.py
+++ b/tests/unit/document_store/test_links_module.py
@@ -95,6 +95,29 @@ def test_validate_and_link(tmp_path: Path) -> None:
         )
 
 
+def test_link_accepts_mixed_case_rids(tmp_path: Path) -> None:
+    sys_doc = Document(prefix="SYS", title="System")
+    hlr_doc = Document(prefix="HLR", title="High", parent="SYS")
+    save_document(tmp_path / "SYS", sys_doc)
+    save_document(tmp_path / "HLR", hlr_doc)
+
+    save_item(tmp_path / "SYS", sys_doc, requirement_to_dict(_requirement(1)))
+    save_item(tmp_path / "HLR", hlr_doc, requirement_to_dict(_requirement(2)))
+
+    docs = load_documents(tmp_path)
+
+    linked = link_requirements(
+        tmp_path,
+        source_rid="sys1",
+        derived_rid="hlr2",
+        link_type="parent",
+        docs=docs,
+    )
+
+    assert linked.links and linked.links[0].rid == "SYS1"
+    assert linked.rid == "HLR2"
+
+
 def test_link_becomes_suspect_after_parent_change(tmp_path: Path) -> None:
     sys_doc = Document(prefix="SYS", title="System")
     hlr_doc = Document(prefix="HLR", title="High", parent="SYS")

--- a/tests/unit/test_agent_tool_result_logging.py
+++ b/tests/unit/test_agent_tool_result_logging.py
@@ -1,0 +1,76 @@
+import logging
+from types import SimpleNamespace
+
+import pytest
+
+from app.ui.main_frame.agent import MainFrameAgentMixin
+
+
+class _StubPanel:
+    def recalc_derived_map(self, _items):
+        return None
+
+    def focus_requirement(self, _req_id: int) -> None:  # pragma: no cover - noop
+        return None
+
+
+class _StubFrame(MainFrameAgentMixin):
+    def __init__(self) -> None:
+        self.current_doc_prefix = "SYS"
+        self.model = SimpleNamespace(get_all=lambda: [])
+        self.panel = _StubPanel()
+        self.editor = SimpleNamespace(load=lambda *_args, **_kwargs: None)
+        self._selected_requirement_id = None
+
+
+@pytest.fixture()
+def caplog_agent(caplog: pytest.LogCaptureFixture) -> pytest.LogCaptureFixture:
+    caplog.set_level(logging.WARNING, logger="cookareq.ui.main_frame.agent")
+    return caplog
+
+
+def test_logs_non_mapping_tool_payload(caplog_agent: pytest.LogCaptureFixture) -> None:
+    frame = _StubFrame()
+
+    frame._on_agent_tool_results(["unexpected"])
+
+    assert any(
+        "not a mapping" in record.getMessage() for record in caplog_agent.records
+    )
+
+
+def test_logs_failed_tool_payload(caplog_agent: pytest.LogCaptureFixture) -> None:
+    frame = _StubFrame()
+
+    frame._on_agent_tool_results(
+        [
+            {
+                "ok": False,
+                "tool_name": "update_requirement_field",
+                "error": {"code": "VALIDATION_ERROR"},
+            }
+        ]
+    )
+
+    assert any(
+        "reported failure" in record.getMessage() for record in caplog_agent.records
+    )
+
+
+def test_logs_missing_requirement_id(caplog_agent: pytest.LogCaptureFixture) -> None:
+    frame = _StubFrame()
+
+    frame._on_agent_tool_results(
+        [
+            {
+                "ok": True,
+                "tool_name": "update_requirement_field",
+                "result": {"title": "Example"},
+            }
+        ]
+    )
+
+    assert any(
+        "missing requirement id" in record.getMessage()
+        for record in caplog_agent.records
+    )

--- a/tests/unit/test_main_frame_documents.py
+++ b/tests/unit/test_main_frame_documents.py
@@ -1,0 +1,75 @@
+from pathlib import Path
+
+from app.settings import MCPSettings
+from app.ui.main_frame.documents import MainFrameDocumentsMixin
+
+
+class _StubConfig:
+    def __init__(self) -> None:
+        self.updated_settings: MCPSettings | None = None
+
+    def set_mcp_settings(self, settings: MCPSettings) -> None:
+        self.updated_settings = settings
+
+
+class _StubMCPController:
+    def __init__(self, running: bool = False) -> None:
+        self._running = running
+        self.stop_calls = 0
+        self.start_calls = 0
+        self.started_with: MCPSettings | None = None
+
+    def is_running(self) -> bool:
+        return self._running
+
+    def stop(self) -> None:
+        self.stop_calls += 1
+        self._running = False
+
+    def start(self, settings: MCPSettings) -> None:
+        self.start_calls += 1
+        self.started_with = settings
+        self._running = True
+
+
+class _StubFrame(MainFrameDocumentsMixin):
+    def __init__(self, *, running: bool, auto_start: bool, base_path: Path) -> None:
+        self.config = _StubConfig()
+        self.mcp_settings = MCPSettings(
+            auto_start=auto_start,
+            base_path=str(base_path),
+        )
+        self.mcp = _StubMCPController(running=running)
+
+
+def test_sync_mcp_base_path_restarts_running_server_when_auto_start_disabled(tmp_path):
+    original = tmp_path / "old"
+    new_path = tmp_path / "new"
+    original.mkdir()
+    new_path.mkdir()
+
+    frame = _StubFrame(running=True, auto_start=False, base_path=original)
+
+    frame._sync_mcp_base_path(new_path)
+
+    assert frame.mcp.stop_calls == 1
+    assert frame.mcp.start_calls == 1
+    assert frame.mcp.started_with is frame.mcp_settings
+    assert frame.mcp_settings.base_path == str(new_path.resolve())
+    assert frame.config.updated_settings is frame.mcp_settings
+
+
+def test_sync_mcp_base_path_avoids_restart_when_server_idle(tmp_path):
+    original = tmp_path / "old"
+    new_path = tmp_path / "new"
+    original.mkdir()
+    new_path.mkdir()
+
+    frame = _StubFrame(running=False, auto_start=False, base_path=original)
+
+    frame._sync_mcp_base_path(new_path)
+
+    assert frame.mcp.stop_calls == 0
+    assert frame.mcp.start_calls == 0
+    assert frame.mcp_settings.base_path == str(new_path.resolve())
+    assert frame.config.updated_settings is frame.mcp_settings


### PR DESCRIPTION
## Summary
- log warnings when agent tool payloads are dropped because they are malformed or report a failure
- add a helper to shorten payload representations before logging to keep messages readable
- cover the new logging paths with unit tests for the agent tool result handler

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d42f0600588320926a3eff9a6c68ca