### PR TITLE
Allow MCP tool calls without pre-validation

### DIFF
--- a/tests/integration/test_llm_client.py
+++ b/tests/integration/test_llm_client.py
@@ -637,16 +637,13 @@ def test_parse_command_reports_tool_validation_details(
 
     client = LLMClient(settings.llm)
 
-    with pytest.raises(ToolValidationError) as excinfo:
-        client.parse_command("Write the text of the first requirement")
+    response = client.parse_command("Write the text of the first requirement")
 
-    exc = excinfo.value
-    assert hasattr(exc, "llm_tool_calls")
-    assert exc.llm_tool_calls
-    first_call = exc.llm_tool_calls[0]
-    assert first_call["function"]["name"] == "create_requirement"
-    arguments = json.loads(first_call["function"]["arguments"])
-    assert arguments["data"]["title"] == "Req-1"
+    assert isinstance(response, LLMResponse)
+    assert response.tool_calls
+    call = response.tool_calls[0]
+    assert call.name == "create_requirement"
+    assert call.arguments["data"]["title"] == "Req-1"
 
 
 def test_parse_command_streaming_message(tmp_path: Path, monkeypatch) -> None:

--- a/tests/integration/test_llm_openrouter_integration.py
+++ b/tests/integration/test_llm_openrouter_integration.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
-from pathlib import Path
-
+import json
 import os
+from pathlib import Path
 
 import pytest
 
 from app.llm.client import LLMClient
+from app.mcp.tools_read import get_requirement
 from tests.env_utils import load_secret_from_env
 from tests.llm_utils import require_real_llm_tests_flag, settings_with_llm
 
@@ -83,3 +84,90 @@ def test_openrouter_reasoning_segments(tmp_path, stream):
     ]
     response = client.respond(conversation)
     assert response.reasoning
+
+
+def test_openrouter_updates_selected_requirement_translations(tmp_path):
+    require_real_llm_tests_flag()
+    key = _load_openrouter_key()
+    if not key:
+        pytest.skip("OPEN_ROUTER key not available")
+    settings = settings_with_llm(tmp_path, api_key=key, stream=False)
+    settings.llm.model = "gpt-oss-120b"
+    client = LLMClient(settings.llm)
+
+    context = (
+        "[Workspace context]\n"
+        "Active document: DEMO — Demo requirements\n"
+        "Selected requirement RIDs: DEMO6, DEMO7, DEMO8, DEMO9\n"
+        "DEMO6 — CLI in the demo — The demo must contain a CLI section showing how commands reuse the core, "
+        "which subcommands are available, and what configuration is required for headless execution.\n"
+        "DEMO7 — Auxiliary modules overview — Demo materials must list auxiliary modules (settings, localisation, logging), "
+        "describe usage rules, and point out potential refactoring targets.\n"
+        "DEMO8 — End-to-end scenarios — The demo package must include at least three end-to-end scenarios "
+        "(open project, edit requirement, generate report) with the sequence of cross-layer interactions.\n"
+        "DEMO9 — Risk and task table — The demo description must include a risk and task table for the architecture, "
+        "including automation ideas and control checks.\n"
+    )
+    user_prompt = (
+        "Переведи выделенные требования на русский, используй update_requirement_field для каждого из них. Внеси такие значения:\n"
+        "DEMO6 — заголовок \"Демонстрация должна содержать раздел CLI\"; формулировка \"Демонстрация должна содержать раздел CLI, "
+        "показывающий, как команды используют ядро, какие подкоманды доступны и какая конфигурация требуется для безголового выполнения.\"\n"
+        "DEMO7 — заголовок \"Вспомогательные модули\"; формулировка \"Материалы демонстрации должны перечислять вспомогательные модули "
+        "(настройки, локализация, логирование), описывать правила использования и указывать потенциальные цели для рефакторинга.\"\n"
+        "DEMO8 — заголовок \"Сквозные сценарии\"; формулировка \"Пакет демонстрации должен включать как минимум три сквозных сценария "
+        "(открыть проект, отредактировать требование, сформировать отчет) с последовательностью межслойных взаимодействий.\"\n"
+        "DEMO9 — заголовок \"Таблица рисков и задач\"; формулировка \"Описание демонстрации должно содержать таблицу рисков и задач для "
+        "архитектуры, включая идеи автоматизации и контрольные проверки.\"\n"
+    )
+
+    conversation: list[dict[str, object]] = [
+        {"role": "system", "content": context},
+        {"role": "user", "content": user_prompt},
+    ]
+
+    update_call = None
+    for _ in range(5):
+        response = client.respond(conversation)
+        assistant_entry: dict[str, object] = {
+            "role": "assistant",
+            "content": response.content or " ",
+        }
+        call = response.tool_calls[0] if response.tool_calls else None
+        if call is not None:
+            assistant_entry["tool_calls"] = [
+                {
+                    "id": call.id,
+                    "type": "function",
+                    "function": {
+                        "name": call.name,
+                        "arguments": json.dumps(call.arguments, ensure_ascii=False),
+                    },
+                }
+            ]
+        conversation.append(assistant_entry)
+        if call is None:
+            continue
+        if call.name == "get_requirement":
+            payload = get_requirement(
+                Path("requirements"),
+                rid=["DEMO6", "DEMO7", "DEMO8", "DEMO9"],
+                fields=["title", "statement"],
+            )
+            conversation.append(
+                {
+                    "role": "tool",
+                    "tool_call_id": call.id,
+                    "name": call.name,
+                    "content": json.dumps(payload, ensure_ascii=False),
+                }
+            )
+            continue
+        update_call = call
+        break
+
+    assert update_call is not None, "model did not request an update"
+    assert update_call.name == "update_requirement_field"
+    arguments = update_call.arguments
+    assert arguments.get("rid") == "DEMO6"
+    assert arguments.get("field") in {"title", "statement"}
+    assert isinstance(arguments.get("value"), str) and arguments["value"].strip()

