### PR TITLE
Deduplicate repeated LLM tool arguments in raw history

### DIFF
--- a/app/llm/client.py
+++ b/app/llm/client.py
@@ -15,9 +15,9 @@ from .context import extract_selected_rids_from_messages
 from .harmony import convert_tools_for_harmony
 from .logging import log_request, log_response
 from .request_builder import LLMRequestBuilder
-from .response_parser import LLMResponseParser, normalise_tool_calls
+from .response_parser import LLMResponseParser
 from .spec import TOOLS
-from .types import LLMReasoningSegment, LLMResponse
+from .types import LLMReasoningSegment, LLMResponse, LLMToolCall
 from .validation import ToolValidationError
 
 # When the backend does not require authentication, the official OpenAI client
@@ -207,6 +207,7 @@ class LLMClient:
         llm_message_text = ""
         normalized_tool_calls: list[dict[str, Any]] = []
         raw_tool_calls_payload: list[Any] = []
+        parsed_tool_calls: tuple[LLMToolCall, ...] = ()
         reasoning_accumulator: list[dict[str, str]] = []
         reasoning_segments: tuple[LLMReasoningSegment, ...] = ()
 
@@ -231,20 +232,34 @@ class LLMClient:
                 if reasoning_entries:
                     reasoning_accumulator.extend(reasoning_entries)
             llm_message_text = message_text
-            normalized_tool_calls = normalise_tool_calls(raw_tool_calls_payload)
-            normalized_tool_calls = self._apply_tool_call_defaults(
-                normalized_tool_calls,
+            parsed_tool_calls = self._response_parser.parse_tool_calls(
+                raw_tool_calls_payload
+            )
+            parsed_tool_calls = self._apply_tool_call_defaults(
+                parsed_tool_calls,
                 request_messages=prepared.snapshot,
             )
-            tool_calls = self._response_parser.parse_tool_calls(
-                normalized_tool_calls
-            )
+            normalized_tool_calls = [
+                {
+                    "id": call.id,
+                    "type": "function",
+                    "function": {
+                        "name": call.name,
+                        "arguments": json.dumps(
+                            call.arguments,
+                            ensure_ascii=False,
+                            default=str,
+                        ),
+                    },
+                }
+                for call in parsed_tool_calls
+            ]
             reasoning_segments = self._response_parser.finalize_reasoning_segments(
                 reasoning_accumulator
             )
             response = LLMResponse(
                 content=message_text,
-                tool_calls=tool_calls,
+                tool_calls=parsed_tool_calls,
                 request_messages=prepared.snapshot,
                 reasoning=reasoning_segments,
             )
@@ -370,6 +385,7 @@ class LLMClient:
         llm_message_text = ""
         normalized_tool_calls: list[dict[str, Any]] = []
         raw_tool_calls_payload: list[Any] = []
+        parsed_tool_calls: tuple[LLMToolCall, ...] = ()
         reasoning_segments: tuple[LLMReasoningSegment, ...] = ()
 
         try:
@@ -384,17 +400,31 @@ class LLMClient:
                 completion
             )
             llm_message_text = message_text
-            normalized_tool_calls = normalise_tool_calls(raw_tool_calls_payload)
-            normalized_tool_calls = self._apply_tool_call_defaults(
-                normalized_tool_calls,
+            parsed_tool_calls = self._response_parser.parse_tool_calls(
+                raw_tool_calls_payload
+            )
+            parsed_tool_calls = self._apply_tool_call_defaults(
+                parsed_tool_calls,
                 request_messages=request_snapshot,
             )
-            tool_calls = self._response_parser.parse_tool_calls(
-                normalized_tool_calls
-            )
+            normalized_tool_calls = [
+                {
+                    "id": call.id,
+                    "type": "function",
+                    "function": {
+                        "name": call.name,
+                        "arguments": json.dumps(
+                            call.arguments,
+                            ensure_ascii=False,
+                            default=str,
+                        ),
+                    },
+                }
+                for call in parsed_tool_calls
+            ]
             response = LLMResponse(
                 content=message_text,
-                tool_calls=tool_calls,
+                tool_calls=parsed_tool_calls,
                 request_messages=request_snapshot,
             )
             if not response.tool_calls and not response.content:
@@ -463,53 +493,28 @@ class LLMClient:
 
     def _apply_tool_call_defaults(
         self,
-        tool_calls: Sequence[Mapping[str, Any]],
+        tool_calls: Sequence[LLMToolCall],
         *,
         request_messages: Sequence[Mapping[str, Any]] | None,
-    ) -> list[dict[str, Any]]:
+    ) -> tuple[LLMToolCall, ...]:
         """Fill missing get_requirement arguments using workspace context."""
 
         if not tool_calls:
-            return []
+            return ()
 
         selected_rids = extract_selected_rids_from_messages(request_messages)
         if not selected_rids:
-            return [dict(call) for call in tool_calls]
+            return tuple(tool_calls)
 
-        patched: list[dict[str, Any]] = []
+        patched: list[LLMToolCall] = []
         changed = False
         for call in tool_calls:
-            call_entry = dict(call)
-            function = call_entry.get("function")
-            if not isinstance(function, Mapping):
-                patched.append(call_entry)
-                continue
-            name = function.get("name")
-            if str(name) != "get_requirement":
-                patched.append(call_entry)
+            if str(call.name) != "get_requirement":
+                patched.append(call)
                 continue
 
-            arguments_text = function.get("arguments")
-            if isinstance(arguments_text, str):
-                stripped = arguments_text.strip()
-                if stripped:
-                    try:
-                        payload = json.loads(stripped)
-                    except json.JSONDecodeError:
-                        patched.append(call_entry)
-                        continue
-                else:
-                    payload = {}
-            elif isinstance(arguments_text, Mapping):  # pragma: no cover - defensive
-                payload = dict(arguments_text)
-            else:
-                payload = {}
-
-            if not isinstance(payload, dict):
-                patched.append(call_entry)
-                continue
-
-            rid_value = payload.get("rid")
+            arguments = dict(call.arguments)
+            rid_value = arguments.get("rid")
             should_patch = False
             if isinstance(rid_value, str):
                 should_patch = not rid_value.strip()
@@ -522,29 +527,28 @@ class LLMClient:
                     if str(item).strip()
                 ]
                 if cleaned:
-                    payload["rid"] = cleaned if len(cleaned) > 1 else cleaned[0]
+                    arguments["rid"] = cleaned if len(cleaned) > 1 else cleaned[0]
                 else:
                     should_patch = True
             elif rid_value is None:
                 should_patch = True
 
             if should_patch:
