### PR TITLE
Revert "Merge pull request #580 from Belerafon/codex/remove-custom-splitters-and-hooks"

### DIFF
--- a/app/ui/agent_chat_panel/layout.py
+++ b/app/ui/agent_chat_panel/layout.py
@@ -11,6 +11,7 @@ from wx.lib.scrolledpanel import ScrolledPanel
 
 from ...i18n import _
 from ..helpers import create_copy_button, dip, inherit_background
+from ..splitter_utils import refresh_splitter_highlight, style_splitter
 from ..widgets.marquee_dataview import MarqueeDataViewListCtrl
 from .batch_ui import BatchControls
 from .confirm_preferences import RequirementConfirmPreference
@@ -66,6 +67,7 @@ class AgentChatLayoutBuilder:
         splitter_style = wx.SP_LIVE_UPDATE | wx.SP_3D
 
         vertical_splitter = wx.SplitterWindow(panel, style=splitter_style)
+        style_splitter(vertical_splitter)
         vertical_splitter.SetMinimumPaneSize(dip(panel, 160))
 
         top_panel = wx.Panel(vertical_splitter)
@@ -74,6 +76,7 @@ class AgentChatLayoutBuilder:
         inherit_background(bottom_panel, panel)
 
         horizontal_splitter = wx.SplitterWindow(top_panel, style=splitter_style)
+        style_splitter(horizontal_splitter)
         history_min_width = dip(panel, 260)
         horizontal_splitter.SetMinimumPaneSize(history_min_width)
 
@@ -292,6 +295,8 @@ class AgentChatLayoutBuilder:
 
         outer.Add(vertical_splitter, 1, wx.EXPAND)
         panel.SetSizer(outer)
+        refresh_splitter_highlight(horizontal_splitter)
+        refresh_splitter_highlight(vertical_splitter)
 
         batch_controls = BatchControls(
             panel=batch_panel,

--- a/app/ui/main_frame/frame.py
+++ b/app/ui/main_frame/frame.py
@@ -18,6 +18,7 @@ from ...columns import available_columns
 from ...config import ConfigManager
 from ...i18n import _
 from ..requirement_model import RequirementModel
+from ..splitter_utils import refresh_splitter_highlight
 from .agent import MainFrameAgentMixin
 from .documents import MainFrameDocumentsMixin
 from .editor import MainFrameEditorMixin
@@ -116,6 +117,13 @@ class MainFrame(
         sizer.Add(self.main_splitter, 1, wx.EXPAND)
         self.SetSizer(sizer)
         self._load_layout()
+        for splitter in (
+            self.main_splitter,
+            self.doc_splitter,
+            self.agent_splitter,
+            self.splitter,
+        ):
+            refresh_splitter_highlight(splitter)
         self.current_dir: Path | None = None
         self.current_doc_prefix: str | None = None
         self._selected_requirement_id: int | None = None

--- a/app/ui/main_frame/sections.py
+++ b/app/ui/main_frame/sections.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 import wx
 
 from ...i18n import _
+from ..splitter_utils import refresh_splitter_highlight, style_splitter
 from ..widgets import SectionContainer
 
 if TYPE_CHECKING:  # pragma: no cover - import for type checking only
@@ -25,6 +26,7 @@ class MainFrameSectionsMixin:
         """Create a splitter with consistent styling and behaviour."""
 
         splitter = wx.SplitterWindow(parent)
+        style_splitter(splitter)
         self._disable_splitter_unsplit(splitter)
         return splitter
 
@@ -94,6 +96,7 @@ class MainFrameSectionsMixin:
                 )
             else:
                 self.doc_splitter.SetSashPosition(target)
+            refresh_splitter_highlight(self.doc_splitter)
             self._doc_tree_last_sash = self.doc_splitter.GetSashPosition()
             if persist:
                 self.config.set_doc_tree_shown(True)
@@ -103,6 +106,7 @@ class MainFrameSectionsMixin:
                 self._doc_tree_last_sash = self.doc_splitter.GetSashPosition()
                 self.doc_splitter.Unsplit(self.doc_tree_container)
             self.doc_tree_container.Hide()
+            refresh_splitter_highlight(self.doc_splitter)
             if persist:
                 self.config.set_doc_tree_shown(False)
                 self.config.set_doc_tree_sash(self._doc_tree_last_sash)
@@ -139,6 +143,7 @@ class MainFrameSectionsMixin:
                 )
             else:
                 self.agent_splitter.SetSashPosition(target)
+            refresh_splitter_highlight(self.agent_splitter)
             self._agent_last_sash = self.agent_splitter.GetSashPosition()
             if persist:
                 self.config.set_agent_chat_shown(True)
