### PR TITLE
Fix agent chat tool call placement and timestamps

### DIFF
--- a/app/ui/agent_chat_panel/view_model.py
+++ b/app/ui/agent_chat_panel/view_model.py
@@ -621,7 +621,7 @@ def _build_response_event(
         return None
     timestamp = entry.response_at or entry.prompt_at or fallback_timestamp
     occurred_at = parse_iso_timestamp(timestamp)
-    formatted_timestamp = format_entry_timestamp(entry.response_at or entry.prompt_at)
+    formatted_timestamp = format_entry_timestamp(timestamp)
     return ResponseEvent(
         event_id=f"{entry_id}:response",
         entry_id=entry_id,


### PR DESCRIPTION
## Summary
- render MCP tool call details inside the agent message bubble instead of as a detached pane
- reuse fallback timestamps when formatting agent responses so their headers always show the local date/time

## Testing
- pytest --suite core -q

------
https://chatgpt.com/codex/tasks/task_e_68dd2ebf354883209e45f03b1109193e