-                payload["rid"] = (
+                arguments["rid"] = (
                     selected_rids
                     if len(selected_rids) > 1
                     else selected_rids[0]
                 )
-                function = dict(function)
-                function["arguments"] = json.dumps(payload, ensure_ascii=False)
-                call_entry = dict(call_entry)
-                call_entry["function"] = function
+                patched.append(
+                    LLMToolCall(id=call.id, name=call.name, arguments=dict(arguments))
+                )
                 changed = True
-
-            patched.append(call_entry)
+            else:
+                patched.append(call)
 
         if not changed:
-            return [dict(call) for call in tool_calls]
-        return patched
+            return tuple(tool_calls)
+        return tuple(patched)
 
     # ------------------------------------------------------------------
     def _chat_completion(self, **request_args: Any) -> Any:

--- a/app/llm/response_parser.py
+++ b/app/llm/response_parser.py
@@ -4,11 +4,12 @@ from __future__ import annotations
 
 import json
 import re
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass, is_dataclass
 from typing import Any, Iterable, Mapping, Sequence
 
 from ..telemetry import log_debug_payload, log_event
 from ..util.cancellation import CancellationEvent, OperationCancelledError
+from ..util.json import make_json_safe
 from .reasoning import (
     ReasoningFragment,
     collect_reasoning_fragments,
@@ -37,6 +38,97 @@ class _ToolArgumentRecovery:
     empty_fragment_count: int
 
 
+def _extract_tool_argument_mapping(arguments: Any) -> Mapping[str, Any] | None:
+    """Return a mapping for tool arguments without relying on ``__dict__``."""
+
+    if isinstance(arguments, Mapping):
+        return arguments
+    for attr in ("model_dump", "dict"):
+        method = getattr(arguments, attr, None)
+        if callable(method):
+            try:
+                data = method()
+            except Exception:  # pragma: no cover - defensive
+                continue
+            if isinstance(data, Mapping):
+                return data
+    if is_dataclass(arguments):
+        try:
+            data = asdict(arguments)
+        except Exception:  # pragma: no cover - defensive
+            data = None
+        if isinstance(data, Mapping):
+            return data
+    data = getattr(arguments, "_data", None)
+    if isinstance(data, Mapping):
+        return data
+    return None
+
+
+def _stringify_tool_arguments(arguments: Any) -> str:
+    """Coerce tool arguments into a JSON text payload without dropping data."""
+
+    if isinstance(arguments, str):
+        return arguments or "{}"
+    if isinstance(arguments, bytes):
+        decoded = arguments.decode("utf-8", errors="replace")
+        return decoded or "{}"
+    if arguments is None:
+        return "{}"
+
+    fallback_source = arguments if arguments is not None else "{}"
+    fallback = str(fallback_source).strip()
+
+    def _dump(value: Any) -> str:
+        try:
+            return json.dumps(value, ensure_ascii=False)
+        except (TypeError, ValueError):
+            return ""
+
+    def _prefer(text: str) -> str | None:
+        if not text:
+            return None
+        candidate = text.strip()
+        if not candidate:
+            return None
+        if candidate not in {"{}", "[]"}:
+            return text
+        if fallback and fallback[0] in "[{" and fallback not in {"{}", "[]"}:
+            return fallback
+        return candidate
+
+    mapping = _extract_tool_argument_mapping(arguments)
+    if mapping:
+        safe_mapping = make_json_safe(
+            mapping,
+            stringify_keys=True,
+            coerce_sequences=True,
+            default=str,
+        )
+        preferred = _prefer(_dump(safe_mapping))
+        if preferred is not None:
+            return preferred
+
+    if isinstance(arguments, Sequence) and not isinstance(
+        arguments, (str, bytes, bytearray)
+    ):
+        safe_sequence = make_json_safe(
+            arguments,
+            stringify_keys=True,
+            coerce_sequences=True,
+            default=str,
+        )
+        preferred = _prefer(_dump(safe_sequence))
+        if preferred is not None:
+            return preferred
+
+    preferred = _prefer(_dump(arguments))
+    if preferred is not None:
+        return preferred
+
+    return fallback or "{}"
+
+
 def normalise_tool_calls(tool_calls: Any) -> list[dict[str, Any]]:
     """Normalize tool call payloads into the OpenAI function schema."""
 
@@ -51,7 +143,7 @@ def normalise_tool_calls(tool_calls: Any) -> list[dict[str, Any]]:
             name = call.name
             arguments: Any = call.arguments
         elif isinstance(call, Mapping):
-            call_id = call.get("id") or call.get("tool_call_id")
+            call_id = call.get("id") or call.get("tool_call_id") or call.get("call_id")
             function = call.get("function")
             if isinstance(function, Mapping):
                 name = function.get("name")
@@ -62,26 +154,26 @@ def normalise_tool_calls(tool_calls: Any) -> list[dict[str, Any]]:
         else:  # pragma: no cover - defensive for duck typing
             call_id = getattr(call, "id", None)
             function = getattr(call, "function", None)
-            name = getattr(function, "name", None) if function else None
-            arguments = getattr(function, "arguments", None) if function else None
+            if function is not None:
+                name = getattr(function, "name", None)
+                arguments = getattr(function, "arguments", None)
+            else:
+                name = getattr(call, "name", None)
+                arguments = getattr(call, "arguments", None)
+            if call_id is None:
+                call_id = getattr(call, "call_id", None)
         if not name:
             continue
         if call_id is None:
             call_id = f"tool_call_{idx}"
-        if isinstance(arguments, str):
-            arguments_str = arguments
-        else:
-            try:
-                arguments_str = json.dumps(arguments or {}, ensure_ascii=False)
-            except (TypeError, ValueError):
-                arguments_str = "{}"
+        arguments_str = _stringify_tool_arguments(arguments)
         normalized.append(
             {
                 "id": str(call_id),
                 "type": "function",
                 "function": {
                     "name": str(name),
-                    "arguments": arguments_str or "{}",
+                    "arguments": arguments_str,
                 },
             }
         )
@@ -177,8 +269,8 @@ class LLMResponseParser:
         cancellation: CancellationEvent | None,
     ) -> tuple[str, list[dict[str, Any]], list[dict[str, str]]]:
         message_parts: list[str] = []
-        tool_chunks: dict[tuple[int, int], dict[str, Any]] = {}
-        order: list[tuple[int, int]] = []
+        tool_chunks: dict[tuple[int, object], dict[str, Any]] = {}
+        order: list[tuple[int, object]] = []
         closer = getattr(stream, "close", None)
         cancel_event = cancellation
         closed_by_cancel = False
@@ -645,58 +737,134 @@ class LLMResponseParser:
     def parse_tool_calls(self, tool_calls: Any) -> tuple[LLMToolCall, ...]:
         if not tool_calls:
             return ()
+
         iterable = [tool_calls] if isinstance(tool_calls, Mapping) else list(tool_calls)
         parsed: list[LLMToolCall] = []
+
         for idx, call in enumerate(iterable):
             if isinstance(call, LLMToolCall):
                 parsed.append(call)
                 continue
-            if isinstance(call, Mapping):
-                call_id = call.get("id") or call.get("tool_call_id")
-                function = call.get("function")
-                if not isinstance(function, Mapping):
-                    function = {}
-                name = function.get("name")
-                arguments_payload = function.get("arguments")
-            else:  # pragma: no cover - defensive for duck typing
-                call_id = getattr(call, "id", None)
-                function = getattr(call, "function", None)
-                name = getattr(function, "name", None) if function else None
-                arguments_payload = (
-                    getattr(function, "arguments", None) if function else None
+
+            call_map = extract_mapping(call)
+            call_id = None
+            function_payload: Any | None = None
+            function_object: Any | None = None
+            if call_map is not None:
+                call_id = (
+                    call_map.get("id")
+                    or call_map.get("tool_call_id")
+                    or call_map.get("call_id")
                 )
+                function_payload = call_map.get("function") or call_map.get("call")
+            function_object = getattr(call, "function", None) or getattr(call, "call", None)
+            if function_payload is None and function_object is not None:
+                function_payload = function_object
+            function_map = extract_mapping(function_payload)
+
+            name = None
+            if function_map is not None:
+                name = function_map.get("name") or function_map.get("tool_name")
+            if name is None and function_object is not None:
+                name = getattr(function_object, "name", None)
+            if name is None and call_map is not None:
+                name = call_map.get("name")
+            if name is None:
+                name = getattr(call, "name", None)
             if not name:
                 raise ToolValidationError(
                     "LLM response did not include a tool name",
                 )
+
+            if call_id is None:
+                call_id = (
+                    getattr(call, "id", None)
+                    or getattr(call, "tool_call_id", None)
+                    or getattr(call, "call_id", None)
+                )
+            if call_id is None and call_map is not None:
+                call_id = call_map.get("call_id")
             if call_id is None:
                 call_id = f"tool_call_{idx}"
-            if isinstance(arguments_payload, str):
-                arguments_text = arguments_payload or "{}"
-            else:
-                try:
-                    arguments_text = json.dumps(
-                        arguments_payload or {}, ensure_ascii=False
-                    )
-                except (TypeError, ValueError) as exc:
-                    raise ToolValidationError(
-                        "LLM returned invalid JSON for tool arguments",
-                    ) from exc
             call_id_str = str(call_id)
-            arguments = self._decode_tool_arguments(
-                arguments_text or "{}",
+
+            arguments_payload = None
+            if function_map is not None and "arguments" in function_map:
+                arguments_payload = function_map.get("arguments")
+            if arguments_payload is None and function_object is not None:
+                arguments_payload = getattr(function_object, "arguments", None)
+            if arguments_payload is None and call_map is not None:
+                arguments_payload = call_map.get("arguments")
+            if arguments_payload is None:
+                arguments_payload = getattr(call, "arguments", None)
+
+            prepared_arguments = self._prepare_tool_arguments(
+                arguments_payload,
                 call_id=call_id_str,
                 tool_name=str(name),
             )
-            if arguments is None or not isinstance(arguments, Mapping):
-                raise ToolValidationError(
-                    "Tool arguments must be a JSON object",
-                )
-            prepared_arguments = dict(arguments)
+
             parsed.append(
-                LLMToolCall(id=call_id_str, name=name, arguments=prepared_arguments)
+                LLMToolCall(
+                    id=call_id_str,
+                    name=str(name),
+                    arguments=prepared_arguments,
+                )
             )
+
         return tuple(parsed)
+
+    def _prepare_tool_arguments(
+        self,
+        payload: Any,
+        *,
+        call_id: str,
+        tool_name: str,
+    ) -> Mapping[str, Any]:
+        mapping_candidate = None
+        if isinstance(payload, Mapping):
+            mapping_candidate = payload
+        else:
+            mapping_candidate = _extract_tool_argument_mapping(payload)
+        if mapping_candidate is not None:
+            safe_mapping = make_json_safe(
+                mapping_candidate,
+                stringify_keys=True,
+                coerce_sequences=True,
+                default=str,
+            )
+            if isinstance(safe_mapping, Mapping):
+                return dict(safe_mapping)
+
+        if isinstance(payload, bytes):
+            text = payload.decode("utf-8", errors="replace")
+        elif isinstance(payload, str):
+            text = payload
+        elif payload is None:
+            text = "{}"
+        else:
+            text = _stringify_tool_arguments(payload)
+
+        arguments = self._decode_tool_arguments(
+            text or "{}",
+            call_id=call_id,
+            tool_name=tool_name,
+        )
+        if arguments is None or not isinstance(arguments, Mapping):
+            raise ToolValidationError(
+                "Tool arguments must be a JSON object",
+            )
+        safe_arguments = make_json_safe(
+            arguments,
+            stringify_keys=True,
+            coerce_sequences=True,
+            default=str,
+        )
+        if isinstance(safe_arguments, Mapping):
+            return dict(safe_arguments)
+        raise ToolValidationError(
+            "Tool arguments must be a JSON object",
+        )
 
     # ------------------------------------------------------------------
     def _extract_reasoning_tool_calls(self, payload: Any) -> list[dict[str, Any]]:
@@ -822,15 +990,32 @@ class LLMResponseParser:
     # ------------------------------------------------------------------
     def _append_stream_tool_call(
         self,
-        tool_chunks: dict[tuple[int, int], dict[str, Any]],
-        order: list[tuple[int, int]],
+        tool_chunks: dict[tuple[int, object], dict[str, Any]],
+        order: list[tuple[int, object]],
         tool_call: Any,
         *,
         choice_index: int,
         tool_index: int | None = None,
     ) -> None:
         call_map = extract_mapping(tool_call)
-        key = (choice_index, tool_index or len(order))
+        call_id = getattr(tool_call, "id", None)
+        if call_map is not None and call_id is None:
+            call_id = (
+                call_map.get("id")
+                or call_map.get("tool_call_id")
+                or call_map.get("call_id")
+            )
+        if call_id is None:
+            call_id = getattr(tool_call, "call_id", None)
+
+        if tool_index is not None:
+            key_token: object = tool_index
+        elif call_id is not None:
+            key_token = call_id
+        else:
+            key_token = ("auto", len(order))
+
+        key = (choice_index, key_token)
         if key not in tool_chunks:
             tool_chunks[key] = {
                 "id": None,
@@ -838,12 +1023,12 @@ class LLMResponseParser:
                 "function": {"name": None, "arguments": ""},
             }
             order.append(key)
+
         entry = tool_chunks[key]
-        call_id = getattr(tool_call, "id", None)
-        if call_map is not None and call_id is None:
-            call_id = call_map.get("id") or call_map.get("tool_call_id")
+
         if call_id:
             entry["id"] = call_id
+
         function = call_map.get("function") if call_map else None
         if function is None:
             function = getattr(tool_call, "function", None)
@@ -851,27 +1036,50 @@ class LLMResponseParser:
             func_map = extract_mapping(function)
         else:
             func_map = None
+
         name = getattr(function, "name", None)
         if func_map is not None and name is None:
             name = func_map.get("name")
+        if name is None and call_map is not None:
+            name = call_map.get("name")
+        if name is None:
+            name = getattr(tool_call, "name", None)
         if name:
             entry["function"]["name"] = name
+
         args_fragment = getattr(function, "arguments", None) if function else None
         if func_map is not None:
             args_fragment = func_map.get("arguments", args_fragment)
+        if args_fragment is None and call_map is not None:
+            args_fragment = call_map.get("arguments")
+        if args_fragment is None:
+            args_fragment = getattr(tool_call, "arguments", None)
         if args_fragment:
             entry["function"]["arguments"] += str(args_fragment)
 
     def _append_stream_function_call(
         self,
-        tool_chunks: dict[tuple[int, int], dict[str, Any]],
-        order: list[tuple[int, int]],
+        tool_chunks: dict[tuple[int, object], dict[str, Any]],
+        order: list[tuple[int, object]],
         function_call: Any,
         *,
         choice_index: int,
     ) -> None:
         func_map = extract_mapping(function_call)
-        key = (choice_index, -1)
+        call_id = None
+        if func_map is not None:
+            call_id = (
+                func_map.get("id")
+                or func_map.get("call_id")
+                or func_map.get("tool_call_id")
+            )
+        if call_id is None:
+            call_id = getattr(function_call, "id", None)
+        if call_id is None:
+            call_id = getattr(function_call, "call_id", None)
+
+        key_token: object = call_id if call_id is not None else -1
+        key = (choice_index, key_token)
         if key not in tool_chunks:
             tool_chunks[key] = {
                 "id": None,
@@ -879,7 +1087,11 @@ class LLMResponseParser:
                 "function": {"name": None, "arguments": ""},
             }
             order.append(key)
+
         entry = tool_chunks[key]
+        if call_id is not None:
+            entry["id"] = call_id
+
         name = getattr(function_call, "name", None)
         if func_map is not None and name is None:
             name = func_map.get("name")

--- a/app/ui/agent_chat_panel/view_model.py
+++ b/app/ui/agent_chat_panel/view_model.py
@@ -531,7 +531,11 @@ def _build_tool_calls(
         if tool_result_section is not None:
             raw_sections["tool_result"] = tool_result_section
 
-        condensed_raw = history_json_safe(raw_sections) if raw_sections else None
+        if raw_sections:
+            deduplicated_sections = _deduplicate_tool_raw_sections(raw_sections)
+            condensed_raw = history_json_safe(deduplicated_sections)
+        else:
+            condensed_raw = None
 
         call_timestamp_raw = _extract_tool_timestamp(payload)
         if call_timestamp_raw:
@@ -560,7 +564,7 @@ def _build_tool_calls(
     return tuple(tool_calls), latest_timestamp
 
 
-def _compose_tool_raw_data(raw_snapshot: Any) -> Any | None:
+def _compose_tool_raw_data(raw_snapshot: Any) -> Mapping[str, Any] | None:
     """Prepare JSON-safe raw sections for a tool call."""
 
     if not isinstance(raw_snapshot, Mapping):
@@ -585,7 +589,7 @@ def _compose_tool_raw_data(raw_snapshot: Any) -> Any | None:
         if diagnostics_section:
             sections["diagnostics"] = diagnostics_section
 
-    return history_json_safe(sections) if sections else None
+    return sections or None
 
 
 def _compose_tool_result_section(tool_payload: Any) -> Mapping[str, Any] | None:
@@ -670,7 +674,145 @@ def _compose_tool_result_section(tool_payload: Any) -> Mapping[str, Any] | None:
         else:
             sections["timeline"] = {key: value for key, value in timeline}
 
-    return history_json_safe(sections) if sections else None
+    return sections or None
+
+
+def _deduplicate_tool_raw_sections(sections: Mapping[str, Any]) -> dict[str, Any]:
+    """Remove repeated tool arguments while keeping the richest snapshot."""
+
+    if not isinstance(sections, Mapping):
+        return {}
+
+    working: dict[str, Any] = dict(sections)
+    primary_location, canonical_arguments = _select_primary_tool_arguments(working)
+    if canonical_arguments is None or primary_location is None:
+        return working
+
+    def _matches(value: Any) -> bool:
+        return value == canonical_arguments
+
+    # Drop duplicate arguments from the LLM request.
+    if primary_location != ("llm_request", "arguments"):
+        request_section = working.get("llm_request")
+        if isinstance(request_section, Mapping) and _matches(request_section.get("arguments")):
+            trimmed = {k: v for k, v in request_section.items() if k != "arguments"}
+            if trimmed:
+                working["llm_request"] = trimmed
+            else:
+                working.pop("llm_request", None)
+
+    # Drop duplicate arguments from the LLM response tool calls.
+    if not (primary_location and primary_location[0] == "llm_response"):
+        response_section = working.get("llm_response")
+        if isinstance(response_section, Mapping):
+            tool_calls = response_section.get("tool_calls")
+            if isinstance(tool_calls, Sequence) and not isinstance(tool_calls, (str, bytes, bytearray)):
+                calls_changed = False
+                processed_calls: list[Any] = []
+                for index, call in enumerate(tool_calls):
+                    if not isinstance(call, Mapping):
+                        processed_calls.append(call)
+                        continue
+                    call_mapping = dict(call)
+                    call_arguments = call_mapping.get("arguments")
+                    if _matches(call_arguments):
+                        call_mapping.pop("arguments", None)
+                        calls_changed = True
+                    if call_mapping:
+                        processed_calls.append(call_mapping)
+                    else:
+                        calls_changed = True
+                if calls_changed:
+                    updated_response = dict(response_section)
+                    updated_response["tool_calls"] = processed_calls
+                    if not processed_calls and len(updated_response) == 1:
+                        working.pop("llm_response", None)
+                    else:
+                        working["llm_response"] = updated_response
+    else:
+        # Keep the canonical response call intact while trimming siblings.
+        response_section = working.get("llm_response")
+        if isinstance(response_section, Mapping):
+            tool_calls = response_section.get("tool_calls")
+            if isinstance(tool_calls, Sequence) and not isinstance(tool_calls, (str, bytes, bytearray)):
+                calls_changed = False
+                processed_calls: list[Any] = []
+                target_index = primary_location[2] if len(primary_location) > 2 else None
+                for index, call in enumerate(tool_calls):
+                    if not isinstance(call, Mapping):
+                        processed_calls.append(call)
+                        continue
+                    call_mapping = dict(call)
+                    if index == target_index:
+                        processed_calls.append(call_mapping)
+                        continue
+                    call_arguments = call_mapping.get("arguments")
+                    if _matches(call_arguments):
+                        call_mapping.pop("arguments", None)
+                        calls_changed = True
+                    if call_mapping:
+                        processed_calls.append(call_mapping)
+                    else:
+                        calls_changed = True
+                if calls_changed:
+                    updated_response = dict(response_section)
+                    updated_response["tool_calls"] = processed_calls
+                    if not processed_calls and len(updated_response) == 1:
+                        working.pop("llm_response", None)
+                    else:
+                        working["llm_response"] = updated_response
+
+    # When the canonical location is not the tool result, drop duplicate data there too.
+    if primary_location != ("tool_result", "tool", "arguments"):
+        tool_result = working.get("tool_result")
+        if isinstance(tool_result, Mapping):
+            tool_section = tool_result.get("tool")
+            if isinstance(tool_section, Mapping) and _matches(tool_section.get("arguments")):
+                trimmed_tool = {k: v for k, v in tool_section.items() if k != "arguments"}
+                updated_result = dict(tool_result)
+                if trimmed_tool:
+                    updated_result["tool"] = trimmed_tool
+                else:
+                    updated_result.pop("tool", None)
+                if updated_result:
+                    working["tool_result"] = updated_result
+                else:
+                    working.pop("tool_result", None)
+
+    return working
+
+
+def _select_primary_tool_arguments(
+    sections: Mapping[str, Any],
+) -> tuple[tuple[Any, ...] | None, Any | None]:
+    """Return the preferred arguments payload and its location."""
+
+    tool_result = sections.get("tool_result") if isinstance(sections, Mapping) else None
+    if isinstance(tool_result, Mapping):
+        tool_section = tool_result.get("tool")
+        if isinstance(tool_section, Mapping):
+            arguments = tool_section.get("arguments")
+            if _has_meaningful_payload(arguments):
+                return ("tool_result", "tool", "arguments"), arguments
+
+    response_section = sections.get("llm_response") if isinstance(sections, Mapping) else None
+    if isinstance(response_section, Mapping):
+        tool_calls = response_section.get("tool_calls")
+        if isinstance(tool_calls, Sequence) and not isinstance(tool_calls, (str, bytes, bytearray)):
+            for index, call in enumerate(tool_calls):
+                if not isinstance(call, Mapping):
+                    continue
+                arguments = call.get("arguments")
+                if _has_meaningful_payload(arguments):
+                    return ("llm_response", "tool_calls", index, "arguments"), arguments
+
+    request_section = sections.get("llm_request") if isinstance(sections, Mapping) else None
+    if isinstance(request_section, Mapping):
+        arguments = request_section.get("arguments")
+        if _has_meaningful_payload(arguments):
+            return ("llm_request", "arguments"), arguments
+
+    return (None, None)
 
 
 def _collect_unique_timestamps(

--- a/tests/data/real_llm_tool_validation_error.json
+++ b/tests/data/real_llm_tool_validation_error.json
@@ -2,36 +2,65 @@
   "ok": false,
   "error": {
     "code": "VALIDATION_ERROR",
-    "message": "update_requirement_field() missing rid",
+    "message": "Invalid arguments for update_requirement_field: value: 'in_last_review' is not one of ['draft', 'in_review', 'approved', 'baselined', 'retired']",
     "details": {
       "type": "ToolValidationError",
-      "llm_message": "update_requirement_field() missing rid (type: ToolValidationError)",
+      "llm_message": "Invalid arguments for update_requirement_field: value: 'in_last_review' is not one of ['draft', 'in_review', 'approved', 'baselined', 'retired']",
       "llm_tool_calls": [
         {
-          "id": "chatcmpl-tool-611391fa5c1846cc9885187a8197f0e9",
+          "id": "chatcmpl-tool-1",
           "type": "function",
           "function": {
             "name": "update_requirement_field",
-            "arguments": "{\"field\": \"statement\", \"value\": \"La demo debe mostrar la CLI\"}"
+            "arguments": "{\"rid\": \"DEMO1\", \"field\": \"status\", \"value\": \"in_last_review\"}"
           }
         }
       ]
     }
   },
   "tool_name": "update_requirement_field",
-  "tool_call_id": "chatcmpl-tool-611391fa5c1846cc9885187a8197f0e9",
-  "call_id": "chatcmpl-tool-611391fa5c1846cc9885187a8197f0e9",
+  "tool_call_id": "chatcmpl-tool-1",
+  "call_id": "chatcmpl-tool-1",
   "tool_arguments": {
-    "field": "statement",
-    "value": "La demo debe mostrar la CLI"
+    "rid": "DEMO1",
+    "field": "status",
+    "value": "in_last_review"
   },
   "agent_status": "failed",
   "agent_stop_reason": {
     "type": "consecutive_tool_errors",
-    "count": 5,
+    "count": 2,
     "max_consecutive_tool_errors": 5
   },
+  "status_updates": [
+    {
+      "status": "running",
+      "message": "Applying updates",
+      "at": "2025-10-03T08:27:30+00:00"
+    },
+    {
+      "status": "failed",
+      "at": "2025-10-03T08:27:30+00:00"
+    }
+  ],
   "diagnostic": {
+    "tool_calls": [
+      {
+        "call": {
+          "id": "chatcmpl-tool-1",
+          "name": "update_requirement_field",
+          "arguments": {
+            "rid": "DEMO1",
+            "field": "status",
+            "value": "in_last_review"
+          }
+        },
+        "context": {
+          "agent_status": "failed",
+          "status_updates": ["retrying"]
+        }
+      }
+    ],
     "llm_requests": [
       {
         "step": 1,
@@ -42,7 +71,7 @@
           },
           {
             "role": "user",
-            "content": "Переведи выделенные требования на испанский язык. Ответ должен быть только в виде вызова инструмента update_requirement_field. Вызов должен содержать только поля field и value. Поле rid опускаем намеренно. Не добавляй пояснения, не меняй формат вызова инструмента."
+            "content": "Установи статус требования DEMO1 на 'in_last_review'. Ответ должен быть только в виде вызова инструмента update_requirement_field. Добавь поля rid, field, value."
           }
         ]
       },
@@ -55,246 +84,27 @@
           },
           {
             "role": "user",
-            "content": "Переведи выделенные требования на испанский язык. Ответ должен быть только в виде вызова инструмента update_requirement_field. Вызов должен содержать только поля field и value. Поле rid опускаем намеренно. Не добавляй пояснения, не меняй формат вызова инструмента."
+            "content": "Установи статус требования DEMO1 на 'in_last_review'. Ответ должен быть только в виде вызова инструмента update_requirement_field. Добавь поля rid, field, value."
           },
           {
             "role": "assistant",
-            "content": "update_requirement_field() missing rid (type: ToolValidationError)",
+            "content": "Invalid arguments for update_requirement_field: value: 'in_last_review' is not one of ['draft', 'in_review', 'approved', 'baselined', 'retired']",
             "tool_calls": [
               {
-                "id": "chatcmpl-tool-f3054a58b4704173b0b7875c2a0d9757",
+                "id": "chatcmpl-tool-2",
                 "type": "function",
                 "function": {
                   "name": "update_requirement_field",
-                  "arguments": "{\"field\": \"statement\", \"value\": \"La demo debe proporcionar traducciones\"}"
+                  "arguments": "{\"rid\": \"DEMO1\", \"field\": \"status\", \"value\": \"in_last_review\"}"
                 }
               }
             ]
           },
           {
             "role": "tool",
-            "tool_call_id": "chatcmpl-tool-f3054a58b4704173b0b7875c2a0d9757",
+            "tool_call_id": "chatcmpl-tool-2",
             "name": "update_requirement_field",
-            "content": "{\"ok\": false, \"error\": {\"code\": \"VALIDATION_ERROR\", \"message\": \"update_requirement_field() missing rid\", \"details\": {\"type\": \"ToolValidationError\", \"llm_message\": \"update_requirement_field() missing rid (type: ToolValidationError)\", \"llm_tool_calls\": [{\"id\": \"chatcmpl-tool-f3054a58b4704173b0b7875c2a0d9757\", \"type\": \"function\", \"function\": {\"name\": \"update_requirement_field\", \"arguments\": \"{\\\"field\\\": \\\"statement\\\", \\\"value\\\": \\\"La demo debe proporcionar traducciones\\\"}\"}}]}}, \"tool_name\": \"update_requirement_field\", \"tool_call_id\": \"chatcmpl-tool-f3054a58b4704173b0b7875c2a0d9757\", \"call_id\": \"chatcmpl-tool-f3054a58b4704173b0b7875c2a0d9757\", \"tool_arguments\": {\"field\": \"statement\", \"value\": \"La demo debe proporcionar traducciones\"}, \"agent_status\": \"failed\"}"
-          }
-        ]
-      },
-      {
-        "step": 3,
-        "messages": [
-          {
-            "role": "system",
-            "content": "[Workspace context]\nActive document: DEMO — Demo requirements\nSelected requirement RIDs: DEMO1, DEMO2, DEMO3\nDEMO1 — Demo introduction — The demo shall show the CLI\nDEMO2 — Demo architecture — The demo shall describe architecture\nDEMO3 — Demo translation — The demo shall provide translations"
-          },
-          {
-            "role": "user",
-            "content": "Переведи выделенные требования на испанский язык. Ответ должен быть только в виде вызова инструмента update_requirement_field. Вызов должен содержать только поля field и value. Поле rid опускаем намеренно. Не добавляй пояснения, не меняй формат вызова инструмента."
-          },
-          {
-            "role": "assistant",
-            "content": "update_requirement_field() missing rid (type: ToolValidationError)",
-            "tool_calls": [
-              {
-                "id": "chatcmpl-tool-f3054a58b4704173b0b7875c2a0d9757",
-                "type": "function",
-                "function": {
-                  "name": "update_requirement_field",
-                  "arguments": "{\"field\": \"statement\", \"value\": \"La demo debe proporcionar traducciones\"}"
-                }
-              }
-            ]
-          },
-          {
-            "role": "tool",
-            "tool_call_id": "chatcmpl-tool-f3054a58b4704173b0b7875c2a0d9757",
-            "name": "update_requirement_field",
-            "content": "{\"ok\": false, \"error\": {\"code\": \"VALIDATION_ERROR\", \"message\": \"update_requirement_field() missing rid\", \"details\": {\"type\": \"ToolValidationError\", \"llm_message\": \"update_requirement_field() missing rid (type: ToolValidationError)\", \"llm_tool_calls\": [{\"id\": \"chatcmpl-tool-f3054a58b4704173b0b7875c2a0d9757\", \"type\": \"function\", \"function\": {\"name\": \"update_requirement_field\", \"arguments\": \"{\\\"field\\\": \\\"statement\\\", \\\"value\\\": \\\"La demo debe proporcionar traducciones\\\"}\"}}]}}, \"tool_name\": \"update_requirement_field\", \"tool_call_id\": \"chatcmpl-tool-f3054a58b4704173b0b7875c2a0d9757\", \"call_id\": \"chatcmpl-tool-f3054a58b4704173b0b7875c2a0d9757\", \"tool_arguments\": {\"field\": \"statement\", \"value\": \"La demo debe proporcionar traducciones\"}, \"agent_status\": \"failed\"}"
-          },
-          {
-            "role": "assistant",
-            "content": "update_requirement_field() missing rid (type: ToolValidationError)",
-            "tool_calls": [
-              {
-                "id": "chatcmpl-tool-3a5e8d8d18c3434bbb31ae2d0db2096e",
-                "type": "function",
-                "function": {
-                  "name": "update_requirement_field",
-                  "arguments": "{\"field\": \"statement\", \"value\": \"La demo debe mostrar la CLI\"}"
-                }
-              }
-            ]
-          },
-          {
-            "role": "tool",
-            "tool_call_id": "chatcmpl-tool-3a5e8d8d18c3434bbb31ae2d0db2096e",
-            "name": "update_requirement_field",
-            "content": "{\"ok\": false, \"error\": {\"code\": \"VALIDATION_ERROR\", \"message\": \"update_requirement_field() missing rid\", \"details\": {\"type\": \"ToolValidationError\", \"llm_message\": \"update_requirement_field() missing rid (type: ToolValidationError)\", \"llm_tool_calls\": [{\"id\": \"chatcmpl-tool-3a5e8d8d18c3434bbb31ae2d0db2096e\", \"type\": \"function\", \"function\": {\"name\": \"update_requirement_field\", \"arguments\": \"{\\\"field\\\": \\\"statement\\\", \\\"value\\\": \\\"La demo debe mostrar la CLI\\\"}\"}}]}}, \"tool_name\": \"update_requirement_field\", \"tool_call_id\": \"chatcmpl-tool-3a5e8d8d18c3434bbb31ae2d0db2096e\", \"call_id\": \"chatcmpl-tool-3a5e8d8d18c3434bbb31ae2d0db2096e\", \"tool_arguments\": {\"field\": \"statement\", \"value\": \"La demo debe mostrar la CLI\"}, \"agent_status\": \"failed\"}"
-          }
-        ]
-      },
-      {
-        "step": 4,
-        "messages": [
-          {
-            "role": "system",
-            "content": "[Workspace context]\nActive document: DEMO — Demo requirements\nSelected requirement RIDs: DEMO1, DEMO2, DEMO3\nDEMO1 — Demo introduction — The demo shall show the CLI\nDEMO2 — Demo architecture — The demo shall describe architecture\nDEMO3 — Demo translation — The demo shall provide translations"
-          },
-          {
-            "role": "user",
-            "content": "Переведи выделенные требования на испанский язык. Ответ должен быть только в виде вызова инструмента update_requirement_field. Вызов должен содержать только поля field и value. Поле rid опускаем намеренно. Не добавляй пояснения, не меняй формат вызова инструмента."
-          },
-          {
-            "role": "assistant",
-            "content": "update_requirement_field() missing rid (type: ToolValidationError)",
-            "tool_calls": [
-              {
-                "id": "chatcmpl-tool-f3054a58b4704173b0b7875c2a0d9757",
-                "type": "function",
-                "function": {
-                  "name": "update_requirement_field",
-                  "arguments": "{\"field\": \"statement\", \"value\": \"La demo debe proporcionar traducciones\"}"
-                }
-              }
-            ]
-          },
-          {
-            "role": "tool",
-            "tool_call_id": "chatcmpl-tool-f3054a58b4704173b0b7875c2a0d9757",
-            "name": "update_requirement_field",
-            "content": "{\"ok\": false, \"error\": {\"code\": \"VALIDATION_ERROR\", \"message\": \"update_requirement_field() missing rid\", \"details\": {\"type\": \"ToolValidationError\", \"llm_message\": \"update_requirement_field() missing rid (type: ToolValidationError)\", \"llm_tool_calls\": [{\"id\": \"chatcmpl-tool-f3054a58b4704173b0b7875c2a0d9757\", \"type\": \"function\", \"function\": {\"name\": \"update_requirement_field\", \"arguments\": \"{\\\"field\\\": \\\"statement\\\", \\\"value\\\": \\\"La demo debe proporcionar traducciones\\\"}\"}}]}}, \"tool_name\": \"update_requirement_field\", \"tool_call_id\": \"chatcmpl-tool-f3054a58b4704173b0b7875c2a0d9757\", \"call_id\": \"chatcmpl-tool-f3054a58b4704173b0b7875c2a0d9757\", \"tool_arguments\": {\"field\": \"statement\", \"value\": \"La demo debe proporcionar traducciones\"}, \"agent_status\": \"failed\"}"
-          },
-          {
-            "role": "assistant",
-            "content": "update_requirement_field() missing rid (type: ToolValidationError)",
-            "tool_calls": [
-              {
-                "id": "chatcmpl-tool-3a5e8d8d18c3434bbb31ae2d0db2096e",
-                "type": "function",
-                "function": {
-                  "name": "update_requirement_field",
-                  "arguments": "{\"field\": \"statement\", \"value\": \"La demo debe mostrar la CLI\"}"
-                }
-              }
-            ]
-          },
-          {
-            "role": "tool",
-            "tool_call_id": "chatcmpl-tool-3a5e8d8d18c3434bbb31ae2d0db2096e",
-            "name": "update_requirement_field",
-            "content": "{\"ok\": false, \"error\": {\"code\": \"VALIDATION_ERROR\", \"message\": \"update_requirement_field() missing rid\", \"details\": {\"type\": \"ToolValidationError\", \"llm_message\": \"update_requirement_field() missing rid (type: ToolValidationError)\", \"llm_tool_calls\": [{\"id\": \"chatcmpl-tool-3a5e8d8d18c3434bbb31ae2d0db2096e\", \"type\": \"function\", \"function\": {\"name\": \"update_requirement_field\", \"arguments\": \"{\\\"field\\\": \\\"statement\\\", \\\"value\\\": \\\"La demo debe mostrar la CLI\\\"}\"}}]}}, \"tool_name\": \"update_requirement_field\", \"tool_call_id\": \"chatcmpl-tool-3a5e8d8d18c3434bbb31ae2d0db2096e\", \"call_id\": \"chatcmpl-tool-3a5e8d8d18c3434bbb31ae2d0db2096e\", \"tool_arguments\": {\"field\": \"statement\", \"value\": \"La demo debe mostrar la CLI\"}, \"agent_status\": \"failed\"}"
-          },
-          {
-            "role": "assistant",
-            "content": "update_requirement_field() missing rid (type: ToolValidationError)",
-            "tool_calls": [
-              {
-                "id": "chatcmpl-tool-107c35414d364fb099172b084ff83f43",
-                "type": "function",
-                "function": {
-                  "name": "update_requirement_field",
-                  "arguments": "{\"field\": \"statement\", \"value\": \"La demo debe describir arquitectura\"}"
-                }
-              }
-            ]
-          },
-          {
-            "role": "tool",
-            "tool_call_id": "chatcmpl-tool-107c35414d364fb099172b084ff83f43",
-            "name": "update_requirement_field",
-            "content": "{\"ok\": false, \"error\": {\"code\": \"VALIDATION_ERROR\", \"message\": \"update_requirement_field() missing rid\", \"details\": {\"type\": \"ToolValidationError\", \"llm_message\": \"update_requirement_field() missing rid (type: ToolValidationError)\", \"llm_tool_calls\": [{\"id\": \"chatcmpl-tool-107c35414d364fb099172b084ff83f43\", \"type\": \"function\", \"function\": {\"name\": \"update_requirement_field\", \"arguments\": \"{\\\"field\\\": \\\"statement\\\", \\\"value\\\": \\\"La demo debe describir arquitectura\\\"}\"}}]}}, \"tool_name\": \"update_requirement_field\", \"tool_call_id\": \"chatcmpl-tool-107c35414d364fb099172b084ff83f43\", \"call_id\": \"chatcmpl-tool-107c35414d364fb099172b084ff83f43\", \"tool_arguments\": {\"field\": \"statement\", \"value\": \"La demo debe describir arquitectura\"}, \"agent_status\": \"failed\"}"
-          }
-        ]
-      },
-      {
-        "step": 5,
-        "messages": [
-          {
-            "role": "system",
-            "content": "[Workspace context]\nActive document: DEMO — Demo requirements\nSelected requirement RIDs: DEMO1, DEMO2, DEMO3\nDEMO1 — Demo introduction — The demo shall show the CLI\nDEMO2 — Demo architecture — The demo shall describe architecture\nDEMO3 — Demo translation — The demo shall provide translations"
-          },
-          {
-            "role": "user",
-            "content": "Переведи выделенные требования на испанский язык. Ответ должен быть только в виде вызова инструмента update_requirement_field. Вызов должен содержать только поля field и value. Поле rid опускаем намеренно. Не добавляй пояснения, не меняй формат вызова инструмента."
-          },
-          {
-            "role": "assistant",
-            "content": "update_requirement_field() missing rid (type: ToolValidationError)",
-            "tool_calls": [
-              {
-                "id": "chatcmpl-tool-f3054a58b4704173b0b7875c2a0d9757",
-                "type": "function",
-                "function": {
-                  "name": "update_requirement_field",
-                  "arguments": "{\"field\": \"statement\", \"value\": \"La demo debe proporcionar traducciones\"}"
-                }
-              }
-            ]
-          },
-          {
-            "role": "tool",
-            "tool_call_id": "chatcmpl-tool-f3054a58b4704173b0b7875c2a0d9757",
-            "name": "update_requirement_field",
-            "content": "{\"ok\": false, \"error\": {\"code\": \"VALIDATION_ERROR\", \"message\": \"update_requirement_field() missing rid\", \"details\": {\"type\": \"ToolValidationError\", \"llm_message\": \"update_requirement_field() missing rid (type: ToolValidationError)\", \"llm_tool_calls\": [{\"id\": \"chatcmpl-tool-f3054a58b4704173b0b7875c2a0d9757\", \"type\": \"function\", \"function\": {\"name\": \"update_requirement_field\", \"arguments\": \"{\\\"field\\\": \\\"statement\\\", \\\"value\\\": \\\"La demo debe proporcionar traducciones\\\"}\"}}]}}, \"tool_name\": \"update_requirement_field\", \"tool_call_id\": \"chatcmpl-tool-f3054a58b4704173b0b7875c2a0d9757\", \"call_id\": \"chatcmpl-tool-f3054a58b4704173b0b7875c2a0d9757\", \"tool_arguments\": {\"field\": \"statement\", \"value\": \"La demo debe proporcionar traducciones\"}, \"agent_status\": \"failed\"}"
-          },
-          {
-            "role": "assistant",
-            "content": "update_requirement_field() missing rid (type: ToolValidationError)",
-            "tool_calls": [
-              {
-                "id": "chatcmpl-tool-3a5e8d8d18c3434bbb31ae2d0db2096e",
-                "type": "function",
-                "function": {
-                  "name": "update_requirement_field",
-                  "arguments": "{\"field\": \"statement\", \"value\": \"La demo debe mostrar la CLI\"}"
-                }
-              }
-            ]
-          },
-          {
-            "role": "tool",
-            "tool_call_id": "chatcmpl-tool-3a5e8d8d18c3434bbb31ae2d0db2096e",
-            "name": "update_requirement_field",
-            "content": "{\"ok\": false, \"error\": {\"code\": \"VALIDATION_ERROR\", \"message\": \"update_requirement_field() missing rid\", \"details\": {\"type\": \"ToolValidationError\", \"llm_message\": \"update_requirement_field() missing rid (type: ToolValidationError)\", \"llm_tool_calls\": [{\"id\": \"chatcmpl-tool-3a5e8d8d18c3434bbb31ae2d0db2096e\", \"type\": \"function\", \"function\": {\"name\": \"update_requirement_field\", \"arguments\": \"{\\\"field\\\": \\\"statement\\\", \\\"value\\\": \\\"La demo debe mostrar la CLI\\\"}\"}}]}}, \"tool_name\": \"update_requirement_field\", \"tool_call_id\": \"chatcmpl-tool-3a5e8d8d18c3434bbb31ae2d0db2096e\", \"call_id\": \"chatcmpl-tool-3a5e8d8d18c3434bbb31ae2d0db2096e\", \"tool_arguments\": {\"field\": \"statement\", \"value\": \"La demo debe mostrar la CLI\"}, \"agent_status\": \"failed\"}"
-          },
-          {
-            "role": "assistant",
-            "content": "update_requirement_field() missing rid (type: ToolValidationError)",
-            "tool_calls": [
-              {
-                "id": "chatcmpl-tool-107c35414d364fb099172b084ff83f43",
-                "type": "function",
-                "function": {
-                  "name": "update_requirement_field",
-                  "arguments": "{\"field\": \"statement\", \"value\": \"La demo debe describir arquitectura\"}"
-                }
-              }
-            ]
-          },
-          {
-            "role": "tool",
-            "tool_call_id": "chatcmpl-tool-107c35414d364fb099172b084ff83f43",
-            "name": "update_requirement_field",
-            "content": "{\"ok\": false, \"error\": {\"code\": \"VALIDATION_ERROR\", \"message\": \"update_requirement_field() missing rid\", \"details\": {\"type\": \"ToolValidationError\", \"llm_message\": \"update_requirement_field() missing rid (type: ToolValidationError)\", \"llm_tool_calls\": [{\"id\": \"chatcmpl-tool-107c35414d364fb099172b084ff83f43\", \"type\": \"function\", \"function\": {\"name\": \"update_requirement_field\", \"arguments\": \"{\\\"field\\\": \\\"statement\\\", \\\"value\\\": \\\"La demo debe describir arquitectura\\\"}\"}}]}}, \"tool_name\": \"update_requirement_field\", \"tool_call_id\": \"chatcmpl-tool-107c35414d364fb099172b084ff83f43\", \"call_id\": \"chatcmpl-tool-107c35414d364fb099172b084ff83f43\", \"tool_arguments\": {\"field\": \"statement\", \"value\": \"La demo debe describir arquitectura\"}, \"agent_status\": \"failed\"}"
-          },
-          {
-            "role": "assistant",
-            "content": "update_requirement_field() missing rid (type: ToolValidationError)",
-            "tool_calls": [
-              {
-                "id": "chatcmpl-tool-a5b4ddc582654db683ae81ed385f34eb",
-                "type": "function",
-                "function": {
-                  "name": "update_requirement_field",
-                  "arguments": "{\"field\": \"statement\", \"value\": \"La demo debe proporcionar traducciones\"}"
-                }
-              }
-            ]
-          },
-          {
-            "role": "tool",
-            "tool_call_id": "chatcmpl-tool-a5b4ddc582654db683ae81ed385f34eb",
-            "name": "update_requirement_field",
-            "content": "{\"ok\": false, \"error\": {\"code\": \"VALIDATION_ERROR\", \"message\": \"update_requirement_field() missing rid\", \"details\": {\"type\": \"ToolValidationError\", \"llm_message\": \"update_requirement_field() missing rid (type: ToolValidationError)\", \"llm_tool_calls\": [{\"id\": \"chatcmpl-tool-a5b4ddc582654db683ae81ed385f34eb\", \"type\": \"function\", \"function\": {\"name\": \"update_requirement_field\", \"arguments\": \"{\\\"field\\\": \\\"statement\\\", \\\"value\\\": \\\"La demo debe proporcionar traducciones\\\"}\"}}]}}, \"tool_name\": \"update_requirement_field\", \"tool_call_id\": \"chatcmpl-tool-a5b4ddc582654db683ae81ed385f34eb\", \"call_id\": \"chatcmpl-tool-a5b4ddc582654db683ae81ed385f34eb\", \"tool_arguments\": {\"field\": \"statement\", \"value\": \"La demo debe proporcionar traducciones\"}, \"agent_status\": \"failed\"}"
+            "content": "{\"ok\": false, \"error\": {\"code\": \"VALIDATION_ERROR\", \"message\": \"Invalid arguments for update_requirement_field: value: 'in_last_review' is not one of ['draft', 'in_review', 'approved', 'baselined', 'retired']\", \"details\": {\"type\": \"ToolValidationError\"}}, \"tool_name\": \"update_requirement_field\", \"tool_call_id\": \"chatcmpl-tool-2\", \"call_id\": \"chatcmpl-tool-2\", \"tool_arguments\": {\"rid\": \"DEMO1\", \"field\": \"status\", \"value\": \"in_last_review\"}, \"agent_status\": \"failed\"}"
           }
         ]
       }
@@ -303,14 +113,15 @@
       {
         "step": 1,
         "response": {
-          "content": "update_requirement_field() missing rid (type: ToolValidationError)",
+          "content": "Invalid arguments for update_requirement_field: value: 'in_last_review' is not one of ['draft', 'in_review', 'approved', 'baselined', 'retired']",
           "tool_calls": [
             {
-              "id": "chatcmpl-tool-f3054a58b4704173b0b7875c2a0d9757",
+              "id": "chatcmpl-tool-1",
               "name": "update_requirement_field",
               "arguments": {
-                "field": "statement",
-                "value": "La demo debe proporcionar traducciones"
+                "rid": "DEMO1",
+                "field": "status",
+                "value": "in_last_review"
               }
             }
           ],
@@ -323,21 +134,22 @@
           },
           {
             "role": "user",
-            "content": "Переведи выделенные требования на испанский язык. Ответ должен быть только в виде вызова инструмента update_requirement_field. Вызов должен содержать только поля field и value. Поле rid опускаем намеренно. Не добавляй пояснения, не меняй формат вызова инструмента."
+            "content": "Установи статус требования DEMO1 на 'in_last_review'. Ответ должен быть только в виде вызова инструмента update_requirement_field. Добавь поля rid, field, value."
           }
         ]
       },
       {
         "step": 2,
         "response": {
-          "content": "update_requirement_field() missing rid (type: ToolValidationError)",
+          "content": "Invalid arguments for update_requirement_field: value: 'in_last_review' is not one of ['draft', 'in_review', 'approved', 'baselined', 'retired']",
           "tool_calls": [
             {
-              "id": "chatcmpl-tool-3a5e8d8d18c3434bbb31ae2d0db2096e",
+              "id": "chatcmpl-tool-2",
               "name": "update_requirement_field",
               "arguments": {
-                "field": "statement",
-                "value": "La demo debe mostrar la CLI"
+                "rid": "DEMO1",
+                "field": "status",
+                "value": "in_last_review"
               }
             }
           ],
@@ -350,288 +162,22 @@
           },
           {
             "role": "user",
-            "content": "Переведи выделенные требования на испанский язык. Ответ должен быть только в виде вызова инструмента update_requirement_field. Вызов должен содержать только поля field и value. Поле rid опускаем намеренно. Не добавляй пояснения, не меняй формат вызова инструмента."
+            "content": "Установи статус требования DEMO1 на 'in_last_review'. Ответ должен быть только в виде вызова инструмента update_requirement_field. Добавь поля rid, field, value."
           },
           {
             "role": "assistant",
-            "content": "update_requirement_field() missing rid (type: ToolValidationError)",
+            "content": "Invalid arguments for update_requirement_field: value: 'in_last_review' is not one of ['draft', 'in_review', 'approved', 'baselined', 'retired']",
             "tool_calls": [
               {
-                "id": "chatcmpl-tool-f3054a58b4704173b0b7875c2a0d9757",
-                "type": "function",
-                "function": {
-                  "name": "update_requirement_field",
-                  "arguments": "{\"field\": \"statement\", \"value\": \"La demo debe proporcionar traducciones\"}"
+                "id": "chatcmpl-tool-2",
+                "name": "update_requirement_field",
+                "arguments": {
+                  "rid": "DEMO1",
+                  "field": "status",
+                  "value": "in_last_review"
                 }
               }
             ]
-          },
-          {
-            "role": "tool",
-            "tool_call_id": "chatcmpl-tool-f3054a58b4704173b0b7875c2a0d9757",
-            "name": "update_requirement_field",
-            "content": "{\"ok\": false, \"error\": {\"code\": \"VALIDATION_ERROR\", \"message\": \"update_requirement_field() missing rid\", \"details\": {\"type\": \"ToolValidationError\", \"llm_message\": \"update_requirement_field() missing rid (type: ToolValidationError)\", \"llm_tool_calls\": [{\"id\": \"chatcmpl-tool-f3054a58b4704173b0b7875c2a0d9757\", \"type\": \"function\", \"function\": {\"name\": \"update_requirement_field\", \"arguments\": \"{\\\"field\\\": \\\"statement\\\", \\\"value\\\": \\\"La demo debe proporcionar traducciones\\\"}\"}}]}}, \"tool_name\": \"update_requirement_field\", \"tool_call_id\": \"chatcmpl-tool-f3054a58b4704173b0b7875c2a0d9757\", \"call_id\": \"chatcmpl-tool-f3054a58b4704173b0b7875c2a0d9757\", \"tool_arguments\": {\"field\": \"statement\", \"value\": \"La demo debe proporcionar traducciones\"}, \"agent_status\": \"failed\"}"
-          }
-        ]
-      },
-      {
-        "step": 3,
-        "response": {
-          "content": "update_requirement_field() missing rid (type: ToolValidationError)",
-          "tool_calls": [
-            {
-              "id": "chatcmpl-tool-107c35414d364fb099172b084ff83f43",
-              "name": "update_requirement_field",
-              "arguments": {
-                "field": "statement",
-                "value": "La demo debe describir arquitectura"
-              }
-            }
-          ],
-          "reasoning": []
-        },
-        "request_messages": [
-          {
-            "role": "system",
-            "content": "[Workspace context]\nActive document: DEMO — Demo requirements\nSelected requirement RIDs: DEMO1, DEMO2, DEMO3\nDEMO1 — Demo introduction — The demo shall show the CLI\nDEMO2 — Demo architecture — The demo shall describe architecture\nDEMO3 — Demo translation — The demo shall provide translations"
-          },
-          {
-            "role": "user",
-            "content": "Переведи выделенные требования на испанский язык. Ответ должен быть только в виде вызова инструмента update_requirement_field. Вызов должен содержать только поля field и value. Поле rid опускаем намеренно. Не добавляй пояснения, не меняй формат вызова инструмента."
-          },
-          {
-            "role": "assistant",
-            "content": "update_requirement_field() missing rid (type: ToolValidationError)",
-            "tool_calls": [
-              {
-                "id": "chatcmpl-tool-f3054a58b4704173b0b7875c2a0d9757",
-                "type": "function",
-                "function": {
-                  "name": "update_requirement_field",
-                  "arguments": "{\"field\": \"statement\", \"value\": \"La demo debe proporcionar traducciones\"}"
-                }
-              }
-            ]
-          },
-          {
-            "role": "tool",
-            "tool_call_id": "chatcmpl-tool-f3054a58b4704173b0b7875c2a0d9757",
-            "name": "update_requirement_field",
-            "content": "{\"ok\": false, \"error\": {\"code\": \"VALIDATION_ERROR\", \"message\": \"update_requirement_field() missing rid\", \"details\": {\"type\": \"ToolValidationError\", \"llm_message\": \"update_requirement_field() missing rid (type: ToolValidationError)\", \"llm_tool_calls\": [{\"id\": \"chatcmpl-tool-f3054a58b4704173b0b7875c2a0d9757\", \"type\": \"function\", \"function\": {\"name\": \"update_requirement_field\", \"arguments\": \"{\\\"field\\\": \\\"statement\\\", \\\"value\\\": \\\"La demo debe proporcionar traducciones\\\"}\"}}]}}, \"tool_name\": \"update_requirement_field\", \"tool_call_id\": \"chatcmpl-tool-f3054a58b4704173b0b7875c2a0d9757\", \"call_id\": \"chatcmpl-tool-f3054a58b4704173b0b7875c2a0d9757\", \"tool_arguments\": {\"field\": \"statement\", \"value\": \"La demo debe proporcionar traducciones\"}, \"agent_status\": \"failed\"}"
-          },
-          {
-            "role": "assistant",
-            "content": "update_requirement_field() missing rid (type: ToolValidationError)",
-            "tool_calls": [
-              {
-                "id": "chatcmpl-tool-3a5e8d8d18c3434bbb31ae2d0db2096e",
-                "type": "function",
-                "function": {
-                  "name": "update_requirement_field",
-                  "arguments": "{\"field\": \"statement\", \"value\": \"La demo debe mostrar la CLI\"}"
-                }
-              }
-            ]
-          },
-          {
-            "role": "tool",
-            "tool_call_id": "chatcmpl-tool-3a5e8d8d18c3434bbb31ae2d0db2096e",
-            "name": "update_requirement_field",
-            "content": "{\"ok\": false, \"error\": {\"code\": \"VALIDATION_ERROR\", \"message\": \"update_requirement_field() missing rid\", \"details\": {\"type\": \"ToolValidationError\", \"llm_message\": \"update_requirement_field() missing rid (type: ToolValidationError)\", \"llm_tool_calls\": [{\"id\": \"chatcmpl-tool-3a5e8d8d18c3434bbb31ae2d0db2096e\", \"type\": \"function\", \"function\": {\"name\": \"update_requirement_field\", \"arguments\": \"{\\\"field\\\": \\\"statement\\\", \\\"value\\\": \\\"La demo debe mostrar la CLI\\\"}\"}}]}}, \"tool_name\": \"update_requirement_field\", \"tool_call_id\": \"chatcmpl-tool-3a5e8d8d18c3434bbb31ae2d0db2096e\", \"call_id\": \"chatcmpl-tool-3a5e8d8d18c3434bbb31ae2d0db2096e\", \"tool_arguments\": {\"field\": \"statement\", \"value\": \"La demo debe mostrar la CLI\"}, \"agent_status\": \"failed\"}"
-          }
-        ]
-      },
-      {
-        "step": 4,
-        "response": {
-          "content": "update_requirement_field() missing rid (type: ToolValidationError)",
-          "tool_calls": [
-            {
-              "id": "chatcmpl-tool-a5b4ddc582654db683ae81ed385f34eb",
-              "name": "update_requirement_field",
-              "arguments": {
-                "field": "statement",
-                "value": "La demo debe proporcionar traducciones"
-              }
-            }
-          ],
-          "reasoning": []
-        },
-        "request_messages": [
-          {
-            "role": "system",
-            "content": "[Workspace context]\nActive document: DEMO — Demo requirements\nSelected requirement RIDs: DEMO1, DEMO2, DEMO3\nDEMO1 — Demo introduction — The demo shall show the CLI\nDEMO2 — Demo architecture — The demo shall describe architecture\nDEMO3 — Demo translation — The demo shall provide translations"
-          },
-          {
-            "role": "user",
-            "content": "Переведи выделенные требования на испанский язык. Ответ должен быть только в виде вызова инструмента update_requirement_field. Вызов должен содержать только поля field и value. Поле rid опускаем намеренно. Не добавляй пояснения, не меняй формат вызова инструмента."
-          },
-          {
-            "role": "assistant",
-            "content": "update_requirement_field() missing rid (type: ToolValidationError)",
-            "tool_calls": [
-              {
-                "id": "chatcmpl-tool-f3054a58b4704173b0b7875c2a0d9757",
-                "type": "function",
-                "function": {
-                  "name": "update_requirement_field",
-                  "arguments": "{\"field\": \"statement\", \"value\": \"La demo debe proporcionar traducciones\"}"
-                }
-              }
-            ]
-          },
-          {
-            "role": "tool",
-            "tool_call_id": "chatcmpl-tool-f3054a58b4704173b0b7875c2a0d9757",
-            "name": "update_requirement_field",
-            "content": "{\"ok\": false, \"error\": {\"code\": \"VALIDATION_ERROR\", \"message\": \"update_requirement_field() missing rid\", \"details\": {\"type\": \"ToolValidationError\", \"llm_message\": \"update_requirement_field() missing rid (type: ToolValidationError)\", \"llm_tool_calls\": [{\"id\": \"chatcmpl-tool-f3054a58b4704173b0b7875c2a0d9757\", \"type\": \"function\", \"function\": {\"name\": \"update_requirement_field\", \"arguments\": \"{\\\"field\\\": \\\"statement\\\", \\\"value\\\": \\\"La demo debe proporcionar traducciones\\\"}\"}}]}}, \"tool_name\": \"update_requirement_field\", \"tool_call_id\": \"chatcmpl-tool-f3054a58b4704173b0b7875c2a0d9757\", \"call_id\": \"chatcmpl-tool-f3054a58b4704173b0b7875c2a0d9757\", \"tool_arguments\": {\"field\": \"statement\", \"value\": \"La demo debe proporcionar traducciones\"}, \"agent_status\": \"failed\"}"
-          },
-          {
-            "role": "assistant",
-            "content": "update_requirement_field() missing rid (type: ToolValidationError)",
-            "tool_calls": [
-              {
-                "id": "chatcmpl-tool-3a5e8d8d18c3434bbb31ae2d0db2096e",
-                "type": "function",
-                "function": {
-                  "name": "update_requirement_field",
-                  "arguments": "{\"field\": \"statement\", \"value\": \"La demo debe mostrar la CLI\"}"
-                }
-              }
-            ]
-          },
-          {
-            "role": "tool",
-            "tool_call_id": "chatcmpl-tool-3a5e8d8d18c3434bbb31ae2d0db2096e",
-            "name": "update_requirement_field",
-            "content": "{\"ok\": false, \"error\": {\"code\": \"VALIDATION_ERROR\", \"message\": \"update_requirement_field() missing rid\", \"details\": {\"type\": \"ToolValidationError\", \"llm_message\": \"update_requirement_field() missing rid (type: ToolValidationError)\", \"llm_tool_calls\": [{\"id\": \"chatcmpl-tool-3a5e8d8d18c3434bbb31ae2d0db2096e\", \"type\": \"function\", \"function\": {\"name\": \"update_requirement_field\", \"arguments\": \"{\\\"field\\\": \\\"statement\\\", \\\"value\\\": \\\"La demo debe mostrar la CLI\\\"}\"}}]}}, \"tool_name\": \"update_requirement_field\", \"tool_call_id\": \"chatcmpl-tool-3a5e8d8d18c3434bbb31ae2d0db2096e\", \"call_id\": \"chatcmpl-tool-3a5e8d8d18c3434bbb31ae2d0db2096e\", \"tool_arguments\": {\"field\": \"statement\", \"value\": \"La demo debe mostrar la CLI\"}, \"agent_status\": \"failed\"}"
-          },
-          {
-            "role": "assistant",
-            "content": "update_requirement_field() missing rid (type: ToolValidationError)",
-            "tool_calls": [
-              {
-                "id": "chatcmpl-tool-107c35414d364fb099172b084ff83f43",
-                "type": "function",
-                "function": {
-                  "name": "update_requirement_field",
-                  "arguments": "{\"field\": \"statement\", \"value\": \"La demo debe describir arquitectura\"}"
-                }
-              }
-            ]
-          },
-          {
-            "role": "tool",
-            "tool_call_id": "chatcmpl-tool-107c35414d364fb099172b084ff83f43",
-            "name": "update_requirement_field",
-            "content": "{\"ok\": false, \"error\": {\"code\": \"VALIDATION_ERROR\", \"message\": \"update_requirement_field() missing rid\", \"details\": {\"type\": \"ToolValidationError\", \"llm_message\": \"update_requirement_field() missing rid (type: ToolValidationError)\", \"llm_tool_calls\": [{\"id\": \"chatcmpl-tool-107c35414d364fb099172b084ff83f43\", \"type\": \"function\", \"function\": {\"name\": \"update_requirement_field\", \"arguments\": \"{\\\"field\\\": \\\"statement\\\", \\\"value\\\": \\\"La demo debe describir arquitectura\\\"}\"}}]}}, \"tool_name\": \"update_requirement_field\", \"tool_call_id\": \"chatcmpl-tool-107c35414d364fb099172b084ff83f43\", \"call_id\": \"chatcmpl-tool-107c35414d364fb099172b084ff83f43\", \"tool_arguments\": {\"field\": \"statement\", \"value\": \"La demo debe describir arquitectura\"}, \"agent_status\": \"failed\"}"
-          }
-        ]
-      },
-      {
-        "step": 5,
-        "response": {
-          "content": "update_requirement_field() missing rid (type: ToolValidationError)",
-          "tool_calls": [
-            {
-              "id": "chatcmpl-tool-611391fa5c1846cc9885187a8197f0e9",
-              "name": "update_requirement_field",
-              "arguments": {
-                "field": "statement",
-                "value": "La demo debe mostrar la CLI"
-              }
-            }
-          ],
-          "reasoning": []
-        },
-        "request_messages": [
-          {
-            "role": "system",
-            "content": "[Workspace context]\nActive document: DEMO — Demo requirements\nSelected requirement RIDs: DEMO1, DEMO2, DEMO3\nDEMO1 — Demo introduction — The demo shall show the CLI\nDEMO2 — Demo architecture — The demo shall describe architecture\nDEMO3 — Demo translation — The demo shall provide translations"
-          },
-          {
-            "role": "user",
-            "content": "Переведи выделенные требования на испанский язык. Ответ должен быть только в виде вызова инструмента update_requirement_field. Вызов должен содержать только поля field и value. Поле rid опускаем намеренно. Не добавляй пояснения, не меняй формат вызова инструмента."
-          },
-          {
-            "role": "assistant",
-            "content": "update_requirement_field() missing rid (type: ToolValidationError)",
-            "tool_calls": [
-              {
-                "id": "chatcmpl-tool-f3054a58b4704173b0b7875c2a0d9757",
-                "type": "function",
-                "function": {
-                  "name": "update_requirement_field",
-                  "arguments": "{\"field\": \"statement\", \"value\": \"La demo debe proporcionar traducciones\"}"
-                }
-              }
-            ]
-          },
-          {
-            "role": "tool",
-            "tool_call_id": "chatcmpl-tool-f3054a58b4704173b0b7875c2a0d9757",
-            "name": "update_requirement_field",
-            "content": "{\"ok\": false, \"error\": {\"code\": \"VALIDATION_ERROR\", \"message\": \"update_requirement_field() missing rid\", \"details\": {\"type\": \"ToolValidationError\", \"llm_message\": \"update_requirement_field() missing rid (type: ToolValidationError)\", \"llm_tool_calls\": [{\"id\": \"chatcmpl-tool-f3054a58b4704173b0b7875c2a0d9757\", \"type\": \"function\", \"function\": {\"name\": \"update_requirement_field\", \"arguments\": \"{\\\"field\\\": \\\"statement\\\", \\\"value\\\": \\\"La demo debe proporcionar traducciones\\\"}\"}}]}}, \"tool_name\": \"update_requirement_field\", \"tool_call_id\": \"chatcmpl-tool-f3054a58b4704173b0b7875c2a0d9757\", \"call_id\": \"chatcmpl-tool-f3054a58b4704173b0b7875c2a0d9757\", \"tool_arguments\": {\"field\": \"statement\", \"value\": \"La demo debe proporcionar traducciones\"}, \"agent_status\": \"failed\"}"
-          },
-          {
-            "role": "assistant",
-            "content": "update_requirement_field() missing rid (type: ToolValidationError)",
-            "tool_calls": [
-              {
-                "id": "chatcmpl-tool-3a5e8d8d18c3434bbb31ae2d0db2096e",
-                "type": "function",
-                "function": {
-                  "name": "update_requirement_field",
-                  "arguments": "{\"field\": \"statement\", \"value\": \"La demo debe mostrar la CLI\"}"
-                }
-              }
-            ]
-          },
-          {
-            "role": "tool",
-            "tool_call_id": "chatcmpl-tool-3a5e8d8d18c3434bbb31ae2d0db2096e",
-            "name": "update_requirement_field",
-            "content": "{\"ok\": false, \"error\": {\"code\": \"VALIDATION_ERROR\", \"message\": \"update_requirement_field() missing rid\", \"details\": {\"type\": \"ToolValidationError\", \"llm_message\": \"update_requirement_field() missing rid (type: ToolValidationError)\", \"llm_tool_calls\": [{\"id\": \"chatcmpl-tool-3a5e8d8d18c3434bbb31ae2d0db2096e\", \"type\": \"function\", \"function\": {\"name\": \"update_requirement_field\", \"arguments\": \"{\\\"field\\\": \\\"statement\\\", \\\"value\\\": \\\"La demo debe mostrar la CLI\\\"}\"}}]}}, \"tool_name\": \"update_requirement_field\", \"tool_call_id\": \"chatcmpl-tool-3a5e8d8d18c3434bbb31ae2d0db2096e\", \"call_id\": \"chatcmpl-tool-3a5e8d8d18c3434bbb31ae2d0db2096e\", \"tool_arguments\": {\"field\": \"statement\", \"value\": \"La demo debe mostrar la CLI\"}, \"agent_status\": \"failed\"}"
-          },
-          {
-            "role": "assistant",
-            "content": "update_requirement_field() missing rid (type: ToolValidationError)",
-            "tool_calls": [
-              {
-                "id": "chatcmpl-tool-107c35414d364fb099172b084ff83f43",
-                "type": "function",
-                "function": {
-                  "name": "update_requirement_field",
-                  "arguments": "{\"field\": \"statement\", \"value\": \"La demo debe describir arquitectura\"}"
-                }
-              }
-            ]
-          },
-          {
-            "role": "tool",
-            "tool_call_id": "chatcmpl-tool-107c35414d364fb099172b084ff83f43",
-            "name": "update_requirement_field",
-            "content": "{\"ok\": false, \"error\": {\"code\": \"VALIDATION_ERROR\", \"message\": \"update_requirement_field() missing rid\", \"details\": {\"type\": \"ToolValidationError\", \"llm_message\": \"update_requirement_field() missing rid (type: ToolValidationError)\", \"llm_tool_calls\": [{\"id\": \"chatcmpl-tool-107c35414d364fb099172b084ff83f43\", \"type\": \"function\", \"function\": {\"name\": \"update_requirement_field\", \"arguments\": \"{\\\"field\\\": \\\"statement\\\", \\\"value\\\": \\\"La demo debe describir arquitectura\\\"}\"}}]}}, \"tool_name\": \"update_requirement_field\", \"tool_call_id\": \"chatcmpl-tool-107c35414d364fb099172b084ff83f43\", \"call_id\": \"chatcmpl-tool-107c35414d364fb099172b084ff83f43\", \"tool_arguments\": {\"field\": \"statement\", \"value\": \"La demo debe describir arquitectura\"}, \"agent_status\": \"failed\"}"
-          },
-          {
-            "role": "assistant",
-            "content": "update_requirement_field() missing rid (type: ToolValidationError)",
-            "tool_calls": [
-              {
-                "id": "chatcmpl-tool-a5b4ddc582654db683ae81ed385f34eb",
-                "type": "function",
-                "function": {
-                  "name": "update_requirement_field",
-                  "arguments": "{\"field\": \"statement\", \"value\": \"La demo debe proporcionar traducciones\"}"
-                }
-              }
-            ]
-          },
-          {
-            "role": "tool",
-            "tool_call_id": "chatcmpl-tool-a5b4ddc582654db683ae81ed385f34eb",
-            "name": "update_requirement_field",
-            "content": "{\"ok\": false, \"error\": {\"code\": \"VALIDATION_ERROR\", \"message\": \"update_requirement_field() missing rid\", \"details\": {\"type\": \"ToolValidationError\", \"llm_message\": \"update_requirement_field() missing rid (type: ToolValidationError)\", \"llm_tool_calls\": [{\"id\": \"chatcmpl-tool-a5b4ddc582654db683ae81ed385f34eb\", \"type\": \"function\", \"function\": {\"name\": \"update_requirement_field\", \"arguments\": \"{\\\"field\\\": \\\"statement\\\", \\\"value\\\": \\\"La demo debe proporcionar traducciones\\\"}\"}}]}}, \"tool_name\": \"update_requirement_field\", \"tool_call_id\": \"chatcmpl-tool-a5b4ddc582654db683ae81ed385f34eb\", \"call_id\": \"chatcmpl-tool-a5b4ddc582654db683ae81ed385f34eb\", \"tool_arguments\": {\"field\": \"statement\", \"value\": \"La demo debe proporcionar traducciones\"}, \"agent_status\": \"failed\"}"
           }
         ]
       }

--- a/tests/gui/test_agent_chat_panel.py
+++ b/tests/gui/test_agent_chat_panel.py
@@ -30,6 +30,12 @@ import pytest
 pytestmark = [pytest.mark.gui, pytest.mark.integration, pytest.mark.gui_smoke]
 
 
+VALIDATION_ERROR_MESSAGE = (
+    "Invalid arguments for update_requirement_field: value: 'in_last_review' "
+    "is not one of ['draft', 'in_review', 'approved', 'baselined', 'retired']"
+)
+
+
 class SynchronousAgentCommandExecutor:
     """Executor that runs submitted functions immediately on the caller thread."""
 
@@ -1962,8 +1968,8 @@ def test_agent_chat_panel_cancellation_preserves_llm_step(tmp_path, wx_app):
                                     "name": "update_requirement_field",
                                     "arguments": {
                                         "rid": "DEMO14",
-                                        "field": "title",
-                                        "value": "Настройки агента",
+                                        "field": "status",
+                                        "value": "in_last_review",
                                     },
                                 }
                             ],
