### PR TITLE
Fix agent loop hang on validation errors

### DIFF
--- a/app/agent/local_agent.py
+++ b/app/agent/local_agent.py
@@ -981,11 +981,12 @@ class AgentLoopRunner:
         )
         self._register_response(response)
         self._advance_step(response)
+        error_payload = exception_to_mcp_error(exc)["error"]
         return _AgentLoopStep(
             response=response,
             tool_error=tool_error,
             batch_results=[],
-            final_result=None,
+            final_result={"ok": False, "error": error_payload},
         )
 
     def _register_response(self, response: LLMResponse) -> None:


### PR DESCRIPTION
## Summary
- stop the agent loop once a ToolValidationError has been reported by converting it into a final result
- reuse the existing MCP error mapping so validation diagnostics are attached to the result

## Testing
- pytest -q tests/integration/test_local_agent.py::test_run_command_reports_llm_tool_validation_details


------
https://chatgpt.com/codex/tasks/task_e_68d654cf872883209588ecbd34d0e128