### PR TITLE
Improve transcript log direction annotations

### DIFF
--- a/tests/gui/test_agent_chat_panel.py
+++ b/tests/gui/test_agent_chat_panel.py
@@ -703,7 +703,7 @@ def test_agent_transcript_log_includes_planned_tool_calls(tmp_path, wx_app):
 
     try:
         log_text = panel.get_transcript_log_text()
-        assert "LLM planned tool calls:" in log_text
+        assert "LLM → Agent planned tool calls:" in log_text
         assert "create_requirement" in log_text
         assert "\"prefix\": \"SYS\"" in log_text
     finally:


### PR DESCRIPTION
## Summary
- restructure the transcript log to annotate each LLM request step with sender direction labels
- add explicit formatting for planned tool calls so the log shows them as LLM outputs
- update GUI tests to match the new transcript log phrasing

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d4df1d2ea88320af8e1f6f15fad40c