### PR TITLE
Prune unused configuration and navigation state

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -109,7 +109,6 @@ class ConfigManager:
         app_name: str = "CookaReq",
         path: Path | str | None = None,
     ) -> None:
-        self._app_name = app_name
         self._path = Path(path) if path is not None else _default_config_path(app_name)
         self._path.parent.mkdir(parents=True, exist_ok=True)
         self._settings = AppSettings()
@@ -206,12 +205,6 @@ class ConfigManager:
         if default is not _MISSING:
             return deepcopy(default)
         raise KeyError(name)
-
-    def has_value(self, name: str) -> bool:
-        binding = self._binding_for(name)
-        if binding is not None:
-            return self._is_overridden(binding)
-        return name in self._raw
 
     def set_value(self, name: str, value: Any) -> None:
         binding = self._binding_for(name)

--- a/app/core/document_store/links.py
+++ b/app/core/document_store/links.py
@@ -242,9 +242,9 @@ def link_requirements(
     try:
         (
             source_prefix,
-            _source_id,
-            source_doc,
-            source_dir,
+            _,
+            _,
+            _,
             source_data,
             source_canonical_rid,
         ) = _resolve_requirement(root_path, source_rid, docs_map)

--- a/app/ui/main_frame/frame.py
+++ b/app/ui/main_frame/frame.py
@@ -157,7 +157,6 @@ class MainFrame(
         """Expose frequently used menu items as attributes."""
 
         self._recent_menu = self.navigation.recent_menu
-        self._recent_menu_item = self.navigation.recent_menu_item
         self.log_menu_item = self.navigation.log_menu_item
         self.hierarchy_menu_item = self.navigation.hierarchy_menu_item
         self.editor_menu_item = self.navigation.editor_menu_item

--- a/app/ui/navigation.py
+++ b/app/ui/navigation.py
@@ -67,7 +67,6 @@ class Navigation:
         self.agent_chat_menu_item: wx.MenuItem | None = None
         self.recent_menu = wx.Menu()
         self.recent_menu_item: wx.MenuItem | None = None
-        self.run_command_id: int | None = None
         self._build()
 
     # ------------------------------------------------------------------
@@ -145,7 +144,6 @@ class Navigation:
         tools_menu = wx.Menu()
         cmd_item = tools_menu.Append(wx.ID_ANY, _("Open Agent Chat\tCtrl+K"))
         self.frame.Bind(wx.EVT_MENU, self.on_run_command, cmd_item)
-        self.run_command_id = cmd_item.GetId()
         logs_item = tools_menu.Append(wx.ID_ANY, _("Open Log Folder"))
         self.frame.Bind(wx.EVT_MENU, self.on_open_logs, logs_item)
         menu_bar.Append(tools_menu, _("&Tools"))


### PR DESCRIPTION
## Summary
- remove unused ConfigManager state that was no longer referenced anywhere
- drop leftover variables while resolving linked requirements
- delete unused navigation attributes carried over from previous menu implementations

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d8320c7ce483209e4d222e5f92b4cd