### PR TITLE
Restore MCP fixtures and improve validation recovery

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,27 @@
+"""Integration-test fixtures."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from app.mcp.server import start_server, stop_server
+from tests.mcp_utils import _wait_until_ready
+
+
+@pytest.fixture
+def mcp_server(tmp_path_factory: pytest.TempPathFactory, free_tcp_port: int) -> int:
+    """Start the MCP server on a temporary port for the duration of a test."""
+
+    port = free_tcp_port
+    base_dir: Path = tmp_path_factory.mktemp("mcp-server")
+
+    stop_server()
+    start_server(port=port, base_path=str(base_dir))
+    _wait_until_ready(port)
+
+    try:
+        yield port
+    finally:
+        stop_server()

--- a/tests/integration/test_local_agent.py
+++ b/tests/integration/test_local_agent.py
@@ -10,6 +10,7 @@ import httpx
 import openai
 import pytest
 
+import app.agent.local_agent as la
 from app.agent.local_agent import LocalAgent
 from app.llm.client import LLMClient, LLMResponse, LLMToolCall
 from app.llm.validation import ToolValidationError
@@ -631,6 +632,9 @@ def test_run_command_recovers_after_tool_validation_error():
                     "'baselined', 'retired']"
                 )
                 exc.llm_message = ""
+                exc.llm_request_messages = tuple(
+                    dict(message) for message in conversation
+                )
                 exc.llm_tool_calls = (
                     {
                         "id": "call-0",

--- a/tests/unit/test_cli_item.py
+++ b/tests/unit/test_cli_item.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import pytest
 
 from app.cli import commands
+from app.confirm import auto_confirm, set_confirm
 from app.core.document_store import (
     Document,
     DocumentLabels,
@@ -13,6 +14,15 @@ from app.core.document_store import (
     save_document,
 )
 from app.core.model import Priority, RequirementType, Status, Verification
+
+
+@pytest.fixture(autouse=True)
+def _auto_confirm_cli():
+    """Ensure CLI commands proceed without interactive confirmation by default."""
+
+    set_confirm(auto_confirm)
+    yield
+    set_confirm(auto_confirm)
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary
- add a shared mcp_server fixture for integration tests so the MCP app runs against a temporary directory
- enrich LocalAgent workspace context with live requirement snapshots and ensure validation errors keep the loop running while preserving diagnostics
- stabilise CLI tests by auto-confirming deletions and ensure validation error tests capture request snapshots

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d687ea7f408320bc5d0912c48a6721