### PR TITLE
Rename Agent settings button to Agent instructions

### DIFF
--- a/app/locale/en/LC_MESSAGES/CookaReq.po
+++ b/app/locale/en/LC_MESSAGES/CookaReq.po
@@ -28,6 +28,9 @@ msgstr "Check tools"
 msgid "not checked"
 msgstr "not checked"
 
+msgid "Agent instructions"
+msgstr "Agent instructions"
+
 msgid "ok"
 msgstr "ok"
 

--- a/app/locale/ru/LC_MESSAGES/CookaReq.po
+++ b/app/locale/ru/LC_MESSAGES/CookaReq.po
@@ -29,6 +29,9 @@ msgstr "Проверить инструменты"
 msgid "not checked"
 msgstr "не проверено"
 
+msgid "Agent instructions"
+msgstr "Инструкции агента"
+
 msgid "ok"
 msgstr "OK"
 

--- a/app/ui/agent_chat_panel/panel.py
+++ b/app/ui/agent_chat_panel/panel.py
@@ -576,7 +576,7 @@ class AgentChatPanel(wx.Panel):
         self.activity.SetToolTip(STATUS_HELP_TEXT)
         self.status_label.SetToolTip(STATUS_HELP_TEXT)
 
-        settings_btn = wx.Button(bottom_panel, label=_("Agent settings"))
+        settings_btn = wx.Button(bottom_panel, label=_("Agent instructions"))
         settings_btn.Bind(wx.EVT_BUTTON, self._on_project_settings)
         self._project_settings_button = settings_btn
 

--- a/app/ui/agent_chat_panel/settings_dialog.py
+++ b/app/ui/agent_chat_panel/settings_dialog.py
@@ -1,4 +1,4 @@
-"""Dialog for editing project-scoped agent settings."""
+"""Dialog for editing project-scoped agent instructions."""
 
 from __future__ import annotations
 
@@ -13,7 +13,7 @@ class AgentProjectSettingsDialog(wx.Dialog):
     """Modal dialog exposing project-specific agent options."""
 
     def __init__(self, parent: wx.Window, *, settings: AgentProjectSettings) -> None:
-        super().__init__(parent, title=_("Agent settings"))
+        super().__init__(parent, title=_("Agent instructions"))
 
         inherit_background(self, parent)
         spacing = dip(self, 6)


### PR DESCRIPTION
## Summary
- rename the agent chat panel button and dialog title to "Agent instructions"
- add English and Russian localization strings for the new label
- refresh dialog documentation to describe agent instructions instead of settings

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d54f3dbe70832090df84af38beb3ab