### PR TITLE
Preserve chat history when cancelling agent run

### DIFF
--- a/tests/gui/test_agent_chat_panel.py
+++ b/tests/gui/test_agent_chat_panel.py
@@ -880,7 +880,13 @@ def test_agent_chat_panel_stop_cancels_generation(tmp_path, wx_app):
         assert agent.completed.wait(1.0)
         wx.Yield()
 
-        assert panel.history == []
+        history = panel.history
+        assert len(history) == 1
+        entry = history[0]
+        assert entry.prompt == "stop me"
+        assert entry.display_response == _("Generation cancelled")
+        assert entry.response == ""
+        assert entry.response_at is not None
     finally:
         if frame is not None and panel is not None:
             destroy_panel(frame, panel)


### PR DESCRIPTION
## Summary
- keep the pending chat entry when the agent run is cancelled so the conversation remains visible
- record cancellation metadata, including any streamed tool results, when finalising the pending entry
- extend the stop button GUI test to cover the preserved transcript state after cancellation

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d5198dfeb883209cc45e5316abc9c3