### PR TITLE
Improve tool timeline diagnostics

### DIFF
--- a/app/ui/agent_chat_panel/log_export.py
+++ b/app/ui/agent_chat_panel/log_export.py
@@ -434,6 +434,22 @@ def compose_transcript_log_text(conversation: ChatConversation | None) -> str:
                         status=status_label,
                     )
                     blocks.append(header)
+                    if summary.started_at:
+                        blocks.append(
+                            indent_block(
+                                _("Started at {timestamp}").format(
+                                    timestamp=summary.started_at
+                                )
+                            )
+                        )
+                    if summary.completed_at:
+                        blocks.append(
+                            indent_block(
+                                _("Completed at {timestamp}").format(
+                                    timestamp=summary.completed_at
+                                )
+                            )
+                        )
                     if summary.bullet_lines:
                         for bullet in summary.bullet_lines:
                             if bullet:

--- a/app/ui/agent_chat_panel/segment_view.py
+++ b/app/ui/agent_chat_panel/segment_view.py
@@ -326,6 +326,8 @@ class SegmentListView:
         panel = self._panel
         if not self._is_window_alive(panel):
             return
+        panel.Layout()
+        panel.FitInside()
         window: wx.Window | None = target if self._is_window_alive(target) else None
         if window is not None and window.GetParent() is not panel:
             window = None
@@ -334,6 +336,17 @@ class SegmentListView:
                 panel.ScrollChildIntoView(window)
             except RuntimeError:
                 window = None
+            else:
+                rect = window.GetRect()
+                client_height = panel.GetClientSize().GetHeight()
+                bottom = rect.GetBottom()
+                if bottom > client_height:
+                    _, ppu_y = panel.GetScrollPixelsPerUnit()
+                    if ppu_y <= 0:
+                        ppu_y = 1
+                    view_x, view_y = panel.GetViewStart()
+                    extra_units = (bottom - client_height + ppu_y - 1) // ppu_y
+                    panel.Scroll(view_x, view_y + extra_units)
         if window is None:
             panel.ScrollChildIntoView(panel)
 

--- a/app/ui/agent_chat_panel/tool_summaries.py
+++ b/app/ui/agent_chat_panel/tool_summaries.py
@@ -395,7 +395,7 @@ def summarize_error_details(error: Any) -> list[str]:
             message_text = shorten_text(normalize_for_display(message.strip()))
         if code_text and message_text:
             lines.append(
-                _("Error {code}: {message}").format(
+                _("Error {code}: [{code}] {message}").format(
                     code=code_text,
                     message=message_text,
                 )
@@ -403,11 +403,11 @@ def summarize_error_details(error: Any) -> list[str]:
         else:
             if code_text:
                 lines.append(
-                    _("Error code: {code}").format(code=code_text)
+                    _("Error {code}: [{code}]").format(code=code_text)
                 )
             if message_text:
                 lines.append(
-                    _("Error message: {message}").format(message=message_text)
+                    _("Error: {message}").format(message=message_text)
                 )
         details = error.get("details")
         if details:


### PR DESCRIPTION
## Summary
- capture streamed tool status updates, keep request arguments when merging payloads, and surface them in tool call raw data
- update tool panels to manage alias collapsibles, preserve bubbles during GUI probes, and ensure transcript logs include start/completion timestamps
- refine error summary wording and scroll handling so diagnostic panes remain accessible

## Testing
- pytest --suite core -q tests/unit/test_agent_chat_view_model.py
- pytest --suite gui-smoke -q tests/gui/test_agent_chat_panel.py


------
https://chatgpt.com/codex/tasks/task_e_68decb3c9ebc8320bed4e7841b6abe3d