### PR TITLE
Improve agent raw data for failed LLM tool calls

### DIFF
--- a/tests/unit/test_agent_chat_log_export.py
+++ b/tests/unit/test_agent_chat_log_export.py
@@ -160,7 +160,7 @@ def test_plain_transcript_uses_agent_turn_text_and_tool_summaries():
         in plain_text
     )
     assert (
-        "• Error message: update_requirement_field() missing 1 required positional argument: 'rid'"
+        "• Error: update_requirement_field() missing 1 required positional argument: 'rid'"
         in plain_text
     )
 


### PR DESCRIPTION
## Summary
- capture LLM tool call diagnostics when the step only reports an error and expose the arguments in raw data
- tidy agent raw payload rendering by removing duplicate tool_call blobs and surfacing llm_error/additional sections
- cover the regression with new unit tests and align transcript expectations with the new error label

## Testing
- pytest --suite core -q

------
https://chatgpt.com/codex/tasks/task_e_68df4bab43d88320982254e5ea053754