### PR TITLE
Fix agent chat history selection regression

### DIFF
--- a/app/ui/agent_chat_panel/panel.py
+++ b/app/ui/agent_chat_panel/panel.py
@@ -2310,7 +2310,7 @@ class AgentChatPanel(ConfirmPreferencesMixin, wx.Panel):
 
     def _on_history_row_activated(self, index: int) -> None:
         self._activate_conversation_by_index(
-            index, persist=True, refresh_history=False, source="history_row"
+            index, persist=True, refresh_history=False, _source="history_row"
         )
 
     def _activate_conversation_by_index(


### PR DESCRIPTION
## Summary
- add a regression test that reproduces the missing history reload when switching back to an older chat after creating a new one
- fix the history row activation callback to pass the correct keyword so chat selection works again

## Testing
- pytest --suite gui-smoke -q tests/gui/test_agent_chat_panel.py::test_switching_to_previous_chat_after_starting_new_one


------
https://chatgpt.com/codex/tasks/task_e_68dc104d21388320909b4a7dda6bbf0d