### PR TITLE
Remove legacy requirement deletion alias

### DIFF
--- a/app/cli/commands.py
+++ b/app/cli/commands.py
@@ -714,11 +714,22 @@ def cmd_item_delete(
     if not confirm(msg):
         sys.stdout.write(_("aborted\n"))
         return
-    removed = service.delete_requirement(args.rid)
-    if removed:
-        sys.stdout.write(f"{args.rid}\n")
-    else:
+    try:
+        canonical = service.delete_requirement(args.rid)
+    except ValueError as exc:
+        sys.stdout.write(_("{msg}\n").format(msg=str(exc)))
+        return
+    except ValidationError as exc:
+        sys.stdout.write(
+            _("cannot delete {rid}: revision error: {msg}\n").format(
+                rid=args.rid, msg=str(exc)
+            )
+        )
+        return
+    except RequirementNotFoundError:
         sys.stdout.write(_("item not found: {rid}\n").format(rid=args.rid))
+        return
+    sys.stdout.write(f"{canonical}\n")
 
 
 def _add_item_payload_arguments(parser: argparse.ArgumentParser) -> None:

--- a/app/mcp/tools_write.py
+++ b/app/mcp/tools_write.py
@@ -215,7 +215,7 @@ def delete_requirement(directory: str | Path, rid: str) -> dict:
     params = {"directory": str(directory), "rid": rid}
     service = RequirementsService(directory)
     try:
-        canonical = service.delete_requirement_record(rid)
+        canonical = service.delete_requirement(rid)
     except ValueError as exc:
         return log_tool(
             "delete_requirement",

--- a/app/services/requirements.py
+++ b/app/services/requirements.py
@@ -137,14 +137,7 @@ class RequirementsService:
         directory = self.root / prefix
         return doc_store.save_item(directory, doc, dict(payload))
 
-    def delete_requirement(self, rid: str) -> bool:
-        """Delete requirement ``rid`` and remove it from caches."""
-
-        docs = self._ensure_documents()
-        removed = doc_store.delete_item(self.root, rid, docs)
-        return bool(removed)
-
-    def delete_requirement_record(self, rid: str) -> str:
+    def delete_requirement(self, rid: str) -> str:
         """Delete requirement ``rid`` enforcing revision semantics."""
 
         docs = self._ensure_documents()


### PR DESCRIPTION
## Summary
- collapse the requirement deletion entry points so `RequirementsService.delete_requirement` directly calls the document store
- update the MCP deletion tool to use the streamlined service method

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d982e870a08320a8eabad81b7f174f