@@ -149,6 +154,7 @@ class MainFrameSectionsMixin:
                 self._agent_last_sash = self.agent_splitter.GetSashPosition()
                 self.agent_splitter.Unsplit(self.agent_container)
             self._hide_agent_section()
+            refresh_splitter_highlight(self.agent_splitter)
             if persist:
                 self.config.set_agent_chat_shown(False)
                 self.config.set_agent_chat_sash(self._agent_last_sash)
@@ -175,12 +181,14 @@ class MainFrameSectionsMixin:
         self.editor.Show()
         self.editor_container.Layout()
         self.editor.Layout()
+        refresh_splitter_highlight(self.splitter)
 
     def _hide_editor_panel(self: MainFrame) -> None:
         """Hide the editor section and its container."""
 
         self.editor.Hide()
         self.editor_container.Hide()
+        refresh_splitter_highlight(self.splitter)
 
     def _clear_editor_panel(self: MainFrame) -> None:
         """Reset editor contents and reflect current visibility setting."""
@@ -205,12 +213,14 @@ class MainFrameSectionsMixin:
         self.agent_panel.Show()
         self.agent_container.Layout()
         self.agent_panel.Layout()
+        refresh_splitter_highlight(self.agent_splitter)
 
     def _hide_agent_section(self: MainFrame) -> None:
         """Hide the agent chat widgets to free screen space."""
 
         self.agent_panel.Hide()
         self.agent_container.Hide()
+        refresh_splitter_highlight(self.agent_splitter)
 
     def _update_section_labels(self: MainFrame) -> None:
         """Refresh captions for titled sections according to current locale."""

