### PR TITLE
Fix tool bubble palette invocation

### DIFF
--- a/app/ui/agent_chat_panel/components/segments.py
+++ b/app/ui/agent_chat_panel/components/segments.py
@@ -651,7 +651,7 @@ class ToolCallPanel(wx.Panel):
             text=text,
             align="left",
             allow_selection=True,
-            palette=tool_bubble_palette(self),
+            palette=tool_bubble_palette(self.GetBackgroundColour(), tool_name),
             width_hint=self._resolve_hint("tool"),
             on_width_change=lambda width: self._emit_layout_hint("tool", width),
         )


### PR DESCRIPTION
## Summary
- pass the tool call panel background colour and tool name to `tool_bubble_palette`

## Testing
- pytest --suite core -q

------
https://chatgpt.com/codex/tasks/task_e_68dd86d793148320a9bef97dee754f65