### PR TITLE
Preserve agent chat bubble widths during updates

### DIFF
--- a/app/ui/agent_chat_panel/panel.py
+++ b/app/ui/agent_chat_panel/panel.py
@@ -1784,6 +1784,15 @@ class AgentChatPanel(ConfirmPreferencesMixin, HistoryPersistenceMixin, wx.Panel)
                     )
                     tool_summaries = summarize_tool_results(entry.tool_results)
                     response_text = entry.display_response or entry.response
+                    valid_hint_keys = {"user", "agent"}
+                    for summary in tool_summaries:
+                        valid_hint_keys.add(
+                            TranscriptMessagePanel.tool_layout_hint_key(summary)
+                        )
+                    hints = entry.layout_hints if isinstance(entry.layout_hints, dict) else {}
+                    entry.layout_hints = {
+                        key: value for key, value in hints.items() if key in valid_hint_keys
+                    }
                     panel = TranscriptMessagePanel(
                         self.transcript_panel,
                         prompt=entry.prompt,
@@ -1796,6 +1805,10 @@ class AgentChatPanel(ConfirmPreferencesMixin, HistoryPersistenceMixin, wx.Panel)
                         context_messages=entry.context_messages,
                         reasoning_segments=entry.reasoning,
                         regenerated=getattr(entry, "regenerated", False),
+                        layout_hints=entry.layout_hints,
+                        on_layout_hint=lambda key, width, entry=entry: entry.layout_hints.__setitem__(
+                            key, int(width)
+                        ),
                     )
                     panel.Bind(wx.EVT_COLLAPSIBLEPANE_CHANGED, self._on_transcript_pane_toggled)
                     self._transcript_sizer.Add(panel, 0, wx.EXPAND)

--- a/app/ui/chat_entry.py
+++ b/app/ui/chat_entry.py
@@ -27,6 +27,7 @@ class ChatEntry:
     reasoning: tuple[dict[str, Any], ...] | None = None
     diagnostic: dict[str, Any] | None = None
     regenerated: bool = False
+    layout_hints: dict[str, int] = field(default_factory=dict, repr=False, compare=False)
 
     def __post_init__(self) -> None:  # pragma: no cover - trivial
         if self.display_response is None:
@@ -36,6 +37,20 @@ class ChatEntry:
                 self.tokens,
                 reason="legacy_tokens",
             )
+        hints = self.layout_hints
+        if not isinstance(hints, dict):
+            self.layout_hints = {}
+        else:
+            sanitized: dict[str, int] = {}
+            for key, value in hints.items():
+                try:
+                    width = int(value)
+                except (TypeError, ValueError):
+                    continue
+                if width <= 0:
+                    continue
+                sanitized[str(key)] = width
+            self.layout_hints = sanitized
         if self.context_messages is not None and not isinstance(
             self.context_messages, tuple
         ):


### PR DESCRIPTION
## Summary
- track layout hint widths per chat entry and reuse them when rebuilding transcript panels
- extend message bubble rendering to accept width hints, preserve previous widths, and emit updates back to the conversation entry
- add GUI regression coverage ensuring transcript message panels reuse recorded widths after rerendering

## Testing
- pytest --suite gui -q tests/gui/test_agent_chat_panel.py

------
https://chatgpt.com/codex/tasks/task_e_68d64c3d22208320bb1d8889b132b08d