### PR TITLE
Show collapsible context banner in agent chat

### DIFF
--- a/app/ui/agent_chat_panel/panel.py
+++ b/app/ui/agent_chat_panel/panel.py
@@ -1874,6 +1874,7 @@ class AgentChatPanel(wx.Panel):
                         on_regenerate=on_regenerate,
                         regenerate_enabled=not self._is_running,
                         tool_summaries=tool_summaries,
+                        context_messages=entry.context_messages,
                     )
                     panel.Bind(wx.EVT_COLLAPSIBLEPANE_CHANGED, self._on_transcript_pane_toggled)
                     self._transcript_sizer.Add(panel, 0, wx.EXPAND)


### PR DESCRIPTION
## Summary
- render a collapsible Context banner at the top of user chat bubbles when environment messages are present
- pass stored context messages into the transcript renderer so the banner reflects the current run
- cover the new behaviour with a GUI test that inspects the collapsible pane contents

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68d54dff17b48320820a6cd4bb8300f6