### PR TITLE
Refactor agent chat panel into composable helpers

### DIFF
--- a/app/ui/agent_chat_panel/__init__.py
+++ b/app/ui/agent_chat_panel/__init__.py
@@ -1,7 +1,10 @@
 """Agent chat panel package."""
 
 from .confirm_preferences import RequirementConfirmPreference
+from .batch_ui import AgentBatchSection
 from .execution import AgentCommandExecutor, ThreadedAgentCommandExecutor
+from .history import AgentChatHistory
+from .layout import AgentChatLayoutBuilder
 from .panel import AgentChatPanel
 from .paths import history_path_for_documents, settings_path_for_documents
 from ...llm.tokenizer import count_text_tokens
@@ -9,6 +12,9 @@ from .project_settings import AgentProjectSettings
 
 __all__ = [
     "AgentChatPanel",
+    "AgentChatHistory",
+    "AgentChatLayoutBuilder",
+    "AgentBatchSection",
     "RequirementConfirmPreference",
     "AgentCommandExecutor",
     "ThreadedAgentCommandExecutor",

--- a/app/ui/agent_chat_panel/batch_ui.py
+++ b/app/ui/agent_chat_panel/batch_ui.py
@@ -1,0 +1,262 @@
+"""User-interface helpers for managing batch agent runs."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Callable, Sequence
+
+import logging
+import textwrap
+
+import wx
+import wx.dataview as dv
+
+from ...i18n import _
+from .batch_runner import AgentBatchRunner, BatchItem, BatchItemStatus, BatchTarget
+
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(slots=True)
+class BatchControls:
+    """Widgets composing the batch queue section."""
+
+    panel: wx.Panel
+    run_button: wx.Button
+    stop_button: wx.Button
+    status_label: wx.StaticText
+    progress: wx.Gauge
+    list_ctrl: dv.DataViewListCtrl
+
+
+class AgentBatchSection:
+    """Coordinator for batch queue lifecycle and related UI."""
+
+    def __init__(
+        self,
+        *,
+        panel: "AgentChatPanel",
+        controls: BatchControls,
+        runner: AgentBatchRunner | None = None,
+        target_provider: Callable[[], Sequence[BatchTarget]] | None = None,
+    ) -> None:
+        if TYPE_CHECKING:  # pragma: no cover - help type checkers
+            from .panel import AgentChatPanel
+
+        self._panel = panel
+        self._controls = controls
+        self._target_provider = target_provider
+        self._runner = runner or AgentBatchRunner(
+            submit_prompt=panel._submit_batch_prompt,
+            create_conversation=panel._create_batch_conversation,
+            ensure_conversation_id=lambda conv: getattr(conv, "conversation_id"),
+            on_state_changed=self.update_ui,
+            context_factory=panel._build_batch_context,
+            prepare_conversation=panel._prepare_batch_conversation,
+        )
+        controls.run_button.Bind(wx.EVT_BUTTON, self._handle_run_request)
+        controls.stop_button.Bind(wx.EVT_BUTTON, self._handle_stop_request)
+        self.update_ui()
+
+    # ------------------------------------------------------------------
+    @property
+    def runner(self) -> AgentBatchRunner:
+        return self._runner
+
+    # ------------------------------------------------------------------
+    def start_batch(self) -> None:
+        if self._panel._is_running:
+            return
+        runner = self._runner
+        if runner.is_running:
+            return
+        prompt_text = self._panel.input.GetValue().strip()
+        if not prompt_text:
+            self._panel.status_label.SetLabel(
+                _("Enter a prompt before starting a batch")
+            )
+            self._panel.input.SetFocus()
+            return
+        targets = self._collect_targets()
+        if not targets:
+            self._panel.status_label.SetLabel(
+                _("Select at least one requirement in the list to run a batch")
+            )
+            return
+        if not runner.start(prompt_text, targets):
+            self._panel.status_label.SetLabel(_("Unable to start batch queue"))
+            return
+        self._panel.status_label.SetLabel(
+            _("Batch started: {count} requirements").format(count=len(targets))
+        )
+        self.update_ui()
+
+    # ------------------------------------------------------------------
+    def stop_batch(self) -> None:
+        runner = self._runner
+        if not runner.items:
+            return
+        runner.cancel_all()
+        controller = self._panel._controller
+        if controller is not None:
+            controller.stop()
+        self._panel.status_label.SetLabel(_("Batch cancellation requested"))
+        self.update_ui()
+
+    # ------------------------------------------------------------------
+    def request_skip_current(self) -> None:
+        self._runner.request_skip_current()
+
+    # ------------------------------------------------------------------
+    def notify_completion(
+        self,
+        *,
+        conversation_id: str,
+        success: bool,
+        error: str | None,
+    ) -> None:
+        self._runner.handle_completion(
+            conversation_id=conversation_id,
+            success=success,
+            error=error,
+        )
+        self.update_ui()
+
+    # ------------------------------------------------------------------
+    def notify_cancellation(self, *, conversation_id: str) -> None:
+        self._runner.handle_cancellation(conversation_id=conversation_id)
+        self.update_ui()
+
+    # ------------------------------------------------------------------
+    def update_ui(self) -> None:
+        panel = self._controls.panel
+        runner = self._runner
+        status_label = self._controls.status_label
+        progress = self._controls.progress
+        run_button = self._controls.run_button
+        stop_button = self._controls.stop_button
+
+        if not runner.items:
+            panel.Hide()
+            status_label.SetLabel(_("Select requirements and run a batch"))
+            progress.SetRange(1)
+            progress.SetValue(0)
+            run_button.Enable(not self._panel._is_running)
+            stop_button.Enable(False)
+            self._panel._refresh_bottom_panel_layout()
+            return
+
+        panel.Show()
+        self._refresh_table(runner.items)
+
+        total = len(runner.items)
+        completed_count = sum(1 for item in runner.items if item.status is BatchItemStatus.COMPLETED)
+        failed_count = sum(1 for item in runner.items if item.status is BatchItemStatus.FAILED)
+        cancelled_count = sum(1 for item in runner.items if item.status is BatchItemStatus.CANCELLED)
+        pending_count = sum(1 for item in runner.items if item.status is BatchItemStatus.PENDING)
+
+        if total <= 0:
+            progress.SetRange(1)
+            progress.SetValue(0)
+        else:
+            completed_steps = completed_count + failed_count + cancelled_count
+            progress.SetRange(total)
+            progress.SetValue(min(completed_steps, total))
+
+        if runner.is_running and runner.active_item is not None:
+            try:
+                active_index = runner.items.index(runner.active_item)
+            except ValueError:
+                active_index = None
+            current = active_index + 1 if active_index is not None else completed_count + 1
+            summary = _(
+                "Running {current} of {total} requirements (done: {done}, failed: {failed}, cancelled: {cancelled})"
+            ).format(
+                current=current,
+                total=total,
+                done=completed_count,
+                failed=failed_count,
+                cancelled=cancelled_count,
+            )
+        elif pending_count:
+            summary = _(
+                "Batch ready: {total} requirements queued ({pending} pending)"
+            ).format(total=total, pending=pending_count)
+        else:
+            summary = _(
+                "Batch finished: {done} completed, {failed} failed, {cancelled} cancelled"
+            ).format(
+                done=completed_count,
+                failed=failed_count,
+                cancelled=cancelled_count,
+            )
+
+        status_label.SetLabel(summary)
+        run_button.Enable(not runner.is_running and not self._panel._is_running)
+        stop_button.Enable(runner.is_running)
+        self._panel._refresh_bottom_panel_layout()
+
+    # ------------------------------------------------------------------
+    def _collect_targets(self) -> list[BatchTarget]:
+        provider = self._target_provider or self._panel._batch_target_provider
+        if provider is None:
+            return []
+        try:
+            candidates = list(provider())
+        except Exception:
+            logger.exception("Failed to collect batch targets")
+            return []
+        unique: list[BatchTarget] = []
+        seen: set[str] = set()
+        for item in candidates:
+            if not isinstance(item, BatchTarget):
+                continue
+            rid = item.rid.strip() if item.rid else ""
+            key = rid or str(item.requirement_id)
+            if key in seen:
+                continue
+            seen.add(key)
+            unique.append(item)
+        return unique
+
+    # ------------------------------------------------------------------
+    def _refresh_table(self, items: Sequence[BatchItem]) -> None:
+        control = self._controls.list_ctrl
+        control.DeleteAllItems()
+        for item in items:
+            rid = item.target.rid.strip() if item.target.rid else ""
+            if not rid:
+                rid = str(item.target.requirement_id)
+            title = item.target.title.strip() if item.target.title else ""
+            if not title:
+                title = rid
+            status_text = self._format_status(item)
+            control.AppendItem([rid, title, status_text])
+
+    # ------------------------------------------------------------------
+    def _format_status(self, item: BatchItem) -> str:
+        labels = {
+            BatchItemStatus.PENDING: _("Pending"),
+            BatchItemStatus.RUNNING: _("Running"),
+            BatchItemStatus.COMPLETED: _("Completed"),
+            BatchItemStatus.FAILED: _("Failed"),
+            BatchItemStatus.CANCELLED: _("Cancelled"),
+        }
+        label = labels.get(item.status, item.status.name.title())
+        if item.error:
+            snippet = textwrap.shorten(str(item.error), width=80, placeholder="…")
+            label = f"{label} — {snippet}"
+        return label
+
+    # ------------------------------------------------------------------
+    def _handle_run_request(self, _event: wx.Event) -> None:
+        self.start_batch()
+
+    # ------------------------------------------------------------------
+    def _handle_stop_request(self, _event: wx.Event) -> None:
+        self.stop_batch()
+
+
+__all__ = ["AgentBatchSection", "BatchControls"]
+

--- a/app/ui/agent_chat_panel/history.py
+++ b/app/ui/agent_chat_panel/history.py
@@ -1,0 +1,115 @@
+"""State management helpers for agent chat history."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Sequence
+from pathlib import Path
+from typing import Callable
+
+import logging
+
+from ..chat_entry import ChatConversation
+from .history_store import HistoryStore
+
+
+logger = logging.getLogger(__name__)
+
+
+class AgentChatHistory:
+    """Encapsulate history persistence and active conversation tracking."""
+
+    def __init__(
+        self,
+        *,
+        history_path: Path | str | None,
+        on_active_changed: Callable[[str | None, str | None], None] | None = None,
+    ) -> None:
+        self._store = HistoryStore(history_path)
+        self._conversations: list[ChatConversation] = []
+        self._active_id: str | None = None
+        self._on_active_changed = on_active_changed
+
+    # ------------------------------------------------------------------
+    @property
+    def conversations(self) -> list[ChatConversation]:
+        """Return the in-memory conversations."""
+
+        return self._conversations
+
+    # ------------------------------------------------------------------
+    @property
+    def active_id(self) -> str | None:
+        """Return identifier of the currently selected conversation."""
+
+        return self._active_id
+
+    # ------------------------------------------------------------------
+    @property
+    def path(self) -> Path:
+        """Expose backing store path so callers can surface it in the UI."""
+
+        return self._store.path
+
+    # ------------------------------------------------------------------
+    def set_conversations(self, conversations: Sequence[ChatConversation]) -> None:
+        """Replace the in-memory conversation list."""
+
+        self._conversations = list(conversations)
+
+    # ------------------------------------------------------------------
+    def set_active_id(self, conversation_id: str | None) -> None:
+        """Set active conversation id notifying listeners on change."""
+
+        previous = self._active_id
+        self._active_id = conversation_id
+        if (
+            self._on_active_changed is not None
+            and previous != conversation_id
+        ):
+            self._on_active_changed(previous, conversation_id)
+
+    # ------------------------------------------------------------------
+    def load(self) -> tuple[list[ChatConversation], str | None]:
+        """Populate memory state from disk and report the loaded payload."""
+
+        previous = self._active_id
+        conversations, active_id = self._store.load()
+        self._conversations = list(conversations)
+        self._active_id = active_id
+        if self._on_active_changed is not None and previous != active_id:
+            self._on_active_changed(previous, active_id)
+        return self._conversations, self._active_id
+
+    # ------------------------------------------------------------------
+    def save(self) -> None:
+        """Persist current state to disk logging failures defensively."""
+
+        try:
+            self._store.save(self._conversations, self._active_id)
+        except Exception:  # pragma: no cover - defensive logging
+            logger.exception(
+                "Failed to persist agent chat history to %s", self._store.path
+            )
+
+    # ------------------------------------------------------------------
+    def set_path(
+        self,
+        path: Path | str | None,
+        *,
+        persist_existing: bool = False,
+    ) -> bool:
+        """Switch history store to *path* returning ``True`` on change."""
+
+        conversations: Iterable[ChatConversation] | None = (
+            self._conversations if persist_existing else None
+        )
+        return self._store.set_path(
+            path,
+            persist_existing=persist_existing,
+            conversations=conversations,
+            active_id=self._active_id,
+        )
+
+
+__all__ = ["AgentChatHistory"]
+

--- a/app/ui/agent_chat_panel/layout.py
+++ b/app/ui/agent_chat_panel/layout.py
@@ -1,0 +1,343 @@
+"""Layout helpers for :class:`AgentChatPanel`."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+import wx
+import wx.dataview as dv
+from wx.lib.scrolledpanel import ScrolledPanel
+
+from ...i18n import _
+from ..helpers import create_copy_button, dip, inherit_background
+from ..splitter_utils import refresh_splitter_highlight, style_splitter
+from .batch_ui import BatchControls
+from .confirm_preferences import RequirementConfirmPreference
+from .history_view import HistoryView
+from .transcript_view import TranscriptCallbacks, TranscriptView
+
+if TYPE_CHECKING:  # pragma: no cover - type hints only
+    from .panel import AgentChatPanel
+
+
+@dataclass(slots=True)
+class AgentChatLayout:
+    """Container describing widgets constructed for the chat panel."""
+
+    outer_sizer: wx.BoxSizer
+    vertical_splitter: wx.SplitterWindow
+    horizontal_splitter: wx.SplitterWindow
+    history_panel: wx.Panel
+    history_view: HistoryView
+    history_list: dv.DataViewListCtrl
+    new_chat_button: wx.Button
+    conversation_label: wx.StaticText
+    copy_conversation_button: wx.Window
+    copy_log_button: wx.Window
+    transcript_container: wx.Panel
+    transcript_scroller: ScrolledPanel
+    transcript_sizer: wx.BoxSizer
+    transcript_view: TranscriptView
+    bottom_panel: wx.Panel
+    input_control: wx.TextCtrl
+    run_batch_button: wx.Button
+    stop_batch_button: wx.Button
+    stop_button: wx.Button
+    send_button: wx.Button
+    batch_controls: BatchControls
+    activity_indicator: wx.ActivityIndicator
+    status_label: wx.StaticText
+    project_settings_button: wx.Button
+    confirm_choice: wx.Choice
+    confirm_entries: tuple[tuple[RequirementConfirmPreference, str], ...]
+    confirm_choice_index: dict[RequirementConfirmPreference, int]
+
+
+class AgentChatLayoutBuilder:
+    """Build and configure widgets composing :class:`AgentChatPanel`."""
+
+    def __init__(self, panel: "AgentChatPanel") -> None:
+        self._panel = panel
+
+    def build(self, *, status_help_text: str) -> AgentChatLayout:
+        panel = self._panel
+        spacing = dip(panel, 5)
+
+        outer = wx.BoxSizer(wx.VERTICAL)
+        splitter_style = wx.SP_LIVE_UPDATE | wx.SP_3D
+
+        vertical_splitter = wx.SplitterWindow(panel, style=splitter_style)
+        style_splitter(vertical_splitter)
+        vertical_splitter.SetMinimumPaneSize(dip(panel, 160))
+
+        top_panel = wx.Panel(vertical_splitter)
+        bottom_panel = wx.Panel(vertical_splitter)
+        inherit_background(top_panel, panel)
+        inherit_background(bottom_panel, panel)
+
+        horizontal_splitter = wx.SplitterWindow(top_panel, style=splitter_style)
+        style_splitter(horizontal_splitter)
+        history_min_width = dip(panel, 260)
+        horizontal_splitter.SetMinimumPaneSize(history_min_width)
+
+        history_panel = wx.Panel(horizontal_splitter)
+        inherit_background(history_panel, panel)
+        history_sizer = wx.BoxSizer(wx.VERTICAL)
+        history_header = wx.BoxSizer(wx.HORIZONTAL)
+        history_label = wx.StaticText(history_panel, label=_("Chats"))
+        new_chat_btn = wx.Button(history_panel, label=_("New chat"))
+        new_chat_btn.Bind(wx.EVT_BUTTON, panel._on_new_chat)
+        history_header.Add(history_label, 1, wx.ALIGN_CENTER_VERTICAL)
+        history_header.Add(new_chat_btn, 0, wx.ALIGN_CENTER_VERTICAL)
+        history_style = dv.DV_MULTIPLE | dv.DV_ROW_LINES | dv.DV_VERT_RULES
+        history_list = dv.DataViewListCtrl(history_panel, style=history_style)
+        history_list.SetMinSize(wx.Size(dip(panel, 260), -1))
+        title_col = history_list.AppendTextColumn(
+            _("Title"), mode=dv.DATAVIEW_CELL_INERT, width=dip(panel, 180)
+        )
+        title_col.SetMinWidth(dip(panel, 140))
+        activity_col = history_list.AppendTextColumn(
+            _("Last activity"), mode=dv.DATAVIEW_CELL_INERT, width=dip(panel, 140)
+        )
+        activity_col.SetMinWidth(dip(panel, 120))
+
+        history_view = HistoryView(
+            history_list,
+            get_conversations=lambda: panel.conversations,
+            format_row=panel._format_conversation_row,
+            get_active_index=panel._active_index,
+            activate_conversation=panel._on_history_row_activated,
+            handle_delete_request=panel._delete_history_rows,
+            is_running=lambda: panel._is_running,
+            splitter=horizontal_splitter,
+        )
+
+        history_sizer.Add(history_header, 0, wx.EXPAND)
+        history_sizer.AddSpacer(spacing)
+        history_sizer.Add(history_list, 1, wx.EXPAND)
+        history_panel.SetSizer(history_sizer)
+
+        transcript_container = wx.Panel(horizontal_splitter)
+        transcript_sizer = wx.BoxSizer(wx.VERTICAL)
+        transcript_header = wx.BoxSizer(wx.HORIZONTAL)
+        conversation_label = wx.StaticText(
+            transcript_container, label=_("Conversation")
+        )
+        transcript_header.Add(conversation_label, 0, wx.ALIGN_CENTER_VERTICAL)
+        transcript_header.AddStretchSpacer()
+        copy_conversation_btn = create_copy_button(
+            transcript_container,
+            tooltip=_("Copy conversation"),
+            fallback_label=_("Copy conversation"),
+            handler=panel._on_copy_conversation,
+        )
+        copy_conversation_btn.Enable(False)
+        transcript_header.Add(copy_conversation_btn, 0, wx.ALIGN_CENTER_VERTICAL)
+        transcript_header.AddSpacer(dip(panel, 4))
+        copy_log_btn = create_copy_button(
+            transcript_container,
+            tooltip=_("Copy technical log"),
+            fallback_label=_("Copy technical log"),
+            handler=panel._on_copy_transcript_log,
+        )
+        copy_log_btn.Enable(False)
+        transcript_header.Add(copy_log_btn, 0, wx.ALIGN_CENTER_VERTICAL)
+
+        transcript_scroller = ScrolledPanel(
+            transcript_container,
+            style=wx.TAB_TRAVERSAL,
+        )
+        inherit_background(transcript_container, panel)
+        inherit_background(transcript_scroller, transcript_container)
+        transcript_scroller.SetupScrolling(scroll_x=False, scroll_y=True)
+        transcript_box = wx.BoxSizer(wx.VERTICAL)
+        transcript_scroller.SetSizer(transcript_box)
+
+        transcript_view = TranscriptView(
+            panel,
+            transcript_scroller,
+            transcript_box,
+            callbacks=TranscriptCallbacks(
+                get_conversation=panel._get_active_conversation,
+                is_running=lambda: panel._is_running,
+                on_regenerate=panel._handle_regenerate_request,
+                update_copy_buttons=panel._update_transcript_copy_buttons,
+                update_header=panel._update_conversation_header,
+            ),
+        )
+
+        transcript_sizer.Add(transcript_header, 0, wx.EXPAND)
+        transcript_sizer.AddSpacer(spacing)
+        transcript_sizer.Add(transcript_scroller, 1, wx.EXPAND)
+        transcript_container.SetSizer(transcript_sizer)
+
+        horizontal_splitter.SplitVertically(history_panel, transcript_container, history_min_width)
+        horizontal_splitter.SetSashGravity(1.0)
+        horizontal_splitter.Bind(wx.EVT_SIZE, panel._on_history_splitter_size)
+        horizontal_splitter.Bind(
+            wx.EVT_SPLITTER_SASH_POS_CHANGED, panel._on_history_sash_changed
+        )
+
+        top_sizer = wx.BoxSizer(wx.VERTICAL)
+        top_sizer.Add(horizontal_splitter, 1, wx.EXPAND)
+        top_panel.SetSizer(top_sizer)
+
+        bottom_sizer = wx.BoxSizer(wx.VERTICAL)
+        bottom_sizer.Add(wx.StaticLine(bottom_panel), 0, wx.EXPAND)
+        bottom_sizer.AddSpacer(spacing)
+
+        input_label = wx.StaticText(bottom_panel, label=_("Ask the agent"))
+        input_ctrl = wx.TextCtrl(
+            bottom_panel, style=wx.TE_PROCESS_ENTER | wx.TE_MULTILINE
+        )
+        if hasattr(input_ctrl, "SetHint"):
+            input_ctrl.SetHint(_("Describe what you need the agent to do"))
+        input_ctrl.Bind(wx.EVT_TEXT_ENTER, panel._on_send)
+
+        button_row = wx.BoxSizer(wx.HORIZONTAL)
+        run_batch_btn = wx.Button(bottom_panel, label=_("Run batch"))
+        stop_batch_btn = wx.Button(bottom_panel, label=_("Stop batch"))
+        stop_batch_btn.Enable(False)
+        clear_btn = wx.Button(bottom_panel, label=_("Clear input"))
+        clear_btn.Bind(wx.EVT_BUTTON, panel._on_clear_input)
+        stop_btn = wx.Button(bottom_panel, label=_("Stop"))
+        stop_btn.Enable(False)
+        stop_btn.Bind(wx.EVT_BUTTON, panel._on_stop)
+        send_btn = wx.Button(bottom_panel, label=_("Send"))
+        send_btn.Bind(wx.EVT_BUTTON, panel._on_send)
+        button_row.Add(run_batch_btn, 0, wx.RIGHT, spacing)
+        button_row.Add(stop_batch_btn, 0, wx.RIGHT, spacing)
+        button_row.Add(clear_btn, 0, wx.RIGHT, spacing)
+        button_row.Add(stop_btn, 0, wx.RIGHT, spacing)
+        button_row.Add(send_btn, 0)
+
+        batch_panel = wx.Panel(bottom_panel)
+        inherit_background(batch_panel, bottom_panel)
+        batch_box = wx.StaticBoxSizer(wx.VERTICAL, batch_panel, _("Batch queue"))
+        batch_status_label = wx.StaticText(
+            batch_panel, label=_("Select requirements and run a batch")
+        )
+        batch_progress = wx.Gauge(batch_panel, range=1, style=wx.GA_HORIZONTAL)
+        batch_progress.SetValue(0)
+        batch_progress.SetMinSize(wx.Size(-1, dip(panel, 12)))
+        batch_list = dv.DataViewListCtrl(batch_panel, style=dv.DV_ROW_LINES | dv.DV_VERT_RULES)
+        batch_list.SetMinSize(wx.Size(-1, dip(panel, 140)))
+        batch_list.AppendTextColumn(_("RID"), mode=dv.DATAVIEW_CELL_INERT, width=dip(panel, 120))
+        batch_list.AppendTextColumn(_("Title"), mode=dv.DATAVIEW_CELL_INERT, width=dip(panel, 200))
+        batch_list.AppendTextColumn(_("Status"), mode=dv.DATAVIEW_CELL_INERT, width=dip(panel, 220))
+        batch_box.Add(batch_status_label, 0, wx.BOTTOM, spacing)
+        batch_box.Add(batch_progress, 0, wx.EXPAND | wx.BOTTOM, spacing)
+        batch_box.Add(batch_list, 1, wx.EXPAND)
+        batch_panel.SetSizer(batch_box)
+        batch_panel.Hide()
+
+        activity_indicator = wx.ActivityIndicator(bottom_panel)
+        activity_indicator.Hide()
+        status_label = wx.StaticText(bottom_panel, label=_("Ready"))
+        status_row = wx.BoxSizer(wx.HORIZONTAL)
+        status_row.Add(
+            activity_indicator, 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, spacing
+        )
+        status_row.Add(status_label, 0, wx.ALIGN_CENTER_VERTICAL)
+        activity_indicator.SetToolTip(status_help_text)
+        status_label.SetToolTip(status_help_text)
+
+        settings_btn = wx.Button(bottom_panel, label=_("Agent instructions"))
+        settings_btn.Bind(wx.EVT_BUTTON, panel._on_project_settings)
+
+        confirm_entries: tuple[tuple[RequirementConfirmPreference, str], ...] = (
+            (RequirementConfirmPreference.PROMPT, _("Ask every time")),
+            (
+                RequirementConfirmPreference.CHAT_ONLY,
+                _("Skip for this chat"),
+            ),
+            (RequirementConfirmPreference.NEVER, _("Never ask")),
+        )
+        confirm_choice = wx.Choice(
+            bottom_panel,
+            choices=[label for _pref, label in confirm_entries],
+        )
+        confirm_choice.Bind(wx.EVT_CHOICE, panel._on_confirm_choice)
+        confirm_choice_index = {
+            pref: idx for idx, (pref, _label) in enumerate(confirm_entries)
+        }
+        confirm_label = wx.StaticText(
+            bottom_panel, label=_("Requirement confirmations")
+        )
+        confirm_row = wx.BoxSizer(wx.HORIZONTAL)
+        confirm_row.Add(
+            confirm_label, 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, dip(panel, 4)
+        )
+        confirm_row.Add(confirm_choice, 0, wx.ALIGN_CENTER_VERTICAL)
+
+        controls_row = wx.BoxSizer(wx.HORIZONTAL)
+        controls_row.Add(status_row, 0, wx.ALIGN_CENTER_VERTICAL)
+        controls_row.AddStretchSpacer()
+        controls_row.Add(settings_btn, 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, spacing)
+        controls_row.Add(confirm_row, 0, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, spacing)
+        controls_row.Add(button_row, 0, wx.ALIGN_CENTER_VERTICAL)
+
+        bottom_sizer.Add(input_label, 0)
+        bottom_sizer.AddSpacer(spacing)
+        bottom_sizer.Add(input_ctrl, 1, wx.EXPAND)
+        bottom_sizer.AddSpacer(spacing)
+        bottom_sizer.Add(batch_panel, 0, wx.EXPAND)
+        bottom_sizer.AddSpacer(spacing)
+        bottom_sizer.Add(controls_row, 0, wx.EXPAND)
+        bottom_sizer.AddSpacer(spacing)
+        bottom_panel.SetSizer(bottom_sizer)
+
+        vertical_splitter.SplitHorizontally(top_panel, bottom_panel)
+        vertical_splitter.SetSashGravity(1.0)
+        vertical_splitter.Bind(
+            wx.EVT_SPLITTER_SASH_POS_CHANGED, panel._on_vertical_sash_changed
+        )
+
+        outer.Add(vertical_splitter, 1, wx.EXPAND)
+        panel.SetSizer(outer)
+        refresh_splitter_highlight(horizontal_splitter)
+        refresh_splitter_highlight(vertical_splitter)
+
+        batch_controls = BatchControls(
+            panel=batch_panel,
+            run_button=run_batch_btn,
+            stop_button=stop_batch_btn,
+            status_label=batch_status_label,
+            progress=batch_progress,
+            list_ctrl=batch_list,
+        )
+
+        return AgentChatLayout(
+            outer_sizer=outer,
+            vertical_splitter=vertical_splitter,
+            horizontal_splitter=horizontal_splitter,
+            history_panel=history_panel,
+            history_view=history_view,
+            history_list=history_list,
+            new_chat_button=new_chat_btn,
+            conversation_label=conversation_label,
+            copy_conversation_button=copy_conversation_btn,
+            copy_log_button=copy_log_btn,
+            transcript_container=transcript_container,
+            transcript_scroller=transcript_scroller,
+            transcript_sizer=transcript_box,
+            transcript_view=transcript_view,
+            bottom_panel=bottom_panel,
+            input_control=input_ctrl,
+            run_batch_button=run_batch_btn,
+            stop_batch_button=stop_batch_btn,
+            stop_button=stop_btn,
+            send_button=send_btn,
+            batch_controls=batch_controls,
+            activity_indicator=activity_indicator,
+            status_label=status_label,
+            project_settings_button=settings_btn,
+            confirm_choice=confirm_choice,
+            confirm_entries=confirm_entries,
+            confirm_choice_index=confirm_choice_index,
+        )
+
+
+__all__ = ["AgentChatLayout", "AgentChatLayoutBuilder"]
+

--- a/tests/gui/test_agent_batch_section.py
+++ b/tests/gui/test_agent_batch_section.py
@@ -1,0 +1,99 @@
+import pytest
+
+
+pytestmark = pytest.mark.gui
+
+
+def test_agent_batch_section_handles_start_and_stop(wx_app):
+    import wx
+    import wx.dataview as dv
+
+    from app.ui.agent_chat_panel.batch_runner import BatchItem, BatchTarget
+    from app.ui.agent_chat_panel.batch_ui import AgentBatchSection, BatchControls
+
+    frame = wx.Frame(None)
+
+    class DummyPanel(wx.Panel):
+        def __init__(self, parent: wx.Window) -> None:
+            super().__init__(parent)
+            self._is_running = False
+            self.input = wx.TextCtrl(self)
+            self.status_label = wx.StaticText(self)
+            self._controller = type(
+                "Controller",
+                (),
+                {"stop": lambda self: True},
+            )()
+            self._batch_target_provider = lambda: [
+                BatchTarget(requirement_id=1, rid="REQ-1", title="Sample"),
+            ]
+            self.layout_refreshes = 0
+
+        def _refresh_bottom_panel_layout(self) -> None:
+            self.layout_refreshes += 1
+
+    panel = DummyPanel(frame)
+
+    run_button = wx.Button(panel, label="Run")
+    stop_button = wx.Button(panel, label="Stop")
+    status_label = wx.StaticText(panel)
+    progress = wx.Gauge(panel, range=1)
+    list_ctrl = dv.DataViewListCtrl(panel)
+
+    controls = BatchControls(
+        panel=panel,
+        run_button=run_button,
+        stop_button=stop_button,
+        status_label=status_label,
+        progress=progress,
+        list_ctrl=list_ctrl,
+    )
+
+    class StubRunner:
+        def __init__(self) -> None:
+            self.started = None
+            self.cancelled = False
+            self.skipped = False
+            self._items: list[BatchItem] = []
+            self.is_running = False
+            self.active_item = None
+
+        @property
+        def items(self):
+            return tuple(self._items)
+
+        def start(self, prompt, targets):
+            self.started = (prompt, tuple(targets))
+            self._items = [BatchItem(target=targets[0])]
+            self.active_item = self._items[0]
+            self.is_running = True
+            return True
+
+        def cancel_all(self):
+            self.cancelled = True
+            self.is_running = False
+
+        def request_skip_current(self):
+            self.skipped = True
+
+        def handle_completion(self, *, conversation_id, success, error):
+            self.is_running = False
+
+        def handle_cancellation(self, *, conversation_id):
+            self.is_running = False
+
+    runner = StubRunner()
+    section = AgentBatchSection(panel=panel, controls=controls, runner=runner)
+
+    panel.input.SetValue("Plan release")
+    section.start_batch()
+
+    assert runner.started is not None
+    assert runner.is_running
+    assert "Batch started" in panel.status_label.GetLabel()
+
+    section.stop_batch()
+    assert runner.cancelled
+    assert "Batch cancellation requested" in panel.status_label.GetLabel()
+
+    frame.Destroy()

--- a/tests/gui/test_agent_chat_panel.py
+++ b/tests/gui/test_agent_chat_panel.py
@@ -1607,7 +1607,7 @@ def test_agent_chat_panel_delete_multiple_chats(tmp_path, wx_app):
     assert len(panel.conversations) == 1
     assert panel.history_list.GetItemCount() == 1
     assert panel.conversations[0].conversation_id == last_id
-    assert panel._active_conversation_id == last_id
+    assert panel.active_conversation_id == last_id
     assert panel.input.GetValue() == "draft text"
 
     destroy_panel(frame, panel)

--- a/tests/unit/test_agent_chat_history.py
+++ b/tests/unit/test_agent_chat_history.py
@@ -1,0 +1,55 @@
+from app.ui.agent_chat_panel.history import AgentChatHistory
+from app.ui.chat_entry import ChatConversation
+
+
+def test_agent_chat_history_round_trip(tmp_path):
+    history_path = tmp_path / "history.json"
+    events: list[tuple[str | None, str | None]] = []
+    history = AgentChatHistory(
+        history_path=history_path,
+        on_active_changed=lambda previous, current: events.append((previous, current)),
+    )
+
+    conversation = ChatConversation.new()
+    conversation.title = "Initial"
+    history.set_conversations([conversation])
+    history.set_active_id(conversation.conversation_id)
+    history.save()
+
+    assert history_path.exists()
+    assert events == [(None, conversation.conversation_id)]
+
+    loaded_events: list[tuple[str | None, str | None]] = []
+    reloaded = AgentChatHistory(
+        history_path=history_path,
+        on_active_changed=lambda previous, current: loaded_events.append((previous, current)),
+    )
+    conversations, active_id = reloaded.load()
+
+    assert len(conversations) == 1
+    assert active_id == conversation.conversation_id
+    assert loaded_events == [(None, conversation.conversation_id)]
+
+
+def test_agent_chat_history_switch_path_persists_existing(tmp_path):
+    original = tmp_path / "first.json"
+    history = AgentChatHistory(history_path=original, on_active_changed=None)
+    initial = ChatConversation.new()
+    history.set_conversations([initial])
+    history.set_active_id(initial.conversation_id)
+    history.save()
+
+    new_conversation = ChatConversation.new()
+    new_path = tmp_path / "second.json"
+    history.set_conversations([new_conversation])
+    history.set_active_id(new_conversation.conversation_id)
+    changed = history.set_path(new_path, persist_existing=True)
+
+    assert changed is True
+    history.save()
+    assert new_path.exists()
+
+    restored = AgentChatHistory(history_path=new_path, on_active_changed=None)
+    conversations, active_id = restored.load()
+    assert len(conversations) == 1
+    assert active_id == new_conversation.conversation_id


### PR DESCRIPTION
## Summary
- extract an AgentChatHistory helper that owns persistence, active chat tracking, and path switching
- add an AgentChatLayoutBuilder and AgentBatchSection to build the panel UI and coordinate batch controls
- update AgentChatPanel to delegate to the new helpers and cover them with unit and GUI tests

## Testing
- pytest -q -m "not gui"
- pytest --suite gui-smoke -q tests/gui/test_agent_chat_panel.py
- pytest --suite gui-smoke -q tests/gui/test_agent_batch_section.py

------
https://chatgpt.com/codex/tasks/task_e_68d7880506b88320906b27afa5cb85bb