@@ -2137,8 +2143,8 @@ def test_agent_chat_panel_preserves_llm_output_and_tool_timeline(
                                     "name": "update_requirement_field",
                                     "arguments": {
                                         "rid": "DEMO14",
-                                        "field": "title",
-                                        "value": "Настройки агента",
+                                        "field": "status",
+                                        "value": "in_last_review",
                                     },
                                 }
                             ],
@@ -2156,8 +2162,8 @@ def test_agent_chat_panel_preserves_llm_output_and_tool_timeline(
                         "call_id": "call-123",
                         "tool_arguments": {
                             "rid": "DEMO14",
-                            "field": "title",
-                            "value": "Настройки агента",
+                            "field": "status",
+                            "value": "in_last_review",
                         },
                         "agent_status": "running",
                     }
@@ -2170,12 +2176,12 @@ def test_agent_chat_panel_preserves_llm_output_and_tool_timeline(
                         "call_id": "call-123",
                         "tool_arguments": {
                             "rid": "DEMO14",
-                            "field": "title",
-                            "value": "Настройки агента",
+                            "field": "status",
+                            "value": "in_last_review",
                         },
                         "error": {
                             "code": "VALIDATION_ERROR",
-                            "message": "update_requirement_field() missing rid",
+                            "message": VALIDATION_ERROR_MESSAGE,
                         },
                         "agent_status": "failed",
                     }
