### PR TITLE
Enable additional Ruff lint suites

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,8 @@ Without both the environment variable and a valid key the test is skipped automa
 
 ### Linting and formatting
 
-`ruff` enforces code style and import hygiene:
+`ruff` enforces code style, import hygiene, flake8-bugbear safety rules,
+flake8-comprehensions normalisation, and flake8-simplify clarity tweaks:
 
 ```bash
 ruff check app tests

--- a/app/agent/local_agent.py
+++ b/app/agent/local_agent.py
@@ -751,8 +751,6 @@ class LocalAgent:
             arguments = prepared.arguments_for_payload
             if isinstance(arguments, Mapping):
                 error_payload["tool_arguments"] = dict(arguments)
-            elif isinstance(arguments, str) and arguments:
-                error_payload["tool_arguments"] = arguments
             elif arguments is not None:
                 error_payload["tool_arguments"] = arguments
             error_payload.setdefault("agent_status", "failed")

--- a/app/cli/commands.py
+++ b/app/cli/commands.py
@@ -201,7 +201,7 @@ def _sorted_cell_links(matrix: TraceMatrix) -> list[TraceMatrixLinkView]:
     row_order = {entry.rid: index for index, entry in enumerate(matrix.rows)}
     column_order = {entry.rid: index for index, entry in enumerate(matrix.columns)}
     links: list[TraceMatrixLinkView] = []
-    for _, cell in sorted(
+    for _pair, cell in sorted(
         matrix.cells.items(),
         key=lambda pair_cell: (
             row_order.get(pair_cell[0][0], 10**9),

--- a/app/config.py
+++ b/app/config.py
@@ -25,10 +25,7 @@ def _default_config_path(app_name: str) -> Path:
     """Return platform-appropriate config path for *app_name*."""
 
     base = os.environ.get("XDG_CONFIG_HOME")
-    if base:
-        root = Path(base)
-    else:
-        root = Path.home() / ".config"
+    root = Path(base) if base else Path.home() / ".config"
     return root / app_name / "config.json"
 
 

--- a/app/core/document_store/__init__.py
+++ b/app/core/document_store/__init__.py
@@ -7,9 +7,6 @@ from typing import TYPE_CHECKING, Any, List, Mapping
 if TYPE_CHECKING:  # pragma: no cover - import for typing only
     from ..model import Requirement
 
-from collections.abc import Sequence
-from pathlib import Path
-
 
 class ValidationError(Exception):
     """Raised when requirement links or payload violate business rules."""

--- a/app/core/document_store/documents.py
+++ b/app/core/document_store/documents.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 from dataclasses import asdict
 from pathlib import Path
-from typing import Any, Mapping, Optional
+from typing import Mapping, Optional
 
 from . import Document, DocumentLabels, LabelDef, ValidationError
 

--- a/app/core/document_store/items.py
+++ b/app/core/document_store/items.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import re
+from contextlib import suppress
 from dataclasses import fields
 from pathlib import Path
 from typing import Any, Callable, Mapping, Sequence
@@ -665,10 +666,8 @@ def move_requirement(
         save_item(directory, doc, item_payload)
 
     src_path = item_path(src_directory, src_doc, item_id)
-    try:
+    with suppress(FileNotFoundError):  # pragma: no cover - defensive
         src_path.unlink()
-    except FileNotFoundError:  # pragma: no cover - defensive
-        pass
 
     return req
 

--- a/app/core/model.py
+++ b/app/core/model.py
@@ -97,13 +97,13 @@ def requirement_from_dict(
         "id",
         "statement",
     ]
-    for field in required:
-        if field not in data:
-            raise KeyError(f"missing required field: {field}")
+    for required_field in required:
+        if required_field not in data:
+            raise KeyError(f"missing required field: {required_field}")
 
-    for field in ("text", "tags"):
-        if field in data:
-            raise KeyError(f"unsupported field: {field}")
+    for legacy_field in ("text", "tags"):
+        if legacy_field in data:
+            raise KeyError(f"unsupported field: {legacy_field}")
 
     def _enum_value(field: str, enum_cls: type[Enum], default: Enum) -> Enum:
         value = data.get(field, default)

--- a/app/core/requirement_export.py
+++ b/app/core/requirement_export.py
@@ -98,9 +98,8 @@ def build_requirement_export(
 
     root_path = Path(root)
     docs = load_documents(root_path)
-    if not docs:
-        if not root_path.is_dir():
-            raise FileNotFoundError(root_path)
+    if not docs and not root_path.is_dir():
+        raise FileNotFoundError(root_path)
     ordered_prefixes = _normalize_prefixes(prefixes, docs)
     requirements = load_requirements(root_path, prefixes=ordered_prefixes or None, docs=docs)
     by_rid = {req.rid: req for req in requirements}

--- a/app/llm/__init__.py
+++ b/app/llm/__init__.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Any
 __all__ = ["LLMClient"]
 
 if TYPE_CHECKING:  # pragma: no cover - typing helper
-    from .client import LLMClient as _LLMClient
+    from .client import LLMClient
 
 
 def __getattr__(name: str) -> Any:

--- a/app/llm/tokenizer.py
+++ b/app/llm/tokenizer.py
@@ -37,7 +37,7 @@ class TokenCountResult:
         return cls(tokens=max(tokens, 0), approximate=False, model=model, reason=reason)
 
     @classmethod
-    def approximate(
+    def approximate_result(
         cls,
         tokens: int,
         *,
@@ -95,7 +95,7 @@ class TokenCountResult:
         if tokens is None:
             return cls.unavailable(model=model_text, reason=reason_text)
         if approximate:
-            return cls.approximate(tokens, model=model_text, reason=reason_text)
+            return cls.approximate_result(tokens, model=model_text, reason=reason_text)
         return cls.exact(tokens, model=model_text, reason=reason_text)
 
 
@@ -167,21 +167,21 @@ def count_text_tokens(text: object, *, model: str | None = None) -> TokenCountRe
                 tokens = len(encoding.encode(text_value, disallowed_special=()))
             except Exception as exc:  # pragma: no cover - defensive
                 estimate = _whitespace_count(text_value)
-                return TokenCountResult.approximate(
+                return TokenCountResult.approximate_result(
                     estimate,
                     model=model,
                     reason=f"tokenize_failed: {exc}",
                 )
             if model and getattr(encoding, "name", None) == model:
                 return TokenCountResult.exact(tokens, model=model)
-            return TokenCountResult.approximate(
+            return TokenCountResult.approximate_result(
                 tokens,
                 model=model,
                 reason="model_approximation",
             )
 
     estimate = _whitespace_count(text_value)
-    return TokenCountResult.approximate(
+    return TokenCountResult.approximate_result(
         estimate,
         model=model,
         reason="fallback_whitespace",

--- a/app/mcp/client.py
+++ b/app/mcp/client.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
 import logging
 import json
 import time
@@ -10,8 +9,6 @@ from collections.abc import Callable, Mapping
 from typing import Any
 
 import httpx
-
-logger = logging.getLogger(__name__)
 
 from ..confirm import (
     ConfirmDecision,
@@ -24,6 +21,9 @@ from ..settings import MCPSettings
 from ..telemetry import log_debug_payload, log_event
 from .events import notify_tool_success
 from .utils import ErrorCode, mcp_error
+
+
+logger = logging.getLogger(__name__)
 
 
 class MCPNotReadyError(ConnectionError):

--- a/app/mcp/utils.py
+++ b/app/mcp/utils.py
@@ -30,16 +30,14 @@ else:  # pragma: no cover - executed in production/runtime environment
         for name in ("APIConnectionError", "APITimeoutError")
         if hasattr(openai, name)
     )
-    _OPENAI_STATUS_ERROR = (
-        (getattr(openai, "APIStatusError"),)
-        if hasattr(openai, "APIStatusError")
-        else ()
-    )
-    _OPENAI_BASE_ERRORS = (
-        (getattr(openai, "OpenAIError"),)
-        if hasattr(openai, "OpenAIError")
-        else ()
-    )
+    if hasattr(openai, "APIStatusError"):
+        _OPENAI_STATUS_ERROR = (openai.APIStatusError,)
+    else:
+        _OPENAI_STATUS_ERROR = ()
+    if hasattr(openai, "OpenAIError"):
+        _OPENAI_BASE_ERRORS = (openai.OpenAIError,)
+    else:
+        _OPENAI_BASE_ERRORS = ()
 
 _GENERIC_NETWORK_ERRORS: tuple[type[BaseException], ...] = (ConnectionError, TimeoutError)
 

--- a/app/ui/agent_chat_panel/batch_ui.py
+++ b/app/ui/agent_chat_panel/batch_ui.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Callable, Sequence
 
@@ -13,6 +15,9 @@ import wx.dataview as dv
 
 from ...i18n import _
 from .batch_runner import AgentBatchRunner, BatchItem, BatchItemStatus, BatchTarget
+
+if TYPE_CHECKING:  # pragma: no cover - help type checkers
+    from .panel import AgentChatPanel
 
 
 logger = logging.getLogger(__name__)
@@ -36,21 +41,18 @@ class AgentBatchSection:
     def __init__(
         self,
         *,
-        panel: "AgentChatPanel",
+        panel: AgentChatPanel,
         controls: BatchControls,
         runner: AgentBatchRunner | None = None,
         target_provider: Callable[[], Sequence[BatchTarget]] | None = None,
     ) -> None:
-        if TYPE_CHECKING:  # pragma: no cover - help type checkers
-            from .panel import AgentChatPanel
-
         self._panel = panel
         self._controls = controls
         self._target_provider = target_provider
         self._runner = runner or AgentBatchRunner(
             submit_prompt=panel._submit_batch_prompt,
             create_conversation=panel._create_batch_conversation,
-            ensure_conversation_id=lambda conv: getattr(conv, "conversation_id"),
+            ensure_conversation_id=lambda conv: conv.conversation_id,
             on_state_changed=self.update_ui,
             context_factory=panel._build_batch_context,
             prepare_conversation=panel._prepare_batch_conversation,

--- a/app/ui/agent_chat_panel/confirm_preferences.py
+++ b/app/ui/agent_chat_panel/confirm_preferences.py
@@ -13,7 +13,6 @@ from ...confirm import (
     RequirementUpdatePrompt,
     reset_requirement_update_preference,
 )
-from ...i18n import _
 
 logger = logging.getLogger("cookareq.ui.agent_chat_panel.confirm")
 

--- a/app/ui/agent_chat_panel/controller.py
+++ b/app/ui/agent_chat_panel/controller.py
@@ -215,10 +215,7 @@ class AgentRunController:
                     )
 
                 history_arg: tuple[dict[str, Any], ...] | None
-                if history_payload:
-                    history_arg = history_payload
-                else:
-                    history_arg = None
+                history_arg = history_payload or None
 
                 return agent.run_command(
                     normalized_prompt,

--- a/app/ui/agent_chat_panel/panel.py
+++ b/app/ui/agent_chat_panel/panel.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import datetime
 import json
 import logging
 import textwrap
@@ -19,7 +18,6 @@ from ...confirm import confirm
 from ...i18n import _
 from ...llm.spec import SYSTEM_PROMPT, TOOLS
 from ...llm.tokenizer import TokenCountResult, combine_token_counts, count_text_tokens
-from ...util.cancellation import OperationCancelledError
 from ...util.time import utc_now_iso
 from ..chat_entry import ChatConversation, ChatEntry
 from ..helpers import (
@@ -55,15 +53,13 @@ from .project_settings import (
 )
 from .layout import AgentChatLayoutBuilder
 from .settings_dialog import AgentProjectSettingsDialog
-from .time_formatting import format_entry_timestamp, format_last_activity
+from .time_formatting import format_last_activity
 from .token_usage import ContextTokenBreakdown
 from .tool_summaries import (
-    format_value_snippet,
     render_tool_summaries_plain,
     summarize_tool_results,
-    shorten_text,
 )
-from .transcript_view import TranscriptCallbacks, TranscriptView
+from .transcript_view import TranscriptView
 
 
 logger = logging.getLogger("cookareq.ui.agent_chat_panel")
@@ -326,7 +322,7 @@ class AgentChatPanel(ConfirmPreferencesMixin, wx.Panel):
         self.input = layout.input_control
         self._stop_btn = layout.stop_button
         self._send_btn = layout.send_button
-        batch_controls = layout.batch_controls
+        self._batch_controls = layout.batch_controls
         self.activity = layout.activity_indicator
         self.status_label = layout.status_label
         self._project_settings_button = layout.project_settings_button
@@ -374,7 +370,7 @@ class AgentChatPanel(ConfirmPreferencesMixin, wx.Panel):
         if self._layout is not None:
             self._batch_section = AgentBatchSection(
                 panel=self,
-                controls=self._layout.batch_controls,
+                controls=self._batch_controls,
                 target_provider=self._batch_target_provider,
             )
         else:

--- a/app/ui/agent_chat_panel/tool_summaries.py
+++ b/app/ui/agent_chat_panel/tool_summaries.py
@@ -638,7 +638,7 @@ def format_value_snippet(value: Any) -> str:
         return joined
     if isinstance(value, Mapping):
         keys: list[str] = []
-        for key in value.keys():
+        for key in value:
             keys.append(normalize_for_display(str(key)))
             if len(keys) >= 5:
                 break

--- a/app/ui/chat_entry.py
+++ b/app/ui/chat_entry.py
@@ -28,7 +28,11 @@ def _recalculate_pair_token_info(prompt: str, response: str) -> TokenCountResult
     if tokens is None:
         return TokenCountResult.unavailable(model=model, reason=combined.reason)
     if combined.approximate:
-        return TokenCountResult.approximate(tokens, model=model, reason=combined.reason)
+        return TokenCountResult.approximate_result(
+            tokens,
+            model=model,
+            reason=combined.reason,
+        )
     return TokenCountResult.exact(tokens, model=model, reason=combined.reason)
 
 

--- a/app/ui/detached_editor.py
+++ b/app/ui/detached_editor.py
@@ -158,10 +158,9 @@ class DetachedEditorFrame(wx.Frame):
             event.Skip()
             return
 
-        if self.editor.is_dirty():
-            if not confirm(_("Discard unsaved changes?")):
-                event.Veto()
-                return
+        if self.editor.is_dirty() and not confirm(_("Discard unsaved changes?")):
+            event.Veto()
+            return
         if self._on_close:
             self._on_close(self)
         event.Skip()

--- a/app/ui/document_tree.py
+++ b/app/ui/document_tree.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from contextlib import suppress
 from typing import Callable, Dict
 
 import wx
@@ -119,7 +120,7 @@ class DocumentTree(wx.Panel):
 
         def _next_menu_id() -> int:
             if hasattr(wx, "ID_ANY"):
-                return getattr(wx, "ID_ANY")
+                return wx.ID_ANY
             if hasattr(wx, "Window") and hasattr(wx.Window, "NewControlId"):
                 return wx.Window.NewControlId()
             # Fallback for extremely limited stubs.
@@ -156,15 +157,10 @@ class DocumentTree(wx.Panel):
             pos = get_position()
             screen_to_client = getattr(self.tree, "ScreenToClient", None)
             if screen_to_client and pos is not None:
-                try:
+                with suppress(Exception):  # pragma: no cover - backend quirks
                     pos = screen_to_client(pos)
-                except Exception:  # pragma: no cover - backend quirks
-                    pass
             hit = hit_test(pos)
-            if isinstance(hit, tuple):
-                hit_item = hit[0]
-            else:
-                hit_item = hit
+            hit_item = hit[0] if isinstance(hit, tuple) else hit
             if hit_item and hasattr(hit_item, "IsOk") and hit_item.IsOk():
                 if hasattr(event, "Skip"):
                     event.Skip()

--- a/app/ui/editor_panel.py
+++ b/app/ui/editor_panel.py
@@ -478,10 +478,7 @@ class EditorPanel(wx.Panel):
         rid = str(link.get("rid", "")).strip()
         title = str(link.get("title", "")).strip()
         doc_title = str(link.get("doc_title", "")).strip()
-        if title:
-            text = f"{rid} — {title}" if rid else title
-        else:
-            text = rid
+        text = (f"{rid} — {title}" if rid else title) if title else rid
         if doc_title and doc_title not in text:
             suffix = f"({doc_title})"
             text = f"{text} {suffix}" if text else suffix
@@ -792,7 +789,9 @@ class EditorPanel(wx.Panel):
             try:
                 revision = int(revision_text)
             except (TypeError, ValueError):
-                raise ValueError(_("Revision must be a positive integer"))
+                raise ValueError(
+                    _("Revision must be a positive integer")
+                ) from None
         else:
             revision = 1
         if revision <= 0:
@@ -977,7 +976,7 @@ class EditorPanel(wx.Panel):
             try:
                 root = Path(self.directory).parent
                 doc = load_document(root / prefix)
-                data, _ = load_item(root / prefix, doc, item_id)
+                data, _metadata = load_item(root / prefix, doc, item_id)
                 title = str(data.get("title", ""))
                 fingerprint = requirement_fingerprint(data)
                 doc_title = doc.title

--- a/app/ui/helpers.py
+++ b/app/ui/helpers.py
@@ -415,11 +415,8 @@ def format_error_message(error: object, *, fallback: str | None = None) -> str:
         parts = [str(part) for part in (code, message) if part]
         if parts:
             return ": ".join(parts)
-    if isinstance(error, BaseException):
-        text = str(error)
-        if text:
-            return text
-    elif error:
+    text: str | None = None
+    if isinstance(error, BaseException) or error:
         text = str(error)
         if text:
             return text

--- a/app/ui/labels_dialog.py
+++ b/app/ui/labels_dialog.py
@@ -211,7 +211,9 @@ class LabelsDialog(wx.Dialog):
             if not new_key:
                 dlg.Destroy()
                 return
-            existing = {l.key for i, l in enumerate(self._labels) if i != idx}
+            existing = {
+                label.key for i, label in enumerate(self._labels) if i != idx
+            }
             if new_key in existing:
                 wx.MessageBox(_("Label already exists"), _("Error"), style=wx.ICON_ERROR)
             else:

--- a/app/ui/list_panel.py
+++ b/app/ui/list_panel.py
@@ -150,10 +150,8 @@ class RequirementsListCtrl(wx.ListCtrl):
                 _apply_item_selection(self, idx, False)
             self._marquee_base.clear()
         if not self.HasCapture():  # pragma: no cover - defensive
-            try:
+            with suppress(Exception):  # pragma: no cover - defensive
                 self.CaptureMouse()
-            except Exception:  # pragma: no cover - defensive
-                pass
 
     def _finish_marquee(self) -> None:
         self._clear_overlay()
@@ -483,7 +481,7 @@ class ListPanel(wx.Panel, ColumnSorterMixin):
         dc.SetBackground(wx.Brush(self.list.GetBackgroundColour()))
         dc.Clear()
         x = 0
-        for name, w in zip(names, widths):
+        for name, w in zip(names, widths, strict=True):
             colour = wx.Colour(self._label_color(name))
             dc.SetBrush(wx.Brush(colour))
             dc.SetPen(wx.Pen(colour))

--- a/app/ui/main_frame/agent.py
+++ b/app/ui/main_frame/agent.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Mapping, Sequence
+from contextlib import suppress
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable
 
@@ -133,10 +134,8 @@ class MainFrameAgentMixin:
         ids: list[int] = []
         panel = getattr(self, "panel", None)
         if panel is not None and hasattr(panel, "get_selected_ids"):
-            try:
+            with suppress(Exception):  # pragma: no cover - defensive
                 ids.extend(panel.get_selected_ids())
-            except Exception:  # pragma: no cover - defensive
-                pass
         current = getattr(self, "_selected_requirement_id", None)
         if isinstance(current, int) and current not in ids:
             ids.append(current)

--- a/app/ui/main_frame/documents.py
+++ b/app/ui/main_frame/documents.py
@@ -307,10 +307,7 @@ class MainFrameDocumentsMixin:
                 filter_details += f" ({filter_summary})"
         elif filter_summary:
             filter_details = f"; filter summary={filter_summary}"
-        if doc_path:
-            location = f" from {doc_path}"
-        else:
-            location = ""
+        location = f" from {doc_path}" if doc_path else ""
         logger.info(
             "Document %s loaded%s: %s requirement(s), %s visible after filters%s; %s parent(s) with %s derived child link(s)",
             prefix,

--- a/app/ui/main_frame/sections.py
+++ b/app/ui/main_frame/sections.py
@@ -312,10 +312,12 @@ class MainFrameSectionsMixin:
 
         if not self.editor_menu_item:
             return
-        if not self.editor_menu_item.IsChecked():
-            if not self._confirm_discard_changes():
-                self.editor_menu_item.Check(True)
-                return
+        if (
+            not self.editor_menu_item.IsChecked()
+            and not self._confirm_discard_changes()
+        ):
+            self.editor_menu_item.Check(True)
+            return
         self._apply_editor_visibility(persist=True)
 
     # ------------------------------------------------------------------

--- a/app/ui/main_frame/settings.py
+++ b/app/ui/main_frame/settings.py
@@ -6,7 +6,6 @@ from typing import TYPE_CHECKING
 
 import wx
 
-from ...i18n import _
 from ...settings import LLMSettings, MCPSettings
 
 if TYPE_CHECKING:  # pragma: no cover - import for type checking only

--- a/app/ui/splitter_utils.py
+++ b/app/ui/splitter_utils.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterator
-from contextlib import contextmanager
+from contextlib import contextmanager, suppress
 
 import wx
 
@@ -94,10 +94,8 @@ class _SplitterHighlighter:
         desired = max(self.thickness, _MIN_THICKNESS)
         current = int(getattr(self.splitter, "SashSize", 0) or 0)
         if current < desired:
-            try:
+            with suppress(Exception):
                 self.splitter.SashSize = desired
-            except Exception:
-                pass
 
     def _on_paint(self, event: wx.Event) -> None:
         event.Skip()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,3 +31,10 @@ build-backend = "setuptools.build_meta"
 line-length = 88
 target-version = "py312"
 extend-exclude = ["dist"]
+
+[tool.ruff.lint]
+extend-select = [
+    "B",
+    "C4",
+    "SIM",
+]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,11 +6,14 @@ import contextlib
 from types import MethodType, ModuleType
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Mapping, Sequence
+from typing import TYPE_CHECKING, Mapping, Sequence
 
 import pytest
 
 from tests.env_utils import load_dotenv_variables
+
+if TYPE_CHECKING:  # pragma: no cover - typing hints for wx fixtures
+    import wx
 
 # Load the nearest .env file once so integration tests that rely on external
 # services (for example OpenRouter) automatically receive credentials without
@@ -81,12 +84,13 @@ class SuiteDefinition:
         if not self.include_by_default:
             return False
 
-        if markers & exclude:
-            return False
-        if self._exclude_paths and _path_matches_prefixes(path, self._exclude_paths):
-            return False
-
-        return True
+        return not (
+            markers & exclude
+            or (
+                self._exclude_paths
+                and _path_matches_prefixes(path, self._exclude_paths)
+            )
+        )
 
 
 SUITES: Mapping[str, SuiteDefinition] = {

--- a/tests/gui/test_agent_chat_panel.py
+++ b/tests/gui/test_agent_chat_panel.py
@@ -851,7 +851,6 @@ def test_transcript_message_panel_shows_reasoning(wx_app):
 
 def test_transcript_message_panel_orders_supplements_after_messages(wx_app):
     wx = pytest.importorskip("wx")
-    from app.i18n import _
     from app.ui.widgets.chat_message import MessageBubble
 
     frame = wx.Frame(None)
@@ -910,7 +909,6 @@ def test_transcript_message_panel_orders_supplements_after_messages(wx_app):
         ), "context pane should be nested under the user message bubble"
 
         reasoning_pane = top_level_collapsible[0]
-        context_pane = context_panes[0]
 
         def collect_labels(window: wx.Window) -> list[str]:
             labels: list[str] = []

--- a/tests/gui/test_agent_context.py
+++ b/tests/gui/test_agent_context.py
@@ -5,6 +5,8 @@ import pytest
 
 pytestmark = pytest.mark.gui
 
+wx = pytest.importorskip("wx")
+
 
 def _copy_sample_repository(tmp_path: Path) -> Path:
     source = Path(__file__).resolve().parents[2] / "requirements"
@@ -14,7 +16,6 @@ def _copy_sample_repository(tmp_path: Path) -> Path:
 
 
 def _create_main_frame(tmp_path: Path):
-    wx = pytest.importorskip("wx")
     from app.config import ConfigManager
     from app.settings import MCPSettings
     from app.ui.main_frame import MainFrame
@@ -31,7 +32,6 @@ def _create_main_frame(tmp_path: Path):
 def test_agent_context_includes_selected_requirements(tmp_path, wx_app):
     repository = _copy_sample_repository(tmp_path)
     frame = _create_main_frame(tmp_path)
-    wx = pytest.importorskip("wx")
 
     try:
         wx_app.Yield()

--- a/tests/gui/test_agent_tool_updates.py
+++ b/tests/gui/test_agent_tool_updates.py
@@ -36,7 +36,7 @@ def _copy_sample_repository(tmp_path: Path) -> Path:
 
 
 def _create_main_frame(tmp_path: Path):
-    wx = pytest.importorskip("wx")
+    _wx = pytest.importorskip("wx")
     from app.config import ConfigManager
     from app.settings import MCPSettings
     from app.ui.main_frame import MainFrame
@@ -50,7 +50,7 @@ def _create_main_frame(tmp_path: Path):
 
 
 def test_agent_tool_updates_reflect_in_ui(tmp_path, wx_app):
-    wx = pytest.importorskip("wx")
+    _wx = pytest.importorskip("wx")
 
     repository = _copy_sample_repository(tmp_path)
     frame = _create_main_frame(tmp_path)
@@ -135,7 +135,7 @@ def test_agent_tool_updates_reflect_in_ui(tmp_path, wx_app):
 
 
 def test_agent_streaming_tool_updates_refresh_list_during_run(tmp_path, wx_app):
-    wx = pytest.importorskip("wx")
+    _wx = pytest.importorskip("wx")
 
     repository = _copy_sample_repository(tmp_path)
     frame = _create_main_frame(tmp_path)

--- a/tests/gui/test_editor_dirty.py
+++ b/tests/gui/test_editor_dirty.py
@@ -1,5 +1,7 @@
 """Tests for editor dirty state tracking."""
 
+from contextlib import suppress
+
 import pytest
 
 
@@ -167,9 +169,7 @@ def test_detached_editor_cancel_closes_window_without_saving(wx_app, tmp_path):
             with pytest.raises(RuntimeError):
                 frame.IsShown()
         finally:
-            try:
+            with suppress(RuntimeError):
                 frame.Destroy()
-            except RuntimeError:
-                pass
     finally:
         parent.Destroy()

--- a/tests/gui/test_help_static_box.py
+++ b/tests/gui/test_help_static_box.py
@@ -1,3 +1,5 @@
+from contextlib import suppress
+
 import pytest
 import wx
 
@@ -40,10 +42,8 @@ def test_help_static_box_handles_prepend_and_insert(wx_app):
     frame.Destroy()
     app = wx.GetApp()
     if app is not None:
-        try:
+        with suppress(Exception):
             app.Yield(True)
-        except Exception:
-            pass
 
 
 def test_calculate_popup_position_prefers_right():

--- a/tests/gui/test_link_column_width.py
+++ b/tests/gui/test_link_column_width.py
@@ -1,7 +1,6 @@
 import pytest
 import wx
 
-from app.core.model import Priority, Requirement, RequirementType, Status, Verification
 from app.ui.editor_panel import EditorPanel
 
 pytestmark = pytest.mark.gui
@@ -11,18 +10,6 @@ def test_title_column_expands_to_available_width(wx_app, monkeypatch):
     frame = wx.Frame(None)
     panel = EditorPanel(frame)
     panel.set_directory("dummy")
-
-    req = Requirement(
-        id=1,
-        title="T",
-        statement="",
-        type=RequirementType.REQUIREMENT,
-        status=Status.DRAFT,
-        owner="",
-        priority=Priority.MEDIUM,
-        source="",
-        verification=Verification.ANALYSIS,
-    )
 
     frame.SetClientSize((400, 300))
     frame.Show()

--- a/tests/gui/test_link_titles.py
+++ b/tests/gui/test_link_titles.py
@@ -2,7 +2,6 @@ import pytest
 import wx
 
 from app.core.document_store import Document
-from app.core.model import Priority, Requirement, RequirementType, Status, Verification
 from app.ui.editor_panel import EditorPanel
 
 pytestmark = pytest.mark.gui
@@ -12,18 +11,6 @@ def test_added_link_shows_id_and_title(wx_app, monkeypatch):
     frame = wx.Frame(None)
     panel = EditorPanel(frame)
     panel.set_directory("dummy")
-
-    req = Requirement(
-        id=123,
-        title="Sample",
-        statement="",
-        type=RequirementType.REQUIREMENT,
-        status=Status.DRAFT,
-        owner="",
-        priority=Priority.MEDIUM,
-        source="",
-        verification=Verification.ANALYSIS,
-    )
 
     panel.links_id.SetValue("SYS123")
     panel._on_add_link_generic("links")

--- a/tests/gui/test_list_panel.py
+++ b/tests/gui/test_list_panel.py
@@ -61,7 +61,6 @@ def test_list_panel_has_filter_and_list(stubbed_list_panel_env):
 
 def test_column_click_sorts(stubbed_list_panel_env):
     env = stubbed_list_panel_env
-    wx_stub = env.wx
     panel = env.create_panel()
     panel.set_columns(["id"])
     panel.set_requirements(
@@ -165,7 +164,6 @@ def test_apply_status_filter(stubbed_list_panel_env):
 
 def test_labels_column_uses_imagelist(stubbed_list_panel_env):
     env = stubbed_list_panel_env
-    wx_stub = env.wx
     panel = env.create_panel()
     panel.set_columns(["labels"])
     panel.set_requirements([

--- a/tests/gui/test_main_clone_derive.py
+++ b/tests/gui/test_main_clone_derive.py
@@ -18,6 +18,8 @@ from app.settings import MCPSettings
 from app.ui.controllers import DocumentsController
 from app.ui.requirement_model import RequirementModel
 
+wx = pytest.importorskip("wx")
+
 pytestmark = pytest.mark.gui
 
 
@@ -49,7 +51,6 @@ def _req(req_id: int, title: str) -> Requirement:
 
 
 def _prepare_frame(tmp_path, extra_requirements=None):
-    wx = pytest.importorskip("wx")
     import app.ui.main_frame as main_frame_mod
 
     importlib.reload(main_frame_mod)
@@ -88,7 +89,6 @@ def _prepare_frame(tmp_path, extra_requirements=None):
 
 def test_clone_creates_new_requirement(wx_app, tmp_path):
     frame = _prepare_frame(tmp_path)
-    wx = pytest.importorskip("wx")
 
     try:
         wx_app.Yield()
@@ -112,7 +112,6 @@ def test_clone_creates_new_requirement(wx_app, tmp_path):
 
 def test_derive_creates_linked_requirement(wx_app, tmp_path):
     frame = _prepare_frame(tmp_path)
-    wx = pytest.importorskip("wx")
 
     try:
         wx_app.Yield()
@@ -149,7 +148,6 @@ def test_derive_creates_linked_requirement(wx_app, tmp_path):
 def test_delete_many_removes_requirements(monkeypatch, wx_app, tmp_path):
     extra = [_req(2, "Second"), _req(3, "Third")]
     frame = _prepare_frame(tmp_path, extra_requirements=extra)
-    wx = pytest.importorskip("wx")
     import app.ui.main_frame as main_frame_mod
 
     try:
@@ -185,7 +183,6 @@ def test_delete_many_removes_requirements(monkeypatch, wx_app, tmp_path):
 
 def test_save_derived_requirement_with_missing_parent_rid(monkeypatch, wx_app, tmp_path):
     frame = _prepare_frame(tmp_path)
-    _ = pytest.importorskip("wx")
     import app.ui.error_dialog as error_dialog_module
     import app.ui.main_frame as main_frame_mod
 

--- a/tests/gui/test_requirement_import_dialog.py
+++ b/tests/gui/test_requirement_import_dialog.py
@@ -17,7 +17,7 @@ def _select_path(dialog, path):
 
 
 def test_import_dialog_csv_autopreview_enables_ok(wx_app, tmp_path):
-    wx = pytest.importorskip("wx")
+    _wx = pytest.importorskip("wx")
     from app.ui.import_dialog import RequirementImportDialog
 
     csv_path = tmp_path / "requirements.csv"
@@ -57,7 +57,7 @@ def test_import_dialog_csv_autopreview_enables_ok(wx_app, tmp_path):
 
 
 def test_import_dialog_requires_statement_mapping(wx_app, tmp_path):
-    wx = pytest.importorskip("wx")
+    _wx = pytest.importorskip("wx")
     from app.ui.import_dialog import RequirementImportDialog
 
     csv_path = tmp_path / "data.csv"

--- a/tests/gui/test_splitter_regressions.py
+++ b/tests/gui/test_splitter_regressions.py
@@ -1,5 +1,4 @@
 import pytest
-import wx
 
 from app.config import ConfigManager
 from app.settings import MCPSettings

--- a/tests/gui/test_trace_matrix_window.py
+++ b/tests/gui/test_trace_matrix_window.py
@@ -49,7 +49,7 @@ def _requirement(
 def test_trace_matrix_frame_renders_links(wx_app, tmp_path):
     """The matrix grid should highlight linked pairs and show details."""
 
-    wx = pytest.importorskip("wx")
+    _wx = pytest.importorskip("wx")
 
     controller = DocumentsController(tmp_path, RequirementModel())
 

--- a/tests/integration/test_local_agent.py
+++ b/tests/integration/test_local_agent.py
@@ -862,7 +862,9 @@ def test_run_command_streams_tool_results_to_callback():
     assert [
         payload.get("agent_status") for payload in result["tool_results"]
     ] == ["completed", "completed"]
-    for streamed, final in zip(completed_updates, result["tool_results"]):
+    for streamed, final in zip(
+        completed_updates, result["tool_results"], strict=True
+    ):
         assert streamed == final
         assert streamed is not final
 

--- a/tests/llm_utils.py
+++ b/tests/llm_utils.py
@@ -82,10 +82,7 @@ def make_openai_mock(responses: dict[str, object]):
             queue = prepared.get(user_msg)
             if queue is None:
                 queue = prepared.setdefault(user_msg, [("list_requirements", {})])
-            if len(queue) > 1:
-                result = queue.pop(0)
-            else:
-                result = queue[0]
+            result = queue.pop(0) if len(queue) > 1 else queue[0]
             if isinstance(result, Exception):
                 raise result
             if isinstance(result, str):

--- a/tests/unit/test_config_manager.py
+++ b/tests/unit/test_config_manager.py
@@ -436,7 +436,7 @@ def test_save_layout_tracks_doc_tree_collapse(tmp_path, wx_app):
     editor_splitter.SplitVertically(wx.Panel(editor_splitter), wx.Panel(editor_splitter))
     doc_splitter.SplitVertically(wx.Panel(doc_splitter), editor_splitter)
     panel = DummyListPanel()
-    log_console = wx.TextCtrl(main_splitter)
+    _log_console = wx.TextCtrl(main_splitter)
 
     frame.SetSize((820, 620))
     doc_splitter.SetSashPosition(250)


### PR DESCRIPTION
## Summary
- enable Ruff's flake8-comprehensions (C4) and flake8-simplify (SIM) rules and document the stricter linting scope
- refactor agent, core, and UI helpers to satisfy the new rules by collapsing redundant branches and replacing try/except shims with contextlib.suppress
- update supporting tests and utilities to align with the simplified control-flow expectations

## Testing
- `ruff check`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68d8346eb8248320b1b66bd08174bb05