--- a/app/ui/splitter_utils.py
+++ b/app/ui/splitter_utils.py
@@ -1,0 +1,193 @@
+"""Helpers ensuring splitter sashes are easy to discover and drag."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager, suppress
+
+import wx
+
+
+class SplitterEventBlocker:
+    """Re-entrant guard that suppresses splitter change callbacks."""
+
+    def __init__(self) -> None:
+        self._depth = 0
+
+    @contextmanager
+    def pause(self) -> Iterator[None]:
+        """Temporarily increment the guard depth while yielding control."""
+
+        self._depth += 1
+        try:
+            yield
+        finally:
+            self._depth -= 1
+
+    @property
+    def active(self) -> bool:
+        """Return ``True`` when callbacks should be ignored."""
+
+        return self._depth > 0
+
+_DEFAULT_SASH_THICKNESS_DIP = 6
+_TINT_FACTOR = 0.25
+_MIN_THICKNESS = 4
+
+
+def style_splitter(
+    splitter: wx.SplitterWindow,
+    *,
+    sash_colour: wx.Colour | None = None,
+    thickness: int | None = None,
+) -> None:
+    """Highlight ``splitter`` so the draggable sash is easy to find."""
+
+    if not splitter:
+        return
+    accent = _resolve_colour(splitter, sash_colour)
+    resolved_thickness = _resolve_thickness(splitter, thickness)
+    helper = getattr(splitter, "_cooka_splitter_highlight", None)
+    if helper is None:
+        helper = _SplitterHighlighter(splitter, accent, resolved_thickness)
+        splitter._cooka_splitter_highlight = helper  # type: ignore[attr-defined]
+    else:
+        helper.update(accent=accent, thickness=resolved_thickness)
+    helper.refresh()
+
+
+def refresh_splitter_highlight(splitter: wx.SplitterWindow) -> None:
+    """Force ``splitter`` to repaint its sash highlight if configured."""
+
+    helper = getattr(splitter, "_cooka_splitter_highlight", None)
+    if helper is not None:
+        helper.refresh()
+
+
+class _SplitterHighlighter:
+    """State holder responsible for tinting a ``wx.SplitterWindow`` sash."""
+
+    def __init__(self, splitter: wx.SplitterWindow, accent: wx.Colour, thickness: int) -> None:
+        self.splitter = splitter
+        self.accent = accent
+        self.thickness = thickness
+        self._pending_draw = False
+        self._bind_events()
+        self.splitter.SetDoubleBuffered(True)
+
+    def update(self, *, accent: wx.Colour, thickness: int) -> None:
+        self.accent = accent
+        self.thickness = thickness
+
+    def refresh(self) -> None:
+        self._apply_thickness()
+        self._schedule_draw()
+
+    def _bind_events(self) -> None:
+        self.splitter.Bind(wx.EVT_PAINT, self._on_paint)
+        self.splitter.Bind(wx.EVT_SIZE, self._on_size)
+        self.splitter.Bind(wx.EVT_SPLITTER_SASH_POS_CHANGED, self._on_sash_move)
+        self.splitter.Bind(wx.EVT_SPLITTER_SASH_POS_CHANGING, self._on_sash_move)
+        self.splitter.Bind(wx.EVT_SHOW, self._on_show)
+
+    def _apply_thickness(self) -> None:
+        desired = max(self.thickness, _MIN_THICKNESS)
+        current = int(getattr(self.splitter, "SashSize", 0) or 0)
+        if current < desired:
+            with suppress(Exception):
+                self.splitter.SashSize = desired
+
+    def _on_paint(self, event: wx.Event) -> None:
+        event.Skip()
+        self._schedule_draw()
+
+    def _on_size(self, event: wx.Event) -> None:
+        event.Skip()
+        self._schedule_draw()
+
+    def _on_show(self, event: wx.ShowEvent) -> None:
+        event.Skip()
+        if event.IsShown():
+            self._schedule_draw()
+
+    def _on_sash_move(self, event: wx.SplitterEvent) -> None:
+        event.Skip()
+        self._schedule_draw()
+
+    def _schedule_draw(self) -> None:
+        if self._pending_draw:
+            return
+        self._pending_draw = True
+        wx.CallAfter(self._draw)
+
+    def _draw(self) -> None:
+        self._pending_draw = False
+        splitter = self.splitter
+        if not splitter or not splitter:  # pragma: no cover - defensive
+            return
+        if hasattr(splitter, "IsSashInvisible") and splitter.IsSashInvisible():
+            return
+        if not splitter.IsSplit():
+            return
+        size = splitter.GetClientSize()
+        if size.width <= 0 or size.height <= 0:
+            return
+        sash_size = int(getattr(splitter, "SashSize", 0) or 0)
+        if sash_size <= 0:
+            sash_size = max(self.thickness, _MIN_THICKNESS)
+        sash_pos = splitter.GetSashPosition()
+        mode = splitter.GetSplitMode()
+        if mode == wx.SPLIT_VERTICAL:
+            rect = wx.Rect(sash_pos, 0, sash_size, size.height)
+        else:
+            rect = wx.Rect(0, sash_pos, size.width, sash_size)
+        try:
+            dc = wx.ClientDC(splitter)
+            dc.SetPen(wx.TRANSPARENT_PEN)
+            dc.SetBrush(wx.Brush(self.accent))
+            dc.DrawRectangle(rect)
+        except Exception:  # pragma: no cover - GUI drawing best effort
+            pass
+
+
+def _resolve_thickness(splitter: wx.Window, thickness: int | None) -> int:
+    if thickness is not None and thickness > 0:
+        return thickness
+    try:
+        return max(int(splitter.FromDIP(_DEFAULT_SASH_THICKNESS_DIP)), _MIN_THICKNESS)
+    except Exception:
+        return max(_DEFAULT_SASH_THICKNESS_DIP, _MIN_THICKNESS)
+
+
+def _resolve_colour(splitter: wx.Window, colour: wx.Colour | None) -> wx.Colour:
+    if colour is not None and colour.IsOk():
+        return wx.Colour(colour)
+    highlight = wx.SystemSettings.GetColour(wx.SYS_COLOUR_HIGHLIGHT)
+    if not highlight.IsOk():
+        highlight = wx.Colour(0, 120, 215)
+    tinted = _tint_colour(highlight, _TINT_FACTOR)
+    background = splitter.GetBackgroundColour()
+    if background.IsOk() and _colours_similar(tinted, background):
+        tinted = _tint_colour(highlight, _TINT_FACTOR / 2)
+    return tinted
+
+
+def _tint_colour(colour: wx.Colour, factor: float) -> wx.Colour:
+    factor = max(0.0, min(1.0, factor))
+    r = colour.Red()
+    g = colour.Green()
+    b = colour.Blue()
+    return wx.Colour(
+        min(255, int(r + (255 - r) * factor)),
+        min(255, int(g + (255 - g) * factor)),
+        min(255, int(b + (255 - b) * factor)),
+    )
+
+
+def _colours_similar(a: wx.Colour, b: wx.Colour) -> bool:
+    threshold = 24
+    return (
+        abs(a.Red() - b.Red()) <= threshold
+        and abs(a.Green() - b.Green()) <= threshold
+        and abs(a.Blue() - b.Blue()) <= threshold
+    )


### PR DESCRIPTION
## Summary
- revert the previous merge that removed the splitter styling utilities
- restore splitter highlighting helpers across the agent chat and main frame panels

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e00e63a964832095dfc8f64e898dcd