### PR TITLE
Allow MCP requirement reader to accept RID lists

### DIFF
--- a/app/llm/spec.py
+++ b/app/llm/spec.py
@@ -122,8 +122,15 @@ TOOLS: list[dict[str, Any]] = [
                 "type": "object",
                 "properties": {
                     "rid": {
-                        "type": "string",
-                        "description": "Requirement identifier to load (for example, SYS12).",
+                        "oneOf": [
+                            {"type": "string"},
+                            {
+                                "type": "array",
+                                "items": {"type": "string"},
+                                "minItems": 1,
+                            },
+                        ],
+                        "description": "Requirement identifier or list of identifiers to load (for example, SYS12 or [\"SYS1\", \"SYS2\"]).",
                     },
                     "fields": {
                         "type": ["array", "string", "null"],

--- a/app/mcp/server.py
+++ b/app/mcp/server.py
@@ -220,8 +220,10 @@ def list_requirements(
 
 
 @register_tool()
-def get_requirement(rid: str, fields: list[str] | None = None) -> dict:
-    """Return a single requirement by identifier."""
+def get_requirement(
+    rid: str | Sequence[str], fields: list[str] | None = None
+) -> dict:
+    """Return one or more requirements by identifier."""
     directory = app.state.base_path
     return tools_read.get_requirement(directory, rid, fields=fields)
 

--- a/tests/unit/test_llm_validation.py
+++ b/tests/unit/test_llm_validation.py
@@ -53,6 +53,14 @@ def test_validate_tool_call_accepts_string_fields():
     assert result == arguments
 
 
+def test_validate_tool_call_accepts_rid_list():
+    arguments = {"rid": ["SYS1", "SYS2"], "fields": ["title"]}
+
+    result = validate_tool_call("get_requirement", arguments)
+
+    assert result == arguments
+
+
 @pytest.mark.parametrize(
     "arguments,expected_message",
     [


### PR DESCRIPTION
## Summary
- add support for passing multiple requirement identifiers to the MCP get_requirement tool and report missing entries
- update the MCP server and tool schema so the LLM contract documents the broader signature
- extend validation and unit coverage for list-based get_requirement calls

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d6af8ee09483209d560abe2d225285