### PR TITLE
Enable Ruff pyupgrade rules and modernize annotations

### DIFF
--- a/app/agent/local_agent.py
+++ b/app/agent/local_agent.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 import asyncio
 import json
 from dataclasses import dataclass
-from collections.abc import Sequence
-from typing import Any, Awaitable, Callable, Mapping, Protocol, runtime_checkable
+from collections.abc import Awaitable, Callable, Mapping, Sequence
+from typing import Any, Protocol, runtime_checkable
 
 from ..confirm import (
     ConfirmDecision,
@@ -799,7 +799,7 @@ class LocalAgent:
 
     def _prepare_invalid_tool_calls(
         self, raw_calls: Sequence[Any] | None
-    ) -> list["_ValidationToolCallPayload"]:
+    ) -> list[_ValidationToolCallPayload]:
         if not isinstance(raw_calls, Sequence) or isinstance(
             raw_calls, (str, bytes, bytearray)
         ):
@@ -1028,7 +1028,7 @@ class AgentLoopRunner:
     def __init__(
         self,
         *,
-        agent: "LocalAgent",
+        agent: LocalAgent,
         conversation: list[Mapping[str, Any]],
         cancellation: CancellationEvent | None,
         on_tool_result: Callable[[Mapping[str, Any]], None] | None,

--- a/app/cli/commands.py
+++ b/app/cli/commands.py
@@ -10,7 +10,8 @@ import sys
 from copy import deepcopy
 from dataclasses import MISSING, asdict, dataclass, field, fields
 from pathlib import Path
-from typing import Any, Callable, Mapping, TextIO
+from typing import Any, TextIO
+from collections.abc import Callable, Mapping
 
 from app.confirm import confirm
 from app.core.document_store import (

--- a/app/config.py
+++ b/app/config.py
@@ -83,16 +83,16 @@ FIELD_BINDINGS: dict[str, FieldBinding] = {
 class ListPanelLike(Protocol):
     """Protocol for panels persisting column layout state."""
 
-    def load_column_widths(self, cfg: "ConfigManager") -> None:
+    def load_column_widths(self, cfg: ConfigManager) -> None:
         """Restore column widths from *cfg*."""
 
-    def load_column_order(self, cfg: "ConfigManager") -> None:
+    def load_column_order(self, cfg: ConfigManager) -> None:
         """Restore column order from *cfg*."""
 
-    def save_column_widths(self, cfg: "ConfigManager") -> None:
+    def save_column_widths(self, cfg: ConfigManager) -> None:
         """Persist current column widths to *cfg*."""
 
-    def save_column_order(self, cfg: "ConfigManager") -> None:
+    def save_column_order(self, cfg: ConfigManager) -> None:
         """Persist current column order to *cfg*."""
 
 

--- a/app/confirm.py
+++ b/app/confirm.py
@@ -6,7 +6,8 @@ import json
 import threading
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any, Callable, Iterable, Sequence, TypeVar
+from typing import Any, ParamSpec, TypeVar
+from collections.abc import Callable, Iterable, Sequence
 
 ConfirmCallback = Callable[[str], bool]
 _callback: ConfirmCallback | None = None
@@ -44,6 +45,7 @@ _requirement_update_callback: RequirementUpdateConfirmCallback | None = None
 _requirement_update_always: bool = False
 
 _T = TypeVar("_T")
+_P = ParamSpec("_P")
 
 
 def set_confirm(callback: ConfirmCallback) -> None:
@@ -98,7 +100,7 @@ def confirm_requirement_update(prompt: RequirementUpdatePrompt) -> ConfirmDecisi
 
 
 def _call_in_wx_main_thread(
-    func: Callable[..., _T], /, *args: Any, **kwargs: Any
+    func: Callable[_P, _T], /, *args: _P.args, **kwargs: _P.kwargs
 ) -> _T:
     """Execute *func* on the wx main thread and return its result."""
 

--- a/app/core/document_store/__init__.py
+++ b/app/core/document_store/__init__.py
@@ -2,7 +2,8 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, List, Mapping
+from typing import TYPE_CHECKING, Any
+from collections.abc import Mapping
 
 if TYPE_CHECKING:  # pragma: no cover - import for typing only
     from ..model import Requirement
@@ -56,7 +57,7 @@ class DocumentLabels:
     """Label configuration for a document."""
 
     allow_freeform: bool = False
-    defs: List[LabelDef] = field(default_factory=list)
+    defs: list[LabelDef] = field(default_factory=list)
 
 
 @dataclass(init=False)
@@ -96,7 +97,7 @@ class Document:
 class RequirementPage:
     """Represent a paginated slice of requirements."""
 
-    items: list["Requirement"]
+    items: list[Requirement]
     total: int
     page: int
     per_page: int

--- a/app/core/document_store/documents.py
+++ b/app/core/document_store/documents.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 from dataclasses import asdict
 from pathlib import Path
-from typing import Mapping, Optional
+from collections.abc import Mapping
 
 from . import Document, DocumentLabels, LabelDef, ValidationError
 
@@ -143,7 +143,7 @@ def collect_labels(prefix: str, docs: Mapping[str, Document]) -> tuple[set[str],
 
 def validate_labels(
     prefix: str, labels: list[str], docs: Mapping[str, Document]
-) -> Optional[str]:
+) -> str | None:
     """Validate ``labels`` for items under document ``prefix``."""
 
     allowed, freeform = collect_labels(prefix, docs)

--- a/app/core/document_store/items.py
+++ b/app/core/document_store/items.py
@@ -5,7 +5,8 @@ import re
 from contextlib import suppress
 from dataclasses import fields
 from pathlib import Path
-from typing import Any, Callable, Mapping, Sequence
+from typing import Any
+from collections.abc import Callable, Mapping, Sequence
 
 from ..model import (
     Link,
@@ -643,10 +644,10 @@ def move_requirement(
                 if link.rid == rid:
                     if not is_ancestor(doc.prefix, new_prefix, docs_map):
                         raise ValidationError(
-                            (
-                                "cannot move {rid}: link from {child} would violate "
+                            
+                                f"cannot move {rid}: link from {rid_for(doc, other_id)} would violate "
                                 "document hierarchy"
-                            ).format(rid=rid, child=rid_for(doc, other_id))
+                            
                         )
                     link.rid = new_rid
                     link.fingerprint = None

--- a/app/core/document_store/links.py
+++ b/app/core/document_store/links.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 import shutil
 from pathlib import Path
-from typing import Any, Iterable, Mapping
+from typing import Any
+from collections.abc import Iterable, Mapping
 
 from ..model import Link, Requirement, requirement_fingerprint, requirement_from_dict, requirement_to_dict
 from . import Document, ValidationError

--- a/app/core/model.py
+++ b/app/core/model.py
@@ -6,7 +6,8 @@ import hashlib
 import json
 from dataclasses import asdict, dataclass, field
 from enum import Enum
-from typing import Any, Mapping
+from typing import Any
+from collections.abc import Mapping
 
 from ..util.time import normalize_timestamp
 
@@ -285,7 +286,7 @@ class Link:
     suspect: bool = False
 
     @classmethod
-    def from_raw(cls, raw: Any) -> "Link":
+    def from_raw(cls, raw: Any) -> Link:
         """Create :class:`Link` from ``raw`` representation."""
 
         if isinstance(raw, str):

--- a/app/core/requirement_export.py
+++ b/app/core/requirement_export.py
@@ -3,10 +3,10 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import datetime, UTC
 from io import BytesIO
 from pathlib import Path
-from typing import Iterable, Mapping, Sequence
+from collections.abc import Iterable, Mapping, Sequence
 
 from reportlab.lib import colors
 from reportlab.lib.pagesizes import A4
@@ -129,7 +129,7 @@ def build_requirement_export(
     return RequirementExport(
         documents=ordered_documents,
         selected_prefixes=ordered_prefixes,
-        generated_at=datetime.now(timezone.utc),
+        generated_at=datetime.now(UTC),
     )
 
 
@@ -161,10 +161,10 @@ def render_requirements_markdown(export: RequirementExport, *, title: str | None
             req = view.requirement
             parts.append(f"### {req.rid} — {req.title or '(no title)'}")
             parts.append("")
-            parts.append("- **Type:** ``{}``".format(req.type.value))
-            parts.append("- **Status:** ``{}``".format(req.status.value))
+            parts.append(f"- **Type:** ``{req.type.value}``")
+            parts.append(f"- **Status:** ``{req.status.value}``")
             if req.priority:
-                parts.append("- **Priority:** ``{}``".format(req.priority.value))
+                parts.append(f"- **Priority:** ``{req.priority.value}``")
             if req.owner:
                 parts.append(f"- **Owner:** {req.owner}")
             if req.labels:
@@ -175,7 +175,7 @@ def render_requirements_markdown(export: RequirementExport, *, title: str | None
                 parts.append(f"- **Modified:** {req.modified_at}")
             if req.approved_at:
                 parts.append(f"- **Approved:** {req.approved_at}")
-            parts.append("- **Revision:** {}".format(req.revision))
+            parts.append(f"- **Revision:** {req.revision}")
             parts.append("")
 
             sections: list[tuple[str, str | None]] = [

--- a/app/core/requirement_import.py
+++ b/app/core/requirement_import.py
@@ -7,7 +7,8 @@ from enum import Enum
 import csv
 from pathlib import Path
 import re
-from typing import Any, Iterable, Sequence
+from typing import Any
+from collections.abc import Iterable, Sequence
 
 from .model import (
     Priority,
@@ -100,8 +101,7 @@ class TabularDataset:
 
     def iter_rows(self, *, skip_header: bool = False) -> Iterable[list[Any]]:
         start = 1 if skip_header and self._header_row is not None else 0
-        for row in self.rows[start:]:
-            yield row
+        yield from self.rows[start:]
 
     def row_count(self, *, skip_header: bool = False) -> int:
         if not self.rows:
@@ -199,7 +199,7 @@ class SequentialIDAllocator:
         self._used: set[int] = {int(value) for value in existing}
         self._next = max(start, max(self._used, default=0) + 1)
 
-    def clone(self) -> "SequentialIDAllocator":
+    def clone(self) -> SequentialIDAllocator:
         clone = SequentialIDAllocator(start=self._next)
         clone._used = set(self._used)
         clone._next = self._next

--- a/app/core/trace_matrix.py
+++ b/app/core/trace_matrix.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
-from typing import Mapping, Sequence
+from collections.abc import Mapping, Sequence
 
 from .document_store import (
     Document,

--- a/app/llm/client.py
+++ b/app/llm/client.py
@@ -51,7 +51,7 @@ class LLMResponse:
     content: str
     tool_calls: tuple[LLMToolCall, ...] = ()
     request_messages: tuple[dict[str, Any], ...] | None = None
-    reasoning: tuple["LLMReasoningSegment", ...] = ()
+    reasoning: tuple[LLMReasoningSegment, ...] = ()
 
 
 @dataclass(frozen=True, slots=True)

--- a/app/llm/harmony.py
+++ b/app/llm/harmony.py
@@ -6,7 +6,8 @@ import copy
 from dataclasses import dataclass
 from datetime import date
 import json
-from typing import Any, Iterable, Mapping, Sequence
+from typing import Any
+from collections.abc import Iterable, Mapping, Sequence
 
 
 HARMONY_KNOWLEDGE_CUTOFF = "2024-06"

--- a/app/llm/tokenizer.py
+++ b/app/llm/tokenizer.py
@@ -6,7 +6,7 @@ import importlib
 import importlib.util
 import sys
 from dataclasses import dataclass
-from typing import Iterable, Mapping
+from collections.abc import Iterable, Mapping
 
 __all__ = [
     "TokenCountResult",
@@ -31,7 +31,7 @@ class TokenCountResult:
         *,
         model: str | None = None,
         reason: str | None = None,
-    ) -> "TokenCountResult":
+    ) -> TokenCountResult:
         """Return a successful, precise token count."""
 
         return cls(tokens=max(tokens, 0), approximate=False, model=model, reason=reason)
@@ -43,7 +43,7 @@ class TokenCountResult:
         *,
         model: str | None = None,
         reason: str | None = None,
-    ) -> "TokenCountResult":
+    ) -> TokenCountResult:
         """Return an approximate token count."""
 
         return cls(tokens=max(tokens, 0), approximate=True, model=model, reason=reason)
@@ -54,7 +54,7 @@ class TokenCountResult:
         *,
         model: str | None = None,
         reason: str | None = None,
-    ) -> "TokenCountResult":
+    ) -> TokenCountResult:
         """Return a result indicating that tokenisation failed."""
 
         return cls(tokens=None, approximate=False, model=model, reason=reason)
@@ -73,7 +73,7 @@ class TokenCountResult:
         return payload
 
     @classmethod
-    def from_dict(cls, payload: Mapping[str, object]) -> "TokenCountResult":
+    def from_dict(cls, payload: Mapping[str, object]) -> TokenCountResult:
         """Create :class:`TokenCountResult` from a mapping."""
 
         tokens_value = payload.get("tokens")

--- a/app/mcp/events.py
+++ b/app/mcp/events.py
@@ -6,7 +6,8 @@ import logging
 from dataclasses import dataclass
 from pathlib import Path
 from threading import RLock
-from typing import Any, Callable, Mapping, Sequence
+from typing import Any
+from collections.abc import Callable, Mapping, Sequence
 
 logger = logging.getLogger("cookareq.mcp.events")
 

--- a/app/mcp/tools_write.py
+++ b/app/mcp/tools_write.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any, Mapping, Sequence
+from typing import Any
+from collections.abc import Mapping, Sequence
 
 from ..core import document_store as doc_store
 from ..core.model import requirement_to_dict

--- a/app/ui/agent_chat_panel/batch_runner.py
+++ b/app/ui/agent_chat_panel/batch_runner.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass
 from enum import Enum, auto
-from typing import Any, Callable, Mapping, Sequence
+from typing import Any
+from collections.abc import Callable, Mapping, Sequence
 
 from ...util.time import utc_now_iso
 

--- a/app/ui/agent_chat_panel/batch_ui.py
+++ b/app/ui/agent_chat_panel/batch_ui.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Callable, Sequence
+from typing import TYPE_CHECKING
+from collections.abc import Callable, Sequence
 
 import logging
 import textwrap

--- a/app/ui/agent_chat_panel/confirm_preferences.py
+++ b/app/ui/agent_chat_panel/confirm_preferences.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 import logging
 from enum import Enum
-from typing import Any, Callable
+from typing import Any
+from collections.abc import Callable
 
 import wx
 

--- a/app/ui/agent_chat_panel/controller.py
+++ b/app/ui/agent_chat_panel/controller.py
@@ -6,7 +6,8 @@ import logging
 from collections.abc import Mapping, Sequence
 from concurrent.futures import Future
 from dataclasses import dataclass
-from typing import Any, Callable
+from typing import Any
+from collections.abc import Callable
 
 import wx
 

--- a/app/ui/agent_chat_panel/execution.py
+++ b/app/ui/agent_chat_panel/execution.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Callable, Protocol
+from typing import Any, Protocol
+from collections.abc import Callable
 
 from concurrent.futures import Future, ThreadPoolExecutor
 

--- a/app/ui/agent_chat_panel/history.py
+++ b/app/ui/agent_chat_panel/history.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Iterable, Sequence
 from pathlib import Path
-from typing import Callable
+from collections.abc import Callable
 
 import logging
 

--- a/app/ui/agent_chat_panel/history_store.py
+++ b/app/ui/agent_chat_panel/history_store.py
@@ -6,7 +6,7 @@ import json
 import logging
 from collections.abc import Mapping, Sequence
 from pathlib import Path
-from typing import Iterable
+from collections.abc import Iterable
 
 from ..chat_entry import ChatConversation
 from .paths import _default_history_path, _normalize_history_path
@@ -84,7 +84,7 @@ class HistoryStore:
             try:
                 conversation = ChatConversation.from_dict(item)
             except Exception:  # pragma: no cover - defensive
-                logger.exception("Failed to deserialize stored conversation", exc_info=True)
+                logger.exception("Failed to deserialize stored conversation")
                 continue
             entries_raw = item.get("entries")
             had_entries = isinstance(entries_raw, Sequence) and bool(entries_raw)

--- a/app/ui/agent_chat_panel/layout.py
+++ b/app/ui/agent_chat_panel/layout.py
@@ -55,7 +55,7 @@ class AgentChatLayout:
 class AgentChatLayoutBuilder:
     """Build and configure widgets composing :class:`AgentChatPanel`."""
 
-    def __init__(self, panel: "AgentChatPanel") -> None:
+    def __init__(self, panel: AgentChatPanel) -> None:
         self._panel = panel
 
     def build(self, *, status_help_text: str) -> AgentChatLayout:

--- a/app/ui/agent_chat_panel/panel.py
+++ b/app/ui/agent_chat_panel/panel.py
@@ -8,7 +8,8 @@ import textwrap
 import time
 from collections.abc import Mapping, Sequence
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any
+from collections.abc import Callable
 
 from concurrent.futures import ThreadPoolExecutor
 
@@ -1691,7 +1692,7 @@ class AgentChatPanel(ConfirmPreferencesMixin, wx.Panel):
         def _normalise_json_value(value: Any) -> Any:
             if isinstance(value, str):
                 stripped = value.strip()
-                if stripped.startswith("{") or stripped.startswith("["):
+                if stripped.startswith(("{", "[")):
                     try:
                         decoded = json.loads(stripped)
                     except (TypeError, ValueError):

--- a/app/ui/agent_chat_panel/project_settings.py
+++ b/app/ui/agent_chat_panel/project_settings.py
@@ -6,7 +6,8 @@ import json
 import logging
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Mapping
+from typing import Any
+from collections.abc import Mapping
 
 
 logger = logging.getLogger(__name__)
@@ -18,7 +19,7 @@ class AgentProjectSettings:
 
     custom_system_prompt: str = ""
 
-    def normalized(self) -> "AgentProjectSettings":
+    def normalized(self) -> AgentProjectSettings:
         """Return settings with whitespace-normalised fields."""
 
         return AgentProjectSettings(custom_system_prompt=self.custom_system_prompt.strip())
@@ -33,7 +34,7 @@ class AgentProjectSettings:
         }
 
     @classmethod
-    def from_dict(cls, payload: Mapping[str, Any]) -> "AgentProjectSettings":
+    def from_dict(cls, payload: Mapping[str, Any]) -> AgentProjectSettings:
         """Create :class:`AgentProjectSettings` from *payload* data."""
 
         prompt = payload.get("custom_system_prompt", "")

--- a/app/ui/agent_chat_panel/time_formatting.py
+++ b/app/ui/agent_chat_panel/time_formatting.py
@@ -17,7 +17,7 @@ def format_last_activity(timestamp: str | None) -> str:
     except ValueError:
         return timestamp
     if moment.tzinfo is None:
-        moment = moment.replace(tzinfo=datetime.timezone.utc)
+        moment = moment.replace(tzinfo=datetime.UTC)
     local_moment = moment.astimezone()
     now = datetime.datetime.now(local_moment.tzinfo)
     today = now.date()
@@ -41,7 +41,7 @@ def format_entry_timestamp(timestamp: str | None) -> str:
     except ValueError:
         return timestamp
     if moment.tzinfo is None:
-        moment = moment.replace(tzinfo=datetime.timezone.utc)
+        moment = moment.replace(tzinfo=datetime.UTC)
     local_moment = moment.astimezone()
     return local_moment.strftime("%Y-%m-%d %H:%M:%S")
 

--- a/app/ui/chat_entry.py
+++ b/app/ui/chat_entry.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Mapping, Sequence
+from typing import Any
+from collections.abc import Mapping, Sequence
 from uuid import uuid4
 
 from ..llm.tokenizer import (
@@ -121,7 +122,7 @@ class ChatEntry:
         return info
 
     @classmethod
-    def from_dict(cls, payload: Mapping[str, Any]) -> "ChatEntry":
+    def from_dict(cls, payload: Mapping[str, Any]) -> ChatEntry:
         """Create :class:`ChatEntry` instance from stored mapping."""
 
         prompt = str(payload.get("prompt", ""))
@@ -244,7 +245,7 @@ class ChatConversation:
     entries: list[ChatEntry] = field(default_factory=list)
 
     @classmethod
-    def new(cls) -> "ChatConversation":
+    def new(cls) -> ChatConversation:
         """Return empty conversation with generated identifiers."""
 
         now = utc_now_iso()
@@ -257,7 +258,7 @@ class ChatConversation:
         )
 
     @classmethod
-    def from_dict(cls, payload: Mapping[str, Any]) -> "ChatConversation":
+    def from_dict(cls, payload: Mapping[str, Any]) -> ChatConversation:
         """Create :class:`ChatConversation` from stored mapping."""
 
         conversation_id_raw = payload.get("id") or payload.get("conversation_id")

--- a/app/ui/controllers/documents.py
+++ b/app/ui/controllers/documents.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 import re
 from pathlib import Path
-from typing import Dict, Iterable, Tuple
+from collections.abc import Iterable
 
 from ...core.document_store import (
     Document,
@@ -34,12 +34,12 @@ class DocumentsController:
     model: object
 
     def __post_init__(self) -> None:
-        self.documents: Dict[str, Document] = {}
+        self.documents: dict[str, Document] = {}
 
     _PREFIX_RE = re.compile(r"^[A-Z][A-Z0-9_]*$")
 
     # ------------------------------------------------------------------
-    def load_documents(self) -> Dict[str, Document]:
+    def load_documents(self) -> dict[str, Document]:
         """Populate ``documents`` from ``root`` and return them."""
         self.documents = load_documents(self.root)
         return self.documents
@@ -236,7 +236,7 @@ class DocumentsController:
         return self.documents[prefix]
 
     # ------------------------------------------------------------------
-    def iter_links(self) -> Iterable[Tuple[str, str]]:
+    def iter_links(self) -> Iterable[tuple[str, str]]:
         """Yield ``(child_rid, parent_rid)`` pairs for requirements."""
 
         return doc_iter_links(self.root)

--- a/app/ui/detached_editor.py
+++ b/app/ui/detached_editor.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Callable
+from collections.abc import Callable
 
 import wx
 
@@ -27,8 +27,8 @@ class DetachedEditorFrame(wx.Frame):
         directory: Path,
         labels: list[LabelDef],
         allow_freeform: bool,
-        on_save: Callable[["DetachedEditorFrame"], bool],
-        on_close: Callable[["DetachedEditorFrame"], None] | None = None,
+        on_save: Callable[[DetachedEditorFrame], bool],
+        on_close: Callable[[DetachedEditorFrame], None] | None = None,
     ) -> None:
         """Create frame initialized with ``requirement`` contents."""
 

--- a/app/ui/document_tree.py
+++ b/app/ui/document_tree.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from contextlib import suppress
-from typing import Callable, Dict
+from collections.abc import Callable
 
 import wx
 
@@ -33,8 +33,8 @@ class DocumentTree(wx.Panel):
         sizer = wx.BoxSizer(wx.VERTICAL)
         sizer.Add(self.tree, 1, wx.EXPAND)
         self.SetSizer(sizer)
-        self._node_for_prefix: Dict[str, wx.TreeItemId] = {}
-        self._prefix_for_id: Dict[wx.TreeItemId, str] = {}
+        self._node_for_prefix: dict[str, wx.TreeItemId] = {}
+        self._prefix_for_id: dict[wx.TreeItemId, str] = {}
         self.root = self.tree.AddRoot(_("Documents"))
         self.tree.Bind(wx.EVT_TREE_SEL_CHANGED, self._handle_select)
         self.tree.Bind(wx.EVT_TREE_ITEM_MENU, self._show_context_menu)
@@ -42,7 +42,7 @@ class DocumentTree(wx.Panel):
             self.tree.Bind(wx.EVT_CONTEXT_MENU, self._show_background_menu)
         self._menu_target_prefix: str | None = None
 
-    def set_documents(self, docs: Dict[str, Document]) -> None:
+    def set_documents(self, docs: dict[str, Document]) -> None:
         """Populate tree from mapping ``docs``."""
         self.tree.DeleteChildren(self.root)
         self._node_for_prefix.clear()

--- a/app/ui/editor_panel.py
+++ b/app/ui/editor_panel.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 import logging
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any
+from collections.abc import Callable
 
 import wx
 import wx.adv

--- a/app/ui/error_dialog.py
+++ b/app/ui/error_dialog.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from typing import Optional
 
 import wx
 
@@ -12,7 +11,7 @@ from ..i18n import _
 class ErrorDialog(wx.Dialog):
     """Dialog showing a copyable error message."""
 
-    def __init__(self, parent: Optional[wx.Window], message: str, *, title: str) -> None:
+    def __init__(self, parent: wx.Window | None, message: str, *, title: str) -> None:
         super().__init__(
             parent,
             title=title,
@@ -46,7 +45,7 @@ class ErrorDialog(wx.Dialog):
         self._copy_btn.SetDefault()
         self.SetEscapeId(close_btn.GetId())
 
-    def _on_copy(self, event: Optional[wx.CommandEvent]) -> None:
+    def _on_copy(self, event: wx.CommandEvent | None) -> None:
         """Copy error text to clipboard."""
 
         clipboard = wx.TheClipboard
@@ -64,7 +63,7 @@ class ErrorDialog(wx.Dialog):
         if event is not None:
             event.Skip(False)
 
-    def _on_close(self, event: Optional[wx.CommandEvent]) -> None:
+    def _on_close(self, event: wx.CommandEvent | None) -> None:
         """Close dialog."""
 
         self.EndModal(wx.ID_OK)
@@ -73,10 +72,10 @@ class ErrorDialog(wx.Dialog):
 
 
 def show_error_dialog(
-    parent: Optional[wx.Window],
+    parent: wx.Window | None,
     message: str,
     *,
-    title: Optional[str] = None,
+    title: str | None = None,
 ) -> None:
     """Display an :class:`ErrorDialog` with ``message``."""
 

--- a/app/ui/helpers.py
+++ b/app/ui/helpers.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Callable
+from collections.abc import Callable
 
 import wx
 

--- a/app/ui/import_dialog.py
+++ b/app/ui/import_dialog.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
 import re
-from typing import Iterable
+from collections.abc import Iterable
 
 import wx
 import wx.grid as gridlib

--- a/app/ui/list_panel.py
+++ b/app/ui/list_panel.py
@@ -162,7 +162,7 @@ class RequirementsListCtrl(wx.ListCtrl):
             with suppress(Exception):
                 self.ReleaseMouse()
 
-    def _on_left_down(self, event: "wx.MouseEvent") -> None:
+    def _on_left_down(self, event: wx.MouseEvent) -> None:
         self._marquee_origin = event.GetPosition()
         self._marquee_base = set(self._selected_indices())
         self._marquee_additive = event.ControlDown() or event.CmdDown() or event.ShiftDown()
@@ -170,7 +170,7 @@ class RequirementsListCtrl(wx.ListCtrl):
         self._clear_overlay()
         event.Skip()
 
-    def _on_left_up(self, event: "wx.MouseEvent") -> None:
+    def _on_left_up(self, event: wx.MouseEvent) -> None:
         if self._marquee_origin and self._marquee_active:
             self._update_marquee_selection(event.GetPosition())
             self._finish_marquee()
@@ -181,7 +181,7 @@ class RequirementsListCtrl(wx.ListCtrl):
         self._clear_overlay()
         event.Skip()
 
-    def _on_mouse_move(self, event: "wx.MouseEvent") -> None:
+    def _on_mouse_move(self, event: wx.MouseEvent) -> None:
         if not self._marquee_origin or not event.LeftIsDown():
             event.Skip()
             return
@@ -195,7 +195,7 @@ class RequirementsListCtrl(wx.ListCtrl):
         self._update_marquee_selection(event.GetPosition())
         event.Skip(False)
 
-    def _on_mouse_leave(self, event: "wx.MouseEvent") -> None:
+    def _on_mouse_leave(self, event: wx.MouseEvent) -> None:
         if self._marquee_origin and not event.LeftIsDown():
             self._finish_marquee()
         event.Skip()

--- a/app/ui/main_frame/agent.py
+++ b/app/ui/main_frame/agent.py
@@ -6,7 +6,8 @@ import logging
 from collections.abc import Mapping, Sequence
 from contextlib import suppress
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable
+from typing import TYPE_CHECKING, Any
+from collections.abc import Callable
 
 import wx
 
@@ -44,7 +45,7 @@ class MainFrameAgentMixin:
     _mcp_tool_listener_callback: Callable[[ToolResultEvent], None] | None = None
 
     def _create_agent(
-        self: "MainFrame",
+        self: MainFrame,
         *,
         confirm_override: Callable[[str], bool] | None = None,
         confirm_requirement_update_override: Callable[
@@ -64,7 +65,7 @@ class MainFrameAgentMixin:
             confirm_requirement_update=confirm_requirement_update_override,
         )
 
-    def _init_mcp_tool_listener(self: "MainFrame") -> None:
+    def _init_mcp_tool_listener(self: MainFrame) -> None:
         """Subscribe to MCP tool result notifications."""
 
         if getattr(self, "_mcp_tool_listener_remove", None):
@@ -80,7 +81,7 @@ class MainFrameAgentMixin:
         self._mcp_tool_listener_callback = _deliver
         self._mcp_tool_listener_remove = add_tool_result_listener(_deliver)
 
-    def _teardown_mcp_tool_listener(self: "MainFrame") -> None:
+    def _teardown_mcp_tool_listener(self: MainFrame) -> None:
         """Detach from MCP tool result notifications."""
 
         remover = getattr(self, "_mcp_tool_listener_remove", None)
@@ -107,7 +108,7 @@ class MainFrameAgentMixin:
                 return False
 
     def _handle_mcp_tool_event(
-        self: "MainFrame", event: ToolResultEvent
+        self: MainFrame, event: ToolResultEvent
     ) -> None:
         """Apply requirement changes described by *event*."""
 
@@ -125,12 +126,12 @@ class MainFrameAgentMixin:
         except Exception:  # pragma: no cover - defensive logging
             logger.exception("Failed to apply MCP tool result event")
 
-    def _on_window_destroy(self: "MainFrame", event: wx.WindowDestroyEvent) -> None:
+    def _on_window_destroy(self: MainFrame, event: wx.WindowDestroyEvent) -> None:
         if event.GetEventObject() is self:
             self._teardown_mcp_tool_listener()
         event.Skip()
 
-    def _selected_requirement_ids_for_agent(self: "MainFrame") -> list[int]:
+    def _selected_requirement_ids_for_agent(self: MainFrame) -> list[int]:
         ids: list[int] = []
         panel = getattr(self, "panel", None)
         if panel is not None and hasattr(panel, "get_selected_ids"):
@@ -149,7 +150,7 @@ class MainFrameAgentMixin:
                 filtered.append(numeric)
         return filtered
 
-    def _agent_batch_targets(self: "MainFrame") -> list[BatchTarget]:
+    def _agent_batch_targets(self: MainFrame) -> list[BatchTarget]:
         model = getattr(self, "model", None)
         if model is None:
             return []
@@ -176,7 +177,7 @@ class MainFrameAgentMixin:
             )
         return targets
 
-    def _agent_context_messages(self: "MainFrame") -> list[dict[str, str]]:
+    def _agent_context_messages(self: MainFrame) -> list[dict[str, str]]:
         lines: list[str] = ["[Workspace context]"]
         summary = self._current_document_summary()
         prefix = getattr(self, "current_doc_prefix", None)
@@ -274,7 +275,7 @@ class MainFrameAgentMixin:
         return [{"role": "system", "content": "\n".join(lines)}]
 
     def _agent_context_for_requirement(
-        self: "MainFrame", requirement_id: int
+        self: MainFrame, requirement_id: int
     ) -> tuple[dict[str, str], ...]:
         model = getattr(self, "model", None)
         if model is None:
@@ -340,7 +341,7 @@ class MainFrameAgentMixin:
         return (({"role": "system", "content": "\n".join(lines)}),)
 
     def _on_agent_tool_results(
-        self: "MainFrame", tool_results: Sequence[Mapping[str, Any]]
+        self: MainFrame, tool_results: Sequence[Mapping[str, Any]]
     ) -> None:
         """Apply requirement updates returned by the agent."""
 
@@ -462,7 +463,7 @@ class MainFrameAgentMixin:
             return str(rid_raw) if isinstance(rid_raw, str) and rid_raw.strip() else None
         return None
 
-    def _convert_tool_result_requirement(self: "MainFrame", result_payload: Any) -> Requirement | None:
+    def _convert_tool_result_requirement(self: MainFrame, result_payload: Any) -> Requirement | None:
         if not isinstance(result_payload, Mapping):
             logger.warning(
                 "Agent tool result has unexpected structure: %s",
@@ -497,7 +498,7 @@ class MainFrameAgentMixin:
         requirement.rid = canonical_rid
         return requirement
 
-    def on_run_command(self: "MainFrame", _event: wx.Event) -> None:
+    def on_run_command(self: MainFrame, _event: wx.Event) -> None:
         """Ensure agent chat panel is visible and focused."""
 
         if not self.agent_chat_menu_item:
@@ -508,7 +509,7 @@ class MainFrameAgentMixin:
         else:
             self._apply_agent_chat_visibility(persist=False)
 
-    def on_toggle_agent_chat(self: "MainFrame", _event: wx.CommandEvent | None) -> None:
+    def on_toggle_agent_chat(self: MainFrame, _event: wx.CommandEvent | None) -> None:
         """Toggle agent chat panel visibility."""
 
         if not self.agent_chat_menu_item:

--- a/app/ui/main_frame/documents.py
+++ b/app/ui/main_frame/documents.py
@@ -35,12 +35,12 @@ class MainFrameDocumentsMixin:
     _doc_tree_min_pane: int
 
     @property
-    def recent_dirs(self: "MainFrame") -> list[str]:
+    def recent_dirs(self: MainFrame) -> list[str]:
         """Return directories recently opened by the user."""
 
         return self.config.get_recent_dirs()
 
-    def _current_document_summary(self: "MainFrame") -> str | None:
+    def _current_document_summary(self: MainFrame) -> str | None:
         """Return prefix and title of the active document for the header."""
 
         prefix = self.current_doc_prefix
@@ -62,7 +62,7 @@ class MainFrameDocumentsMixin:
             return prefix_text
         return prefix
 
-    def _update_requirements_label(self: "MainFrame") -> None:
+    def _update_requirements_label(self: MainFrame) -> None:
         """Adjust requirements pane title to reflect active document."""
 
         label_ctrl = getattr(self, "list_label", None)
@@ -81,7 +81,7 @@ class MainFrameDocumentsMixin:
             if container and hasattr(container, "Layout"):
                 container.Layout()
 
-    def on_open_folder(self: "MainFrame", _event: wx.Event) -> None:
+    def on_open_folder(self: MainFrame, _event: wx.Event) -> None:
         """Handle "Open Folder" menu action."""
 
         dlg = wx.DirDialog(self, _("Select requirements folder"))
@@ -92,7 +92,7 @@ class MainFrameDocumentsMixin:
             self._load_directory(Path(dlg.GetPath()))
         dlg.Destroy()
 
-    def on_open_recent(self: "MainFrame", event: wx.CommandEvent) -> None:
+    def on_open_recent(self: MainFrame, event: wx.CommandEvent) -> None:
         """Open a directory selected from the "recent" menu."""
 
         path = self.navigation.get_recent_path(event.GetId())
@@ -107,7 +107,7 @@ class MainFrameDocumentsMixin:
         except OSError:
             return str(path)
 
-    def _sync_mcp_base_path(self: "MainFrame", path: Path) -> None:
+    def _sync_mcp_base_path(self: MainFrame, path: Path) -> None:
         """Persist MCP base path and keep the running server in sync."""
 
         new_base_path = self._normalise_directory_path(path)
@@ -143,7 +143,7 @@ class MainFrameDocumentsMixin:
                 "Failed to start MCP server after applying new base path"
             )
 
-    def _load_directory(self: "MainFrame", path: Path) -> None:
+    def _load_directory(self: MainFrame, path: Path) -> None:
         """Load requirements from ``path`` and update recent list."""
 
         controller = DocumentsController(path, self.model)
@@ -192,7 +192,7 @@ class MainFrameDocumentsMixin:
         self._selected_requirement_id = None
         self._clear_editor_panel()
 
-    def _show_directory_error(self: "MainFrame", path: Path, error: Exception) -> None:
+    def _show_directory_error(self: MainFrame, path: Path, error: Exception) -> None:
         """Display error message for a failed directory load."""
 
         message = _(
@@ -201,7 +201,7 @@ class MainFrameDocumentsMixin:
         wx.MessageBox(message, _("Error"), wx.ICON_ERROR)
 
     def _refresh_documents(
-        self: "MainFrame",
+        self: MainFrame,
         *,
         select: str | None = None,
         force_reload: bool = False,
@@ -235,7 +235,7 @@ class MainFrameDocumentsMixin:
             self._clear_editor_panel()
             self._update_requirements_label()
 
-    def _load_document_contents(self: "MainFrame", prefix: str) -> bool:
+    def _load_document_contents(self: MainFrame, prefix: str) -> bool:
         """Load items and labels for ``prefix`` and update the views."""
 
         if not self.docs_controller:
@@ -327,7 +327,7 @@ class MainFrameDocumentsMixin:
         self.splitter.UpdateSize()
         return True
 
-    def on_new_document(self: "MainFrame", parent_prefix: str | None) -> None:
+    def on_new_document(self: MainFrame, parent_prefix: str | None) -> None:
         """Create a new document under ``parent_prefix``."""
 
         if not (self.docs_controller and self.current_dir):
@@ -361,7 +361,7 @@ class MainFrameDocumentsMixin:
         self._selected_requirement_id = None
         self._refresh_documents(select=doc.prefix, force_reload=True)
 
-    def on_rename_document(self: "MainFrame", prefix: str) -> None:
+    def on_rename_document(self: MainFrame, prefix: str) -> None:
         """Rename or retitle document ``prefix``."""
 
         if not self.docs_controller:
@@ -397,7 +397,7 @@ class MainFrameDocumentsMixin:
             return
         self._refresh_documents(select=prefix, force_reload=True)
 
-    def on_delete_document(self: "MainFrame", prefix: str) -> None:
+    def on_delete_document(self: MainFrame, prefix: str) -> None:
         """Delete document ``prefix`` after confirmation."""
 
         if not self.docs_controller:
@@ -419,7 +419,7 @@ class MainFrameDocumentsMixin:
         target = parent_prefix if parent_prefix in self.docs_controller.documents else None
         self._refresh_documents(select=target, force_reload=True)
 
-    def _on_doc_changing(self: "MainFrame", event: wx.TreeEvent) -> None:
+    def _on_doc_changing(self: MainFrame, event: wx.TreeEvent) -> None:
         """Request confirmation before switching documents."""
 
         if event.GetItem() == event.GetOldItem():
@@ -431,7 +431,7 @@ class MainFrameDocumentsMixin:
             return
         event.Skip()
 
-    def on_document_selected(self: "MainFrame", prefix: str) -> None:
+    def on_document_selected(self: MainFrame, prefix: str) -> None:
         """Load items and labels for selected document ``prefix``."""
 
         if prefix == self.current_doc_prefix:
@@ -444,7 +444,7 @@ class MainFrameDocumentsMixin:
             self.editor.set_directory(self.current_dir / prefix)
         self._load_document_contents(prefix)
 
-    def on_import_requirements(self: "MainFrame", _event: wx.Event) -> None:
+    def on_import_requirements(self: MainFrame, _event: wx.Event) -> None:
         """Open the import dialog and persist selected requirements."""
 
         if not (self.docs_controller and self.current_doc_prefix and self.current_dir):
@@ -549,7 +549,7 @@ class MainFrameDocumentsMixin:
                 wx.ICON_WARNING,
             )
 
-    def on_manage_labels(self: "MainFrame", _event: wx.Event) -> None:
+    def on_manage_labels(self: MainFrame, _event: wx.Event) -> None:
         """Open dialog to manage defined labels."""
 
         if not (self.docs_controller and self.current_doc_prefix and self.current_dir):
@@ -567,7 +567,7 @@ class MainFrameDocumentsMixin:
             self.editor.update_labels_list(labels_all, freeform)
         dlg.Destroy()
 
-    def on_show_derivation_graph(self: "MainFrame", _event: wx.Event) -> None:
+    def on_show_derivation_graph(self: MainFrame, _event: wx.Event) -> None:
         """Open window displaying requirement derivation graph."""
 
         if not (self.current_dir and self.docs_controller):
@@ -586,7 +586,7 @@ class MainFrameDocumentsMixin:
         self.register_auxiliary_frame(frame)
         frame.Show()
 
-    def on_show_trace_matrix(self: "MainFrame", _event: wx.Event) -> None:
+    def on_show_trace_matrix(self: MainFrame, _event: wx.Event) -> None:
         """Open window displaying requirement trace links."""
 
         if not (self.current_dir and self.docs_controller):

--- a/app/ui/main_frame/editor.py
+++ b/app/ui/main_frame/editor.py
@@ -21,7 +21,7 @@ class MainFrameEditorMixin:
 
     editor: EditorPanel
 
-    def on_requirement_selected(self: "MainFrame", event: wx.ListEvent) -> None:
+    def on_requirement_selected(self: MainFrame, event: wx.ListEvent) -> None:
         """Load requirement into editor when selected in list."""
 
         index = event.GetIndex()
@@ -44,7 +44,7 @@ class MainFrameEditorMixin:
                 self._show_editor_panel()
                 self.splitter.UpdateSize()
 
-    def on_requirement_activated(self: "MainFrame", event: wx.ListEvent) -> None:
+    def on_requirement_activated(self: MainFrame, event: wx.ListEvent) -> None:
         """Open requirement in a detached editor when activated."""
 
         if self._is_editor_visible():
@@ -65,7 +65,7 @@ class MainFrameEditorMixin:
         self._open_detached_editor(req)
 
     def _save_editor_contents(
-        self: "MainFrame",
+        self: MainFrame,
         editor_panel: EditorPanel,
         *,
         doc_prefix: str | None = None,
@@ -108,12 +108,12 @@ class MainFrameEditorMixin:
         self._selected_requirement_id = requirement.id
         return requirement
 
-    def _on_editor_save(self: "MainFrame") -> None:
+    def _on_editor_save(self: MainFrame) -> None:
         if not self.docs_controller:
             return
         self._save_editor_contents(self.editor, doc_prefix=self.current_doc_prefix)
 
-    def _handle_editor_discard(self: "MainFrame") -> bool:
+    def _handle_editor_discard(self: MainFrame) -> bool:
         """Reload currently selected requirement into the editor."""
 
         if self._selected_requirement_id is None:
@@ -124,7 +124,7 @@ class MainFrameEditorMixin:
         self.editor.load(requirement)
         return True
 
-    def _open_detached_editor(self: "MainFrame", requirement: Requirement) -> None:
+    def _open_detached_editor(self: MainFrame, requirement: Requirement) -> None:
         if not (self.docs_controller and self.current_dir):
             return
         prefix = getattr(requirement, "doc_prefix", "") or self.current_doc_prefix
@@ -155,7 +155,7 @@ class MainFrameEditorMixin:
         self._detached_editors[frame.key] = frame
         frame.Show()
 
-    def _on_detached_editor_save(self: "MainFrame", frame: DetachedEditorFrame) -> bool:
+    def _on_detached_editor_save(self: MainFrame, frame: DetachedEditorFrame) -> bool:
         prefix = frame.doc_prefix
         if not prefix or not self.docs_controller or not self.current_dir:
             return False
@@ -171,7 +171,7 @@ class MainFrameEditorMixin:
         self._detached_editors[frame.key] = frame
         return True
 
-    def _on_detached_editor_closed(self: "MainFrame", frame: DetachedEditorFrame) -> None:
+    def _on_detached_editor_closed(self: MainFrame, frame: DetachedEditorFrame) -> None:
         for key, window in list(self._detached_editors.items()):
             if window is frame:
                 del self._detached_editors[key]

--- a/app/ui/main_frame/logging.py
+++ b/app/ui/main_frame/logging.py
@@ -74,7 +74,7 @@ class MainFrameLoggingMixin:
     log_handler: WxLogHandler
     _log_level_values: list[int]
 
-    def _init_log_console(self: "MainFrame") -> None:
+    def _init_log_console(self: MainFrame) -> None:
         """Create the log console panel and attach handler."""
 
         self.log_panel = wx.Panel(self.main_splitter)

--- a/app/ui/main_frame/requirements.py
+++ b/app/ui/main_frame/requirements.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 from dataclasses import replace
-from typing import TYPE_CHECKING, Sequence
+from typing import TYPE_CHECKING
+from collections.abc import Sequence
 
 import wx
 
@@ -19,7 +20,7 @@ if TYPE_CHECKING:  # pragma: no cover - import for type checking only
 class MainFrameRequirementsMixin:
     """Implement actions triggered from the requirements list."""
 
-    def on_toggle_column(self: "MainFrame", event: wx.CommandEvent) -> None:
+    def on_toggle_column(self: MainFrame, event: wx.CommandEvent) -> None:
         """Show or hide column associated with menu item."""
 
         field = self.navigation.get_field_for_id(event.GetId())
@@ -34,7 +35,7 @@ class MainFrameRequirementsMixin:
         self.panel.load_column_order(self.config)
         self.config.set_columns(self.selected_fields)
 
-    def on_new_requirement(self: "MainFrame", _event: wx.Event) -> None:
+    def on_new_requirement(self: MainFrame, _event: wx.Event) -> None:
         """Create and persist a new requirement."""
 
         if not (self.docs_controller and self.current_doc_prefix):
@@ -53,7 +54,7 @@ class MainFrameRequirementsMixin:
         else:
             self._open_detached_editor(data)
 
-    def on_clone_requirement(self: "MainFrame", req_id: int) -> None:
+    def on_clone_requirement(self: MainFrame, req_id: int) -> None:
         """Clone requirement ``req_id`` and open in editor."""
 
         if not (self.docs_controller and self.current_doc_prefix):
@@ -79,7 +80,7 @@ class MainFrameRequirementsMixin:
         else:
             self._open_detached_editor(clone)
 
-    def _create_linked_copy(self: "MainFrame", source: Requirement) -> tuple[Requirement, str]:
+    def _create_linked_copy(self: MainFrame, source: Requirement) -> tuple[Requirement, str]:
         if not (self.docs_controller and self.current_doc_prefix):
             raise RuntimeError("Documents controller not initialized")
         doc = self.docs_controller.documents.get(self.current_doc_prefix)
@@ -124,7 +125,7 @@ class MainFrameRequirementsMixin:
         )
         return clone, parent_rid
 
-    def on_derive_requirement(self: "MainFrame", req_id: int) -> None:
+    def on_derive_requirement(self: MainFrame, req_id: int) -> None:
         """Create a requirement derived from ``req_id`` and open it."""
 
         if not (self.docs_controller and self.current_doc_prefix):
@@ -145,7 +146,7 @@ class MainFrameRequirementsMixin:
             self._open_detached_editor(clone)
 
     def _format_requirement_summary(
-        self: "MainFrame", requirement: Requirement | None
+        self: MainFrame, requirement: Requirement | None
     ) -> str | None:
         if not requirement:
             return None
@@ -159,7 +160,7 @@ class MainFrameRequirementsMixin:
             return " — ".join(summary_parts)
         return None
 
-    def on_delete_requirements(self: "MainFrame", req_ids: Sequence[int]) -> None:
+    def on_delete_requirements(self: MainFrame, req_ids: Sequence[int]) -> None:
         """Delete multiple requirements referenced by ``req_ids``."""
 
         if not req_ids:
@@ -237,12 +238,12 @@ class MainFrameRequirementsMixin:
         self.editor.update_labels_list(labels, freeform)
         self.panel.update_labels_list(labels)
 
-    def on_delete_requirement(self: "MainFrame", req_id: int) -> None:
+    def on_delete_requirement(self: MainFrame, req_id: int) -> None:
         """Delete requirement ``req_id`` and refresh views."""
 
         self.on_delete_requirements([req_id])
 
-    def _on_sort_changed(self: "MainFrame", column: int, ascending: bool) -> None:
+    def _on_sort_changed(self: MainFrame, column: int, ascending: bool) -> None:
         if not self.remember_sort:
             return
         self.sort_column = column

--- a/app/ui/main_frame/sections.py
+++ b/app/ui/main_frame/sections.py
@@ -31,7 +31,7 @@ class MainFrameSectionsMixin:
         return splitter
 
     def _create_section(
-        self: "MainFrame",
+        self: MainFrame,
         parent: wx.Window,
         *,
         label: str,
@@ -76,7 +76,7 @@ class MainFrameSectionsMixin:
 
     # ------------------------------------------------------------------
     # visibility and localisation helpers
-    def _apply_doc_tree_visibility(self: "MainFrame", *, persist: bool) -> None:
+    def _apply_doc_tree_visibility(self: MainFrame, *, persist: bool) -> None:
         """Update hierarchy pane visibility based on the menu state."""
 
         if not getattr(self, "doc_splitter", None) or not getattr(self, "doc_tree_container", None):
@@ -113,19 +113,19 @@ class MainFrameSectionsMixin:
         self.doc_splitter.UpdateSize()
         self.Layout()
 
-    def _is_doc_tree_visible(self: "MainFrame") -> bool:
+    def _is_doc_tree_visible(self: MainFrame) -> bool:
         """Return whether the hierarchy pane is currently shown."""
 
         return bool(self.hierarchy_menu_item and self.hierarchy_menu_item.IsChecked())
 
-    def on_toggle_hierarchy(self: "MainFrame", _event: wx.CommandEvent | None) -> None:
+    def on_toggle_hierarchy(self: MainFrame, _event: wx.CommandEvent | None) -> None:
         """Handle hierarchy visibility toggles from the menu."""
 
         if not self.hierarchy_menu_item:
             return
         self._apply_doc_tree_visibility(persist=True)
 
-    def _apply_agent_chat_visibility(self: "MainFrame", *, persist: bool) -> None:
+    def _apply_agent_chat_visibility(self: MainFrame, *, persist: bool) -> None:
         """Update agent chat pane visibility based on the menu state."""
 
         if not self.agent_chat_menu_item:
@@ -162,12 +162,12 @@ class MainFrameSectionsMixin:
         self.agent_splitter.UpdateSize()
         self.Layout()
 
-    def _is_agent_chat_visible(self: "MainFrame") -> bool:
+    def _is_agent_chat_visible(self: MainFrame) -> bool:
         """Return whether the agent chat pane is currently shown."""
 
         return bool(self.agent_chat_menu_item and self.agent_chat_menu_item.IsChecked())
 
-    def _show_editor_panel(self: "MainFrame") -> None:
+    def _show_editor_panel(self: MainFrame) -> None:
         """Display the editor section alongside its container."""
 
         if not self.splitter.IsSplit():
@@ -183,14 +183,14 @@ class MainFrameSectionsMixin:
         self.editor.Layout()
         refresh_splitter_highlight(self.splitter)
 
-    def _hide_editor_panel(self: "MainFrame") -> None:
+    def _hide_editor_panel(self: MainFrame) -> None:
         """Hide the editor section and its container."""
 
         self.editor.Hide()
         self.editor_container.Hide()
         refresh_splitter_highlight(self.splitter)
 
-    def _clear_editor_panel(self: "MainFrame") -> None:
+    def _clear_editor_panel(self: MainFrame) -> None:
         """Reset editor contents and reflect current visibility setting."""
 
         if not getattr(self, "editor", None):
@@ -201,12 +201,12 @@ class MainFrameSectionsMixin:
         else:
             self._hide_editor_panel()
 
-    def _is_editor_visible(self: "MainFrame") -> bool:
+    def _is_editor_visible(self: MainFrame) -> bool:
         """Return ``True`` when the main editor pane is enabled."""
 
         return bool(self.editor_menu_item and self.editor_menu_item.IsChecked())
 
-    def _show_agent_section(self: "MainFrame") -> None:
+    def _show_agent_section(self: MainFrame) -> None:
         """Display the agent chat section and ensure layout refresh."""
 
         self.agent_container.Show()
@@ -215,14 +215,14 @@ class MainFrameSectionsMixin:
         self.agent_panel.Layout()
         refresh_splitter_highlight(self.agent_splitter)
 
-    def _hide_agent_section(self: "MainFrame") -> None:
+    def _hide_agent_section(self: MainFrame) -> None:
         """Hide the agent chat widgets to free screen space."""
 
         self.agent_panel.Hide()
         self.agent_container.Hide()
         refresh_splitter_highlight(self.agent_splitter)
 
-    def _update_section_labels(self: "MainFrame") -> None:
+    def _update_section_labels(self: MainFrame) -> None:
         """Refresh captions for titled sections according to current locale."""
 
         self.doc_tree_label.SetLabel(_("Hierarchy"))
@@ -234,7 +234,7 @@ class MainFrameSectionsMixin:
             self.list_label.SetLabel(_("Requirements"))
         self.update_log_console_labels()
 
-    def _confirm_discard_changes(self: "MainFrame") -> bool:
+    def _confirm_discard_changes(self: MainFrame) -> bool:
         """Ask user to discard unsaved edits if editor has pending changes."""
 
         from . import confirm
@@ -248,7 +248,7 @@ class MainFrameSectionsMixin:
             return True
         return False
 
-    def _default_editor_sash(self: "MainFrame") -> int:
+    def _default_editor_sash(self: MainFrame) -> int:
         width = self.splitter.GetClientSize().width
         if width <= 0:
             width = self.agent_splitter.GetClientSize().width
@@ -265,7 +265,7 @@ class MainFrameSectionsMixin:
         desired = min(desired, max_left)
         return desired
 
-    def _default_agent_chat_sash(self: "MainFrame") -> int:
+    def _default_agent_chat_sash(self: MainFrame) -> int:
         width = self.agent_splitter.GetClientSize().width
         if width <= 0:
             width = self.doc_splitter.GetClientSize().width
@@ -280,7 +280,7 @@ class MainFrameSectionsMixin:
         desired = min(desired, max_left)
         return desired
 
-    def _apply_editor_visibility(self: "MainFrame", *, persist: bool) -> None:
+    def _apply_editor_visibility(self: MainFrame, *, persist: bool) -> None:
         visible = self._is_editor_visible()
         if visible:
             if not self.splitter.IsSplit():
@@ -307,7 +307,7 @@ class MainFrameSectionsMixin:
         self.splitter.UpdateSize()
         self.Layout()
 
-    def on_toggle_requirement_editor(self: "MainFrame", _event: wx.CommandEvent) -> None:
+    def on_toggle_requirement_editor(self: MainFrame, _event: wx.CommandEvent) -> None:
         """Toggle visibility of the requirement editor pane."""
 
         if not self.editor_menu_item:
@@ -322,7 +322,7 @@ class MainFrameSectionsMixin:
 
     # ------------------------------------------------------------------
     # persistence helpers
-    def _load_layout(self: "MainFrame") -> None:
+    def _load_layout(self: MainFrame) -> None:
         """Restore window geometry, splitter, console, and column widths."""
 
         self.config.restore_layout(
@@ -354,7 +354,7 @@ class MainFrameSectionsMixin:
             self.agent_chat_menu_item.Check(self.config.get_agent_chat_shown())
             self._apply_agent_chat_visibility(persist=False)
 
-    def _save_layout(self: "MainFrame") -> None:
+    def _save_layout(self: MainFrame) -> None:
         """Persist window geometry, splitter, console, and column widths."""
 
         doc_tree_sash = (
@@ -383,13 +383,13 @@ class MainFrameSectionsMixin:
 
     # ------------------------------------------------------------------
     # splitter behaviour
-    def _disable_splitter_unsplit(self: "MainFrame", splitter: wx.SplitterWindow) -> None:
+    def _disable_splitter_unsplit(self: MainFrame, splitter: wx.SplitterWindow) -> None:
         """Attach handlers preventing ``splitter`` from unsplitting on double click."""
 
         splitter.Bind(wx.EVT_SPLITTER_DOUBLECLICKED, self._prevent_splitter_unsplit)
         splitter.Bind(wx.EVT_SPLITTER_DCLICK, self._prevent_splitter_unsplit)
 
-    def _prevent_splitter_unsplit(self: "MainFrame", event: wx.SplitterEvent) -> None:
+    def _prevent_splitter_unsplit(self: MainFrame, event: wx.SplitterEvent) -> None:
         """Block attempts to unsplit panes initiated by double clicks."""
 
         event.Veto()

--- a/app/ui/main_frame/settings.py
+++ b/app/ui/main_frame/settings.py
@@ -16,7 +16,7 @@ class MainFrameSettingsMixin:
     """Handle opening and applying application settings."""
 
     def on_open_settings(
-        self: "MainFrame",
+        self: MainFrame,
         _event: wx.Event,
     ) -> None:  # pragma: no cover - GUI event
         """Display settings dialog and apply changes."""

--- a/app/ui/main_frame/shutdown.py
+++ b/app/ui/main_frame/shutdown.py
@@ -18,7 +18,7 @@ class MainFrameShutdownMixin:
     _detached_editors: dict
     _shutdown_in_progress: bool
 
-    def register_auxiliary_frame(self: "MainFrame", frame: wx.Frame) -> None:
+    def register_auxiliary_frame(self: MainFrame, frame: wx.Frame) -> None:
         """Ensure ``frame`` is configured to follow the main window lifecycle."""
 
         if frame is None:
@@ -32,7 +32,7 @@ class MainFrameShutdownMixin:
         extra_style = frame.GetExtraStyle()
         frame.SetExtraStyle(extra_style | wx.FRAME_FLOAT_ON_PARENT)
 
-    def _request_exit_main_loop(self: "MainFrame") -> None:
+    def _request_exit_main_loop(self: MainFrame) -> None:
         """Ask wx to terminate the main loop if it is still running."""
 
         app = wx.GetApp()
@@ -55,7 +55,7 @@ class MainFrameShutdownMixin:
         except Exception:  # pragma: no cover - wx implementations may vary
             logger.exception("Failed to request wx main loop exit during shutdown")
 
-    def _on_close(self: "MainFrame", event: wx.Event) -> None:  # pragma: no cover - GUI event
+    def _on_close(self: MainFrame, event: wx.Event) -> None:  # pragma: no cover - GUI event
         if self._shutdown_in_progress:
             if event is not None:
                 event.Skip()

--- a/app/ui/resources/editor_config.py
+++ b/app/ui/resources/editor_config.py
@@ -6,7 +6,8 @@ import json
 from dataclasses import dataclass, field
 from functools import cache
 from pathlib import Path
-from typing import Any, Iterable
+from typing import Any
+from collections.abc import Iterable
 
 from ...i18n import translate_resource
 

--- a/app/ui/trace_matrix.py
+++ b/app/ui/trace_matrix.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Mapping, TYPE_CHECKING
+from typing import TYPE_CHECKING
+from collections.abc import Mapping
 
 import wx
 import wx.grid as gridlib

--- a/app/ui/widgets/chat_message.py
+++ b/app/ui/widgets/chat_message.py
@@ -7,7 +7,8 @@ import math
 from collections.abc import Mapping, Sequence
 from contextlib import suppress
 from dataclasses import dataclass
-from typing import Any, Callable
+from typing import Any
+from collections.abc import Callable
 
 import wx
 

--- a/app/util/json.py
+++ b/app/util/json.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
-from typing import Any, Callable
+from typing import Any
+from collections.abc import Callable
 
 
 def make_json_safe(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,4 +37,7 @@ extend-select = [
     "B",
     "C4",
     "SIM",
+    "UP",
+    "G",
+    "PIE",
 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,8 @@ import contextlib
 from types import MethodType, ModuleType
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Mapping, Sequence
+from typing import TYPE_CHECKING
+from collections.abc import Mapping, Sequence
 
 import pytest
 
@@ -206,7 +207,7 @@ def _destroy_top_windows(wx: ModuleType) -> None:
 
 
 @pytest.fixture(scope="session")
-def _wx_session_app(request: pytest.FixtureRequest, xvfb: None) -> tuple[ModuleType, "wx.App"]:
+def _wx_session_app(request: pytest.FixtureRequest, xvfb: None) -> tuple[ModuleType, wx.App]:
     """Create a shared ``wx.App`` guarded by the xvfb fixture."""
 
     wx = pytest.importorskip("wx")
@@ -223,13 +224,13 @@ def _wx_session_app(request: pytest.FixtureRequest, xvfb: None) -> tuple[ModuleT
     return wx, app
 
 
-def _install_safe_yield(app: "wx.App") -> None:
+def _install_safe_yield(app: wx.App) -> None:
     """Replace ``wx.App.Yield`` with a crash-resistant event pump."""
 
     if not hasattr(app, "HasPendingEvents") or not hasattr(app, "ProcessPendingEvents"):
         return
 
-    def _safe_yield(self: "wx.App", *args, **kwargs) -> None:
+    def _safe_yield(self: wx.App, *args, **kwargs) -> None:
         for _ in range(5):
             had_events = False
             while self.HasPendingEvents():
@@ -245,8 +246,8 @@ def _install_safe_yield(app: "wx.App") -> None:
 def wx_app(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path_factory: pytest.TempPathFactory,
-    _wx_session_app: tuple[ModuleType, "wx.App"],
-) -> "wx.App":
+    _wx_session_app: tuple[ModuleType, wx.App],
+) -> wx.App:
     """Return a ``wx.App`` instance with per-test isolation for configs."""
 
     wx, app = _wx_session_app

--- a/tests/env_utils.py
+++ b/tests/env_utils.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
-from typing import Iterable, Optional
+from collections.abc import Iterable
 
 
 class SecretEnvValue:
@@ -49,7 +49,7 @@ def load_secret_from_env(
     *,
     search_from: Path | str | None = None,
     env_file_name: str = ".env",
-) -> Optional[SecretEnvValue]:
+) -> SecretEnvValue | None:
     """Load a secret from the environment or the nearest ``.env`` file.
 
     Parameters
@@ -116,7 +116,7 @@ def _iter_env_paths(root: Path, env_file_name: str) -> Iterable[Path]:
             yield env_path
 
 
-def _extract_from_env_file(env_path: Path, variable_name: str) -> Optional[str]:
+def _extract_from_env_file(env_path: Path, variable_name: str) -> str | None:
     return _parse_env_file(env_path).get(variable_name)
 
 

--- a/tests/gui/test_agent_chat_panel.py
+++ b/tests/gui/test_agent_chat_panel.py
@@ -2,7 +2,8 @@ import json
 import threading
 import time
 from concurrent.futures import Future, ThreadPoolExecutor
-from typing import Any, Mapping, Sequence
+from typing import Any
+from collections.abc import Mapping, Sequence
 
 from app.confirm import ConfirmDecision, reset_requirement_update_preference, set_confirm, set_requirement_update_confirm
 from app.llm.tokenizer import TokenCountResult

--- a/tests/gui/test_confirm.py
+++ b/tests/gui/test_confirm.py
@@ -50,7 +50,7 @@ def test_wx_confirm(monkeypatch):
 
     monkeypatch.setattr(wx, "MessageDialog", lambda *a, **k: DummyDialog())
     monkeypatch.setattr(wx, "GetActiveWindow", lambda: None)
-    monkeypatch.setattr(wx, "GetTopLevelWindows", lambda: [])
+    monkeypatch.setattr(wx, "GetTopLevelWindows", list)
 
     assert wx_confirm("Proceed?") is True
     assert destroyed.pop(0) is True
@@ -85,7 +85,7 @@ def test_wx_confirm_from_worker_thread(monkeypatch, wx_app):
 
     monkeypatch.setattr(wx, "MessageDialog", lambda *a, **k: DummyDialog())
     monkeypatch.setattr(wx, "GetActiveWindow", lambda: None)
-    monkeypatch.setattr(wx, "GetTopLevelWindows", lambda: [])
+    monkeypatch.setattr(wx, "GetTopLevelWindows", list)
     monkeypatch.setattr(wx, "IsMainThread", fake_is_main_thread)
 
     results: list[bool] = []

--- a/tests/integration/test_local_agent.py
+++ b/tests/integration/test_local_agent.py
@@ -4,7 +4,8 @@ import asyncio
 import json
 import threading
 from pathlib import Path
-from typing import Any, Mapping
+from typing import Any
+from collections.abc import Mapping
 
 import httpx
 import openai

--- a/tests/unit/test_agent_loop_runner.py
+++ b/tests/unit/test_agent_loop_runner.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
-from typing import Any, Mapping
+from typing import Any
+from collections.abc import Mapping
 
 from app.agent.local_agent import AgentLoopRunner, LocalAgent
 from app.llm.client import LLMResponse, LLMToolCall

--- a/tests/unit/test_agent_tool_result_logging.py
+++ b/tests/unit/test_agent_tool_result_logging.py
@@ -17,7 +17,7 @@ class _StubPanel:
 class _StubFrame(MainFrameAgentMixin):
     def __init__(self) -> None:
         self.current_doc_prefix = "SYS"
-        self.model = SimpleNamespace(get_all=lambda: [])
+        self.model = SimpleNamespace(get_all=list)
         self.panel = _StubPanel()
         self.editor = SimpleNamespace(load=lambda *_args, **_kwargs: None)
         self._selected_requirement_id = None

--- a/tools/migrate_agent_history.py
+++ b/tools/migrate_agent_history.py
@@ -7,7 +7,8 @@ import argparse
 import json
 import sys
 from pathlib import Path
-from typing import Any, Mapping, Sequence
+from typing import Any
+from collections.abc import Mapping, Sequence
 
 from app.ui.chat_entry import (
     ChatConversation,


### PR DESCRIPTION
## Summary
- enable the Ruff pyupgrade rule set to catch outdated syntax automatically
- update type annotations and helper utilities across the app, tests, and tools to comply with the new checks
- extend Ruff with the logging-format (G) and flake8-pie (PIE) rule families and fix the resulting violations in the chat UI and tests

## Testing
- ruff check
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d83c114d888320bf57eaff8c062733