### PR TITLE
Handle LLM tool validation errors during agent runs

### DIFF
--- a/app/llm/client.py
+++ b/app/llm/client.py
@@ -527,6 +527,8 @@ class LLMClient:
                 exc.llm_message = llm_message_text
             if not hasattr(exc, "llm_tool_calls"):
                 exc.llm_tool_calls = tuple(normalized_tool_calls)
+            if request_snapshot and not hasattr(exc, "llm_request_messages"):
+                exc.llm_request_messages = request_snapshot
             raise
         except Exception as exc:  # pragma: no cover - network errors
             log_event(
@@ -651,6 +653,8 @@ class LLMClient:
                 exc.llm_message = llm_message_text
             if not hasattr(exc, "llm_tool_calls"):
                 exc.llm_tool_calls = tuple(normalized_tool_calls)
+            if request_snapshot and not hasattr(exc, "llm_request_messages"):
+                exc.llm_request_messages = request_snapshot
             raise
         except Exception as exc:  # pragma: no cover - network errors
             log_event(

--- a/app/ui/chat_entry.py
+++ b/app/ui/chat_entry.py
@@ -25,6 +25,7 @@ class ChatEntry:
     response_at: str | None = None
     context_messages: tuple[dict[str, Any], ...] | None = None
     diagnostic: dict[str, Any] | None = None
+    regenerated: bool = False
 
     def __post_init__(self) -> None:  # pragma: no cover - trivial
         if self.display_response is None:
@@ -99,6 +100,9 @@ class ChatEntry:
         if isinstance(diagnostic_raw, Mapping):
             diagnostic = dict(diagnostic_raw)
 
+        regenerated_raw = payload.get("regenerated")
+        regenerated = bool(regenerated_raw) if isinstance(regenerated_raw, bool) else False
+
         return cls(
             prompt=prompt,
             response=response,
@@ -111,6 +115,7 @@ class ChatEntry:
             response_at=response_at,
             context_messages=context_messages,
             diagnostic=diagnostic,
+            regenerated=regenerated,
         )
 
     def to_dict(self) -> dict[str, Any]:
@@ -132,6 +137,7 @@ class ChatEntry:
             if self.context_messages is not None
             else None,
             "diagnostic": dict(self.diagnostic) if self.diagnostic is not None else None,
+            "regenerated": self.regenerated,
         }
 
 

--- a/app/ui/widgets/chat_message.py
+++ b/app/ui/widgets/chat_message.py
@@ -660,6 +660,7 @@ class TranscriptMessagePanel(wx.Panel):
         regenerate_enabled: bool = True,
         tool_summaries: Sequence[ToolCallSummary] | None = None,
         context_messages: Sequence[Mapping[str, Any]] | None = None,
+        regenerated: bool = False,
     ) -> None:
         super().__init__(parent)
         self.SetBackgroundColour(parent.GetBackgroundColour())
@@ -667,6 +668,20 @@ class TranscriptMessagePanel(wx.Panel):
 
         outer = wx.BoxSizer(wx.VERTICAL)
         padding = self.FromDIP(4)
+
+        if regenerated:
+            notice = wx.StaticText(
+                self,
+                label=_("Previous attempt (kept after regeneration)"),
+            )
+            notice_font = notice.GetFont()
+            if notice_font.IsOk():
+                notice_font.MakeItalic()
+                notice.SetFont(notice_font)
+            notice.SetForegroundColour(
+                wx.SystemSettings.GetColour(wx.SYS_COLOUR_GRAYTEXT)
+            )
+            outer.Add(notice, 0, wx.LEFT | wx.RIGHT | wx.TOP, padding)
 
         context_panel = self._create_context_panel(context_messages)
         if context_panel is not None:


### PR DESCRIPTION
## Summary
- treat LLM tool validation failures as synthetic tool results so the agent can continue the same run and retry with corrected arguments
- emit structured tool error payloads (including attempted arguments) and update the chat conversation so downstream LLM calls see the validation feedback
- add an integration test that exercises a validation error scenario and confirms the agent retries without user intervention
- capture request snapshots even when tool validation fails so diagnostics include the failing LLM request and extend integration coverage accordingly

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d565be79b08320bd5eb7292b038b2c