--- a/tests/unit/llm/test_response_parser_arguments.py
+++ b/tests/unit/llm/test_response_parser_arguments.py
@@ -1,0 +1,57 @@
+"""Tests for recovering malformed tool argument payloads."""
+
+from app.llm.response_parser import LLMResponseParser
+from app.settings import LLMSettings
+
+
+def _parser() -> LLMResponseParser:
+    settings = LLMSettings()
+    return LLMResponseParser(settings, settings.message_format)
+
+
+def test_parse_tool_calls_merges_concatenated_json_fragments() -> None:
+    parser = _parser()
+    arguments_text = (
+        '{"rid":"DEMO6"}'
+        '{"field":"title","value":"Перевод"}'
+    )
+    tool_calls = [
+        {
+            "id": "call-0",
+            "type": "function",
+            "function": {
+                "name": "update_requirement_field",
+                "arguments": arguments_text,
+            },
+        }
+    ]
+
+    parsed = parser.parse_tool_calls(tool_calls)
+
+    assert len(parsed) == 1
+    call = parsed[0]
+    assert call.name == "update_requirement_field"
+    assert call.arguments["rid"] == "DEMO6"
+    assert call.arguments["field"] == "title"
+    assert call.arguments["value"] == "Перевод"
+
+
+def test_parse_tool_calls_allows_missing_required_fields() -> None:
+    parser = _parser()
+    tool_calls = [
+        {
+            "id": "call-0",
+            "type": "function",
+            "function": {
+                "name": "update_requirement_field",
+                "arguments": '{"field":"title","value":"Перевод"}',
+            },
+        }
+    ]
+
+    parsed = parser.parse_tool_calls(tool_calls)
+
+    assert len(parsed) == 1
+    call = parsed[0]
+    assert call.name == "update_requirement_field"
+    assert call.arguments == {"field": "title", "value": "Перевод"}


### PR DESCRIPTION
## Summary
- stop invoking the JSON schema validator while parsing LLM tool calls so missing fields no longer block dispatch to MCP
- normalize decoded arguments to plain dicts and cover the relaxed behaviour with unit and integration tests

## Testing
- `pytest -q tests/unit/llm/test_response_parser_arguments.py`
- `pytest -q tests/integration/test_llm_client.py::test_parse_command_reports_tool_validation_details`
- `pytest -q tests/integration/test_llm_client.py`
- `pytest -q tests/integration/test_local_agent.py::test_run_command_recovers_after_tool_validation_error`


------
https://chatgpt.com/codex/tasks/task_e_68dba92b06ec8320a01ff355532c296d