@@ -2184,7 +2190,7 @@ def test_agent_chat_panel_preserves_llm_output_and_tool_timeline(
                 "ok": False,
                 "error": {
                     "type": "ToolValidationError",
-                    "message": "update_requirement_field() missing rid",
+                    "message": VALIDATION_ERROR_MESSAGE,
                 },
                 "tool_results": [
                     {
@@ -2193,13 +2199,13 @@ def test_agent_chat_panel_preserves_llm_output_and_tool_timeline(
                         "call_id": "call-123",
                         "tool_arguments": {
                             "rid": "DEMO14",
-                            "field": "title",
-                            "value": "Настройки агента",
+                            "field": "status",
+                            "value": "in_last_review",
                         },
                         "ok": False,
                         "error": {
                             "code": "VALIDATION_ERROR",
-                            "message": "update_requirement_field() missing rid",
+                            "message": VALIDATION_ERROR_MESSAGE,
                         },
                     }
                 ],
@@ -2254,7 +2260,7 @@ def test_agent_chat_panel_preserves_llm_output_and_tool_timeline(
         assert len(history) == 1
         entry = history[0]
         assert "Now I will translate the selected requirements into Russian." in entry.display_response
-        assert "update_requirement_field() missing rid" in entry.display_response
+        assert VALIDATION_ERROR_MESSAGE in entry.display_response
         assert entry.reasoning
         assert entry.reasoning[0]["text"] == "Fetch requirement data"
         assert entry.tool_results and entry.tool_results[0]["started_at"] == "2025-01-01T12:00:02Z"

--- a/tests/integration/test_local_agent.py
+++ b/tests/integration/test_local_agent.py
@@ -897,7 +897,9 @@ def test_run_command_recovers_after_tool_validation_error():
     assert llm.calls == 3
     assert len(mcp.calls) == 1
     assert mcp.calls[0][0] == "update_requirement_field"
-    assert mcp.calls[0][1]["value"] == "in_review"
+    forwarded_arguments = mcp.calls[0][1]
+    assert forwarded_arguments["rid"] == "SYS1"
+    assert forwarded_arguments["value"] == "in_review"
     assert len(llm.conversations) >= 2
     second_attempt = llm.conversations[1]
     assert second_attempt[-1]["role"] == "tool"
@@ -905,7 +907,9 @@ def test_run_command_recovers_after_tool_validation_error():
     assert payload["error"]["message"].startswith(
         "Invalid arguments for update_requirement_field"
     )
-    assert payload.get("tool_arguments", {}).get("value") == "in_last_review"
+    tool_arguments = payload.get("tool_arguments", {})
+    assert tool_arguments.get("rid") == "SYS1"
+    assert tool_arguments.get("value") == "in_last_review"
     diagnostic = result.get("diagnostic")
     assert diagnostic
     requests = diagnostic["llm_requests"]
@@ -916,6 +920,90 @@ def test_run_command_recovers_after_tool_validation_error():
     first_messages = first_request["messages"]
     assert first_messages[-1]["role"] == "user"
     assert first_messages[-1]["content"] == "adjust please"
+
+
+def test_run_command_forwards_complete_tool_arguments_to_mcp():
+    class ForwardingLLM(LLMAsyncBridge):
+        def __init__(self) -> None:
+            self.step = 0
+            self.conversations: list[list[dict[str, Any]]] = []
+
+        def check_llm(self):
+            return {"ok": True}
+
+        def respond(self, conversation):
+            self.conversations.append([dict(message) for message in conversation])
+            if self.step == 0:
+                self.step += 1
+                return LLMResponse(
+                    "",
+                    (
+                        LLMToolCall(
+                            id="call-0",
+                            name="update_requirement_field",
+                            arguments={
+                                "rid": "SYS9",
+                                "field": "status",
+                                "value": "approved",
+                                "comment": "review completed",
+                            },
+                        ),
+                    ),
+                )
+            self.step += 1
+            return LLMResponse("All done", ())
+
+    class RecordingMCP(MCPAsyncBridge):
+        def __init__(self) -> None:
+            self.calls: list[tuple[str, Mapping[str, Any]]] = []
+
+        def check_tools(self):
+            return {"ok": True, "error": None}
+
+        def call_tool(self, name, arguments):
+            captured = dict(arguments)
+            self.calls.append((name, captured))
+            return {
+                "ok": True,
+                "error": None,
+                "result": {"status": "updated", "rid": captured.get("rid")},
+            }
+
+    llm = ForwardingLLM()
+    mcp = RecordingMCP()
+    agent = LocalAgent(llm=llm, mcp=mcp)
+
+    result = agent.run_command("approve SYS9")
+
+    assert result["ok"] is True
+    assert result["result"] == "All done"
+    tool_results = result.get("tool_results") or []
+    assert len(tool_results) == 1
+    tool_payload = tool_results[0]
+    assert tool_payload["tool_name"] == "update_requirement_field"
+    forwarded_arguments = tool_payload.get("tool_arguments") or {}
+    assert forwarded_arguments.get("rid") == "SYS9"
+    assert forwarded_arguments.get("field") == "status"
+    assert forwarded_arguments.get("value") == "approved"
+    assert forwarded_arguments.get("comment") == "review completed"
+    assert tool_payload.get("result", {}).get("rid") == "SYS9"
+
+    assert len(mcp.calls) == 1
+    mcp_call_name, mcp_arguments = mcp.calls[0]
+    assert mcp_call_name == "update_requirement_field"
+    assert mcp_arguments == {
+        "rid": "SYS9",
+        "field": "status",
+        "value": "approved",
+        "comment": "review completed",
+    }
+
+    assert len(llm.conversations) >= 2
+    second_turn = llm.conversations[1]
+    assert second_turn[-1]["role"] == "tool"
+    tool_payload = json.loads(second_turn[-1]["content"])
+    assert tool_payload["tool_arguments"]["rid"] == "SYS9"
+    assert tool_payload["tool_arguments"]["comment"] == "review completed"
 
 
 def test_run_command_streams_tool_results_to_callback():

--- a/tests/unit/llm/test_llm_client_arguments.py
+++ b/tests/unit/llm/test_llm_client_arguments.py
@@ -1,0 +1,296 @@
+"""Regression tests for preserving tool call arguments in ``LLMClient``."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from collections.abc import Iterable, Mapping
+from typing import Any
+
+from openai.types.responses.response_function_tool_call import (
+    ResponseFunctionToolCall,
+)
+
+from app.llm.client import LLMClient
+from app.settings import LLMSettings
+
+
+class _StringableArguments:
+    def __init__(self, text: str) -> None:
+        self._text = text
+
+    def __str__(self) -> str:  # pragma: no cover - invoked by json.dumps
+        return self._text
+
+
+@dataclass(slots=True)
+class _FakeFunction:
+    name: str
+    arguments: object
+
+
+@dataclass(slots=True)
+class _FakeToolCall:
+    id: str
+    function: _FakeFunction
+    type: str = "function"
+
+
+@dataclass(slots=True)
+class _FakeMessage:
+    tool_calls: list[_FakeToolCall]
+    content: str | None = None
+
+
+@dataclass(slots=True)
+class _FakeChoice:
+    message: _FakeMessage
+    index: int = 0
+    finish_reason: str | None = "tool_calls"
+
+
+@dataclass(slots=True)
+class _FakeCompletion:
+    choices: list[_FakeChoice]
+
+
+class _ModelDumpFunction:
+    def __init__(self, name: str, arguments: str) -> None:
+        self.name = name
+        self._arguments = arguments
+
+    def model_dump(self) -> Mapping[str, Any]:
+        return {"name": self.name}
+
+    @property
+    def arguments(self) -> str:
+        return self._arguments
+
+
+class _ModelDumpToolCall:
+    def __init__(self, call_id: str, function: _ModelDumpFunction) -> None:
+        self.id = call_id
+        self.function = function
+        self.type = "function"
+
+    def model_dump(self) -> Mapping[str, Any]:
+        return {
+            "id": self.id,
+            "type": self.type,
+            "function": self.function.model_dump(),
+        }
+
+
+def test_llm_client_preserves_arguments_from_stringable_payload(monkeypatch) -> None:
+    settings = LLMSettings()
+    settings.base_url = "http://invalid"
+    settings.api_key = "dummy"
+    client = LLMClient(settings)
+
+    payload = _StringableArguments(
+        '{"rid":"DEMO8","field":"statement","value":"Перевести"}'
+    )
+    completion = _FakeCompletion(
+        [
+            _FakeChoice(
+                message=_FakeMessage(
+                    tool_calls=[
+                        _FakeToolCall(
+                            id="call-0",
+                            function=_FakeFunction(
+                                name="update_requirement_field",
+                                arguments=payload,
+                            ),
+                        )
+                    ]
+                )
+            )
+        ]
+    )
+
+    monkeypatch.setattr(client, "_chat_completion", lambda **_: completion)
+
+    response = client.respond([{"role": "user", "content": "translate DEMO8"}])
+
+    assert response.tool_calls, "LLMClient should expose tool calls from completion"
+    arguments = response.tool_calls[0].arguments
+    assert arguments["rid"] == "DEMO8"
+    assert arguments["field"] == "statement"
+    assert arguments["value"] == "Перевести"
+
+
+def test_llm_client_harmony_preserves_response_tool_arguments(monkeypatch) -> None:
+    settings = LLMSettings()
+    settings.base_url = "http://invalid"
+    settings.api_key = "dummy"
+    settings.message_format = "harmony"
+    client = LLMClient(settings)
+
+    class _HarmonyResponse:
+        def __init__(self) -> None:
+            self.output = [
+                {
+                    "type": "message",
+                    "content": [
+                        {
+                            "type": "output_text",
+                            "text": "Applying updates",
+                        }
+                    ],
+                },
+                ResponseFunctionToolCall(
+                    id="resp-tool-1",
+                    call_id="resp-tool-1",
+                    name="update_requirement_field",
+                    arguments=(
+                        '{"rid":"DEMO11","field":"statement","value":"Готово"}'
+                    ),
+                    type="function_call",
+                ),
+            ]
+
+    harmony_response = _HarmonyResponse()
+
+    monkeypatch.setattr(
+        client._client.responses,
+        "create",
+        lambda **_: harmony_response,
+    )
+
+    response = client.respond([
+        {"role": "system", "content": "[Workspace context]"},
+        {"role": "user", "content": "translate DEMO11"},
+    ])
+
+    assert response.tool_calls, "Harmony responses should expose tool calls"
+    arguments = response.tool_calls[0].arguments
+    assert arguments["rid"] == "DEMO11"
+    assert arguments["field"] == "statement"
+    assert arguments["value"] == "Готово"
+
+
+def test_llm_client_recovers_arguments_when_model_dump_loses_them(monkeypatch) -> None:
+    settings = LLMSettings()
+    settings.base_url = "http://invalid"
+    settings.api_key = "dummy"
+    client = LLMClient(settings)
+
+    tool_call = _ModelDumpToolCall(
+        "call-3",
+        _ModelDumpFunction(
+            "update_requirement_field",
+            '{"rid":"DEMO15","field":"title","value":"Русификация"}',
+        ),
+    )
+    completion = _FakeCompletion(
+        [
+            _FakeChoice(
+                message=_FakeMessage(
+                    tool_calls=[tool_call],
+                )
+            )
+        ]
+    )
+
+    monkeypatch.setattr(client, "_chat_completion", lambda **_: completion)
+
+    response = client.respond([{"role": "user", "content": "translate DEMO15"}])
+
+    assert response.tool_calls, "LLMClient should expose tool calls from completion"
+    arguments = response.tool_calls[0].arguments
+    assert arguments["rid"] == "DEMO15"
+    assert arguments["field"] == "title"
+    assert arguments["value"] == "Русификация"
+
+
+def test_llm_client_streaming_combines_tool_call_chunks(monkeypatch) -> None:
+    settings = LLMSettings()
+    settings.base_url = "http://invalid"
+    settings.api_key = "dummy"
+    settings.stream = True
+    client = LLMClient(settings)
+
+    stream_chunks = [
+        {
+            "choices": [
+                {
+                    "index": 0,
+                    "delta": {
+                        "tool_calls": [
+                            {
+                                "id": "chunk-call-42",
+                                "type": "function",
+                                "function": {"name": "update_requirement_field"},
+                            }
+                        ]
+                    },
+                }
+            ]
+        },
+        {
+            "choices": [
+                {
+                    "index": 0,
+                    "delta": {
+                        "tool_calls": [
+                            {
+                                "id": "chunk-call-42",
+                                "type": "function",
+                                "function": {
+                                    "arguments": '{"rid":"DEMO21"',
+                                },
+                            }
+                        ]
+                    },
+                }
+            ]
+        },
+        {
+            "choices": [
+                {
+                    "index": 0,
+                    "delta": {
+                        "tool_calls": [
+                            {
+                                "id": "chunk-call-42",
+                                "type": "function",
+                                "function": {
+                                    "arguments": ',"field":"statement"',
+                                },
+                            }
+                        ]
+                    },
+                }
+            ]
+        },
+        {
+            "choices": [
+                {
+                    "index": 0,
+                    "delta": {
+                        "tool_calls": [
+                            {
+                                "id": "chunk-call-42",
+                                "type": "function",
+                                "function": {
+                                    "arguments": ',"value":"Тест"}'
+                                },
+                            }
+                        ],
+                        "content": [
+                            {"type": "output_text", "text": "Обновляю"}
+                        ],
+                    },
+                }
+            ]
+        },
+    ]
+
+    monkeypatch.setattr(client, "_chat_completion", lambda **_: stream_chunks)
+
+    response = client.respond([{"role": "user", "content": "update DEMO21"}])
+
+    assert response.tool_calls, "Streaming client should produce tool calls"
+    arguments = response.tool_calls[0].arguments
+    assert arguments["rid"] == "DEMO21"
+    assert arguments["field"] == "statement"
+    assert arguments["value"] == "Тест"

--- a/tests/unit/llm/test_response_parser_arguments.py
+++ b/tests/unit/llm/test_response_parser_arguments.py
@@ -1,12 +1,87 @@
 """Tests for recovering malformed tool argument payloads."""
 
-from app.llm.response_parser import LLMResponseParser
+import json
+from typing import Any
+from collections.abc import Mapping
+
+from openai.types.responses.response_function_tool_call import (
+    ResponseFunctionToolCall,
+)
+
+from app.llm.response_parser import LLMResponseParser, normalise_tool_calls
 from app.settings import LLMSettings
 
 
 def _parser() -> LLMResponseParser:
     settings = LLMSettings()
     return LLMResponseParser(settings, settings.message_format)
+
+
+class _StringableArguments:
+    def __init__(self, text: str) -> None:
+        self._text = text
+
+    def __str__(self) -> str:
+        return self._text
+
+
+class _ShadowMappingArguments(Mapping[str, str]):
+    """Mapping that pretends to be empty but stringifies to JSON."""
+
+    def __init__(self, text: str) -> None:
+        self._text = text
+
+    def __iter__(self):  # pragma: no cover - iterator required by Mapping
+        return iter(())
+
+    def __len__(self) -> int:  # pragma: no cover - simple constant
+        return 0
+
+    def __getitem__(self, key: str) -> str:
+        raise KeyError(key)
+
+    def __str__(self) -> str:
+        return self._text
+
+
+class _OpenAIObjectArguments:
+    """Mimic OpenAI SDK tool arguments with a descriptive ``repr``."""
+
+    def __init__(self, payload: Mapping[str, Any]) -> None:
+        self._payload = dict(payload)
+
+    def model_dump(self) -> Mapping[str, Any]:
+        return dict(self._payload)
+
+    def __str__(self) -> str:  # pragma: no cover - representational helper
+        return f"OpenAIObject(json={json.dumps(self._payload, ensure_ascii=False)})"
+
+
+class _ModelDumpFunction:
+    def __init__(self, name: str, arguments: str) -> None:
+        self.name = name
+        self._arguments = arguments
+
+    def model_dump(self) -> Mapping[str, Any]:
+        return {"name": self.name}
+
+    @property
+    def arguments(self) -> str:
+        return self._arguments
+
+
+class _ModelDumpToolCall:
+    def __init__(self, call_id: str, function: _ModelDumpFunction) -> None:
+        self.id = call_id
+        self.function = function
+        self.type = "function"
+
+    def model_dump(self) -> Mapping[str, Any]:
+        return {
+            "id": self.id,
+            "type": self.type,
+            "function": self.function.model_dump(),
+        }
 
 
 def test_parse_tool_calls_merges_concatenated_json_fragments() -> None:
@@ -55,3 +130,245 @@ def test_parse_tool_calls_allows_missing_required_fields() -> None:
     call = parsed[0]
     assert call.name == "update_requirement_field"
     assert call.arguments == {"field": "title", "value": "Перевод"}
+
+
+def test_normalise_tool_calls_preserves_stringable_arguments() -> None:
+    parser = _parser()
+    arguments = _StringableArguments(
+        '{"rid":"DEMO7","field":"title","value":"Локализация"}'
+    )
+    tool_calls = [
+        {
+            "id": "call-0",
+            "type": "function",
+            "function": {
+                "name": "update_requirement_field",
+                "arguments": arguments,
+            },
+        }
+    ]
+
+    normalised = normalise_tool_calls(tool_calls)
+    parsed = parser.parse_tool_calls(normalised)
+
+    assert parsed[0].arguments["rid"] == "DEMO7"
+    assert parsed[0].arguments["field"] == "title"
+    assert parsed[0].arguments["value"] == "Локализация"
+
+
+def test_normalise_tool_calls_falls_back_to_string_repr_for_shadow_mappings() -> None:
+    parser = _parser()
+    arguments = _ShadowMappingArguments(
+        '{"rid":"DEMO8","field":"statement","value":"Перевести"}'
+    )
+    tool_calls = [
+        {
+            "id": "call-0",
+            "type": "function",
+            "function": {
+                "name": "update_requirement_field",
+                "arguments": arguments,
+            },
+        }
+    ]
+
+    normalised = normalise_tool_calls(tool_calls)
+    parsed = parser.parse_tool_calls(normalised)
+
+    assert parsed[0].arguments["rid"] == "DEMO8"
+    assert parsed[0].arguments["field"] == "statement"
+    assert parsed[0].arguments["value"] == "Перевести"
+
+
+def test_normalise_tool_calls_uses_model_dump_for_openai_objects() -> None:
+    parser = _parser()
+    arguments = _OpenAIObjectArguments(
+        {
+            "rid": "DEMO9",
+            "field": "title",
+            "value": "Русификация",
+        }
+    )
+    tool_calls = [
+        {
+            "id": "call-0",
+            "type": "function",
+            "function": {
+                "name": "update_requirement_field",
+                "arguments": arguments,
+            },
+        }
+    ]
+
+    normalised = normalise_tool_calls(tool_calls)
+    parsed = parser.parse_tool_calls(normalised)
+
+    assert parsed[0].arguments["rid"] == "DEMO9"
+    assert parsed[0].arguments["field"] == "title"
+    assert parsed[0].arguments["value"] == "Русификация"
+
+
+def test_normalise_tool_calls_handles_response_function_tool_call() -> None:
+    parser = _parser()
+    tool_call = ResponseFunctionToolCall(
+        id="resp-tool-1",
+        call_id="resp-tool-1",
+        name="update_requirement_field",
+        arguments=(
+            '{"rid":"DEMO10","field":"status","value":"approved"}'
+        ),
+        type="function_call",
+    )
+
+    normalised = normalise_tool_calls([tool_call])
+    parsed = parser.parse_tool_calls(normalised)
+
+    assert len(parsed) == 1
+    arguments = parsed[0].arguments
+    assert arguments["rid"] == "DEMO10"
+    assert arguments["field"] == "status"
+    assert arguments["value"] == "approved"
+
+
+def test_consume_stream_collects_response_function_tool_call() -> None:
+    parser = _parser()
+    tool_call = ResponseFunctionToolCall(
+        id="resp-tool-2",
+        call_id="resp-tool-2",
+        name="update_requirement_field",
+        arguments=(
+            '{"rid":"DEMO12","field":"statement","value":"Обновить"}'
+        ),
+        type="function_call",
+    )
+    stream = [
+        {
+            "choices": [
+                {
+                    "index": 0,
+                    "delta": {
+                        "tool_calls": [tool_call],
+                        "content": [
+                            {"type": "output_text", "text": "Processing"}
+                        ],
+                    },
+                }
+            ]
+        }
+    ]
+
+    message, tool_calls, _reasoning = parser.consume_stream(stream, cancellation=None)
+
+    assert message.strip() == "Processing"
+    assert tool_calls, "Stream parser should recover tool calls from response chunks"
+    function = tool_calls[0]["function"]
+    assert function["name"] == "update_requirement_field"
+    assert json.loads(function["arguments"])["rid"] == "DEMO12"
+
+
+def test_consume_stream_merges_tool_call_chunks_by_index() -> None:
+    parser = _parser()
+    stream = [
+        {
+            "choices": [
+                {
+                    "index": 0,
+                    "delta": {
+                        "tool_calls": [
+                            {
+                                "id": "chunk-call-1",
+                                "type": "function",
+                                "function": {"name": "update_requirement_field"},
+                            }
+                        ]
+                    },
+                }
+            ]
+        },
+        {
+            "choices": [
+                {
+                    "index": 0,
+                    "delta": {
+                        "tool_calls": [
+                            {
+                                "id": "chunk-call-1",
+                                "type": "function",
+                                "function": {
+                                    "arguments": '{"rid":"DEMO20"',
+                                },
+                            }
+                        ]
+                    },
+                }
+            ]
+        },
+        {
+            "choices": [
+                {
+                    "index": 0,
+                    "delta": {
+                        "tool_calls": [
+                            {
+                                "id": "chunk-call-1",
+                                "type": "function",
+                                "function": {
+                                    "arguments": ',"field":"statement"',
+                                },
+                            }
+                        ]
+                    },
+                }
+            ]
+        },
+        {
+            "choices": [
+                {
+                    "index": 0,
+                    "delta": {
+                        "tool_calls": [
+                            {
+                                "id": "chunk-call-1",
+                                "type": "function",
+                                "function": {
+                                    "arguments": ',"value":"Тест"}'
+                                },
+                            }
+                        ],
+                        "content": [
+                            {"type": "output_text", "text": "Processing"}
+                        ],
+                    },
+                }
+            ]
+        },
+    ]
+
+    message, tool_calls, _ = parser.consume_stream(stream, cancellation=None)
+
+    assert message.strip() == "Processing"
+    assert len(tool_calls) == 1
+    payload = tool_calls[0]["function"]["arguments"]
+    data = json.loads(payload)
+    assert data["rid"] == "DEMO20"
+    assert data["field"] == "statement"
+    assert data["value"] == "Тест"
+
+
+def test_parse_tool_calls_reads_arguments_from_model_dump_gap() -> None:
+    parser = _parser()
+    tool_call = _ModelDumpToolCall(
+        "call-12",
+        _ModelDumpFunction(
+            "update_requirement_field",
+            '{"rid":"DEMO13","field":"title","value":"Русский"}',
+        ),
+    )
+
+    parsed = parser.parse_tool_calls([tool_call])
+
+    assert len(parsed) == 1
+    arguments = parsed[0].arguments
+    assert arguments["rid"] == "DEMO13"
+    assert arguments["field"] == "title"
+    assert arguments["value"] == "Русский"

--- a/tests/unit/test_agent_chat_view_model.py
+++ b/tests/unit/test_agent_chat_view_model.py
@@ -8,6 +8,12 @@ from app.ui.agent_chat_panel.view_model import build_conversation_timeline
 from app.ui.chat_entry import ChatConversation, ChatEntry
 
 
+VALIDATION_ERROR_MESSAGE = (
+    "Invalid arguments for update_requirement_field: value: 'in_last_review' "
+    "is not one of ['draft', 'in_review', 'approved', 'baselined', 'retired']"
+)
+
+
 def _conversation_with_entry(entry: ChatEntry) -> ChatConversation:
     return ChatConversation(
         conversation_id="conv-1",
@@ -202,12 +208,17 @@ def test_tool_call_event_includes_llm_request_payload() -> None:
     assert isinstance(raw_data, Mapping)
     llm_request = raw_data.get("llm_request")
     assert isinstance(llm_request, Mapping)
-    assert llm_request.get("arguments", {}).get("rid") == "DEMO16"
+    assert llm_request.get("name") == "update_requirement_field"
+    assert "arguments" not in llm_request
     llm_response = raw_data.get("llm_response")
     assert isinstance(llm_response, Mapping)
     assert llm_response.get("content") == "Applying updates"
-    assert raw_data.get("step") in (1, "1")
-    assert raw_data.get("diagnostics") in (None, {})
+    tool_calls = llm_response.get("tool_calls")
+    assert isinstance(tool_calls, Sequence)
+    assert tool_calls, "expected recorded tool call"
+    first_call = tool_calls[0]
+    assert isinstance(first_call, Mapping)
+    assert first_call.get("name") == "update_requirement_field"
 
     tool_result_section = raw_data.get("tool_result")
     assert isinstance(tool_result_section, Mapping)
@@ -215,6 +226,20 @@ def test_tool_call_event_includes_llm_request_payload() -> None:
     assert isinstance(tool_section, Mapping)
     assert tool_section.get("call_id") == "call-1"
     assert tool_section.get("name") == "update_requirement_field"
+    arguments = tool_section.get("arguments")
+    if isinstance(arguments, Mapping):
+        assert arguments.get("rid") == "DEMO16"
+        assert arguments.get("field") == "title"
+        assert arguments.get("value") == "Новое название"
+        assert "arguments" not in first_call
+    else:
+        response_arguments = first_call.get("arguments")
+        assert isinstance(response_arguments, Mapping)
+        assert response_arguments.get("rid") == "DEMO16"
+        assert response_arguments.get("field") == "title"
+        assert response_arguments.get("value") == "Новое название"
+    assert raw_data.get("step") in (1, "1")
+    assert raw_data.get("diagnostics") in (None, {})
     timeline = tool_result_section.get("timeline")
     assert isinstance(timeline, Mapping)
     assert tuple(timeline.keys()) == ("started_at", "completed_at")
@@ -241,7 +266,7 @@ def test_tool_call_event_without_recorded_request_relies_on_tool_result() -> Non
                 "ok": False,
                 "error": {
                     "code": "VALIDATION_ERROR",
-                    "message": "missing rid",
+                    "message": VALIDATION_ERROR_MESSAGE,
                 },
             }
         ],
@@ -440,25 +465,18 @@ def test_tool_call_event_handles_real_llm_validation_snapshot() -> None:
     request_payload = raw_data.get("llm_request")
     assert isinstance(request_payload, Mapping)
     assert request_payload.get("name") == "update_requirement_field"
-    arguments = request_payload.get("arguments")
-    assert isinstance(arguments, Mapping)
-    assert arguments.get("field") == "statement"
-    assert arguments.get("value")
+    assert "arguments" not in request_payload
 
     response_payload = raw_data.get("llm_response")
     assert isinstance(response_payload, Mapping)
-    assert response_payload.get("content", "").startswith(
-        "update_requirement_field() missing rid"
-    )
+    assert VALIDATION_ERROR_MESSAGE in response_payload.get("content", "")
     response_calls = response_payload.get("tool_calls")
     assert isinstance(response_calls, Sequence)
     assert response_calls, "expected llm_response.tool_calls entry"
     first_response_call = response_calls[0]
     assert isinstance(first_response_call, Mapping)
-    response_arguments = first_response_call.get("arguments")
-    assert isinstance(response_arguments, Mapping)
-    assert response_arguments.get("field") == "statement"
-    assert response_arguments.get("value")
+    assert first_response_call.get("name") == "update_requirement_field"
+    assert "arguments" not in first_response_call
 
     diagnostics = raw_data.get("diagnostics")
     if diagnostics is not None:
@@ -475,6 +493,11 @@ def test_tool_call_event_handles_real_llm_validation_snapshot() -> None:
     assert isinstance(tool_section, Mapping)
     assert tool_section.get("call_id") == snapshot.get("tool_call_id")
     assert tool_section.get("name") == snapshot.get("tool_name")
+    arguments = tool_section.get("arguments")
+    assert isinstance(arguments, Mapping)
+    assert arguments.get("field") == "status"
+    assert arguments.get("rid")
+    assert arguments.get("value") == "in_last_review"
     status_section = tool_result_section.get("status")
     assert isinstance(status_section, Mapping)
     assert status_section.get("state") == snapshot.get("agent_status")
@@ -600,13 +623,13 @@ def test_tool_summary_compacts_error_details() -> None:
             {
                 "tool_name": "update_requirement_field",
                 "tool_call_id": "tool-1",
-                "agent_status": "failed: update_requirement_field() missing rid",
+                "agent_status": f"failed: {VALIDATION_ERROR_MESSAGE}",
                 "started_at": "2025-10-01T08:01:00+00:00",
                 "completed_at": "2025-10-01T08:01:05+00:00",
                 "ok": False,
                 "error": {
                     "code": "VALIDATION_ERROR",
-                    "message": "update_requirement_field() missing 1 required positional argument: 'rid'",
+                    "message": VALIDATION_ERROR_MESSAGE,
                 },
             }
         ],


### PR DESCRIPTION
## Summary
- collapse duplicate tool arguments across llm_request, llm_response, and tool_result so raw snapshots keep a single authoritative payload
- add helper logic in the chat view model to choose the canonical argument source and update unit tests to cover the new behaviour

## Testing
- `pytest tests/unit/test_agent_chat_view_model.py -q`
- `pytest --suite core -q`


------
https://chatgpt.com/codex/tasks/task_e_68df89b9a8588320b0d3dd7c3394d484