### PR TITLE
Refactor batch controls access in agent chat panel

### DIFF
--- a/app/ui/agent_chat_panel/history_store.py
+++ b/app/ui/agent_chat_panel/history_store.py
@@ -82,10 +82,19 @@ class HistoryStore:
             if not isinstance(item, Mapping):
                 continue
             try:
-                conversations.append(ChatConversation.from_dict(item))
+                conversation = ChatConversation.from_dict(item)
             except Exception:  # pragma: no cover - defensive
                 logger.exception("Failed to deserialize stored conversation", exc_info=True)
                 continue
+            entries_raw = item.get("entries")
+            had_entries = isinstance(entries_raw, Sequence) and bool(entries_raw)
+            if had_entries and not conversation.entries:
+                logger.warning(
+                    "Skipping chat conversation %s with no valid entries",
+                    conversation.conversation_id,
+                )
+                continue
+            conversations.append(conversation)
 
         if not conversations:
             return [], None

--- a/app/ui/agent_chat_panel/layout.py
+++ b/app/ui/agent_chat_panel/layout.py
@@ -41,8 +41,6 @@ class AgentChatLayout:
     transcript_view: TranscriptView
     bottom_panel: wx.Panel
     input_control: wx.TextCtrl
-    run_batch_button: wx.Button
-    stop_batch_button: wx.Button
     stop_button: wx.Button
     send_button: wx.Button
     batch_controls: BatchControls
@@ -325,8 +323,6 @@ class AgentChatLayoutBuilder:
             transcript_view=transcript_view,
             bottom_panel=bottom_panel,
             input_control=input_ctrl,
-            run_batch_button=run_batch_btn,
-            stop_batch_button=stop_batch_btn,
             stop_button=stop_btn,
             send_button=send_btn,
             batch_controls=batch_controls,

--- a/app/ui/agent_chat_panel/panel.py
+++ b/app/ui/agent_chat_panel/panel.py
@@ -174,12 +174,6 @@ class AgentChatPanel(ConfirmPreferencesMixin, wx.Panel):
         ] = ()
         self._suppress_confirm_choice_events = False
         self._project_settings_button: wx.Button | None = None
-        self._run_batch_btn: wx.Button | None = None
-        self._stop_batch_btn: wx.Button | None = None
-        self._batch_panel: wx.Panel | None = None
-        self._batch_list = None
-        self._batch_progress: wx.Gauge | None = None
-        self._batch_status_label: wx.StaticText | None = None
         self._layout_builder = AgentChatLayoutBuilder(self)
         self._layout = None
         self._history.load()
@@ -330,15 +324,9 @@ class AgentChatPanel(ConfirmPreferencesMixin, wx.Panel):
         self._transcript_view = layout.transcript_view
         self._bottom_panel = layout.bottom_panel
         self.input = layout.input_control
-        self._run_batch_btn = layout.run_batch_button
-        self._stop_batch_btn = layout.stop_batch_button
         self._stop_btn = layout.stop_button
         self._send_btn = layout.send_button
         batch_controls = layout.batch_controls
-        self._batch_panel = batch_controls.panel
-        self._batch_status_label = batch_controls.status_label
-        self._batch_progress = batch_controls.progress
-        self._batch_list = batch_controls.list_ctrl
         self.activity = layout.activity_indicator
         self.status_label = layout.status_label
         self._project_settings_button = layout.project_settings_button


### PR DESCRIPTION
## Summary
- remove the standalone run/stop batch button handles from `AgentChatLayout` so `BatchControls` becomes the only access point for those widgets
- simplify `AgentChatPanel` state to rely on `BatchControls` for batch UI references
- harden history loading by discarding stored conversations whose entries became invalid after filtering legacy payloads

## Testing
- pytest --suite gui-smoke -q tests/gui/test_agent_chat_panel.py
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d82eea3c28832096d196d94c45e260