### PR TITLE
Adjust agent tool call bubble headers

### DIFF
--- a/app/locale/en/LC_MESSAGES/CookaReq.po
+++ b/app/locale/en/LC_MESSAGES/CookaReq.po
@@ -1470,8 +1470,8 @@ msgstr "Today {time}"
 msgid "Tokens: {count}"
 msgstr "Tokens: {count}"
 
-msgid "  Tool call {index}: {name} — Status: {status}"
-msgstr "  Tool call {index}: {name} — Status: {status}"
+msgid "  Agent: tool call {index}: {name} — Status: {status}"
+msgstr "  Agent: tool call {index}: {name} — Status: {status}"
 
 msgid "    LLM tool call ID: {value}"
 msgstr "    LLM tool call ID: {value}"
@@ -1487,6 +1487,9 @@ msgstr "    MCP → Agent error payload:"
 
 msgid "    Additional fields:"
 msgstr "    Additional fields:"
+
+msgid "Requirement: {rid}"
+msgstr "Requirement: {rid}"
 
 msgid "Unknown"
 msgstr "Unknown"

--- a/app/locale/ru/LC_MESSAGES/CookaReq.po
+++ b/app/locale/ru/LC_MESSAGES/CookaReq.po
@@ -1486,8 +1486,8 @@ msgstr "Сегодня {time}"
 msgid "Tokens: {count}"
 msgstr "Токенов: {count}"
 
-msgid "  Tool call {index}: {name} — Status: {status}"
-msgstr "  Вызов инструмента {index}: {name} — Статус: {status}"
+msgid "  Agent: tool call {index}: {name} — Status: {status}"
+msgstr "  Агент: вызов инструмента {index}: {name} — Статус: {status}"
 
 msgid "    LLM tool call ID: {value}"
 msgstr "    Идентификатор вызова инструмента LLM: {value}"
@@ -1503,6 +1503,9 @@ msgstr "    MCP → Агент: ошибка"
 
 msgid "    Additional fields:"
 msgstr "    Дополнительные поля:"
+
+msgid "Requirement: {rid}"
+msgstr "Требование: {rid}"
 
 msgid "Unknown"
 msgstr "Неизвестно"

--- a/tests/gui/test_agent_chat_panel.py
+++ b/tests/gui/test_agent_chat_panel.py
@@ -542,7 +542,7 @@ def test_agent_chat_panel_hides_tool_results_and_exposes_log(tmp_path, wx_app):
 
         transcript_text = panel.get_transcript_text()
         assert "demo_tool" in transcript_text
-        assert "Tool call" in transcript_text
+        assert "Agent: tool call" in transcript_text
         assert "tool_results" not in transcript_text
         assert "Query: `inspect`" in transcript_text
 
@@ -908,7 +908,7 @@ def test_agent_chat_panel_streams_tool_results(tmp_path, wx_app):
         flush_wx_events(wx, count=6)
 
         transcript = panel.get_transcript_text()
-        assert "Tool call" in transcript
+        assert "Agent: tool call" in transcript
         assert "update_requirement_field" in transcript
         assert _("in progress…") in transcript
         assert panel._is_running


### PR DESCRIPTION
## Summary
- prefix agent tool call summaries with an "Agent: tool call" heading and avoid repeating requirement IDs in the bullet list
- update locale resources to translate the new heading and requirement label consistently
- refresh GUI tests to assert the new heading text

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d4e4c7da688320845c522001cabe3a