### PR TITLE
Stream MCP tool progress updates to agent UI

### DIFF
--- a/app/ui/agent_chat_panel/tool_summaries.py
+++ b/app/ui/agent_chat_panel/tool_summaries.py
@@ -114,6 +114,15 @@ def extract_tool_name(payload: Mapping[str, Any]) -> str:
 
 
 def format_tool_status(payload: Mapping[str, Any]) -> str:
+    agent_status = payload.get("agent_status")
+    if isinstance(agent_status, str):
+        normalized = agent_status.strip().lower()
+        if normalized == "running":
+            return normalize_for_display(_("in progress…"))
+        if normalized == "completed" and payload.get("ok") not in (True, False):
+            return normalize_for_display(_("completed"))
+        if normalized == "failed" and payload.get("ok") not in (True, False):
+            return normalize_for_display(_("failed"))
     ok_value = payload.get("ok")
     if ok_value is True:
         return normalize_for_display(_("completed successfully"))

--- a/tests/integration/test_local_agent.py
+++ b/tests/integration/test_local_agent.py
@@ -620,8 +620,24 @@ def test_run_command_streams_tool_results_to_callback():
 
     assert result["ok"] is True
     assert result["result"] == "All done"
-    assert len(collected) == 2
-    assert [payload["tool_name"] for payload in collected] == [
+    assert len(collected) == 4
+    running_updates = [
+        payload for payload in collected if payload.get("agent_status") == "running"
+    ]
+    assert [payload["tool_name"] for payload in running_updates] == [
+        "list_requirements",
+        "get_requirement",
+    ]
+    completed_updates = [
+        payload
+        for payload in collected
+        if payload.get("agent_status") and payload.get("agent_status") != "running"
+    ]
+    assert [payload.get("agent_status") for payload in completed_updates] == [
+        "completed",
+        "completed",
+    ]
+    assert [payload["tool_name"] for payload in completed_updates] == [
         "list_requirements",
         "get_requirement",
     ]
@@ -630,7 +646,10 @@ def test_run_command_streams_tool_results_to_callback():
     assert [
         payload["tool_name"] for payload in result["tool_results"]
     ] == ["list_requirements", "get_requirement"]
-    for streamed, final in zip(collected, result["tool_results"]):
+    assert [
+        payload.get("agent_status") for payload in result["tool_results"]
+    ] == ["completed", "completed"]
+    for streamed, final in zip(completed_updates, result["tool_results"]):
         assert streamed == final
         assert streamed is not final
 


### PR DESCRIPTION
## Summary
- emit a running-status update before each MCP tool call and tag final payloads with completion state
- merge streamed tool payloads in the agent chat panel so the transcript refreshes while tools are still executing
- surface the new status text in tool summaries and extend GUI/integration tests for the streaming lifecycle

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d4c73496888320ba287e81ae15b1de