### PR TITLE
Simplify directory loading and speed up list refresh

### DIFF
--- a/tests/gui/test_list_panel.py
+++ b/tests/gui/test_list_panel.py
@@ -98,6 +98,27 @@ def test_column_click_after_set_columns_triggers_sort(stubbed_list_panel_env):
     assert [r.id for r in panel.model.get_visible()] == [1, 2]
 
 
+def test_refresh_freezes_list_when_supported(stubbed_list_panel_env):
+    env = stubbed_list_panel_env
+    panel = env.create_panel()
+    panel.set_columns(["id", "title"])
+
+    calls: list[str] = []
+
+    def freeze() -> None:
+        calls.append("freeze")
+
+    def thaw() -> None:
+        calls.append("thaw")
+
+    panel.list.Freeze = freeze  # type: ignore[attr-defined]
+    panel.list.Thaw = thaw  # type: ignore[attr-defined]
+
+    panel.set_requirements([_req(1, "A"), _req(2, "B")])
+
+    assert calls == ["freeze", "thaw"]
+
+
 def test_search_and_label_filters(stubbed_list_panel_env):
     env = stubbed_list_panel_env
     panel = env.create_panel()

--- a/tests/gui/wx_stub_utils.py
+++ b/tests/gui/wx_stub_utils.py
@@ -555,6 +555,8 @@ def stub_list_panel_env(monkeypatch: pytest.MonkeyPatch):
     for module_name, module in patched_modules.items():
         monkeypatch.setitem(sys.modules, module_name, module)
 
+    helpers_module = importlib.import_module("app.ui.helpers")
+    importlib.reload(helpers_module)
     list_panel_module = importlib.import_module("app.ui.list_panel")
     importlib.reload(list_panel_module)
     requirement_model_module = importlib.import_module("app.ui.requirement_model")
@@ -575,6 +577,7 @@ def stub_list_panel_env(monkeypatch: pytest.MonkeyPatch):
         yield env
     finally:
         monkeypatch.undo()
+        importlib.reload(importlib.import_module("app.ui.helpers"))
         importlib.reload(importlib.import_module("app.ui.list_panel"))
         importlib.reload(importlib.import_module("app.ui.requirement_model"))
 


### PR DESCRIPTION
## Summary
- restore the synchronous MainFrame directory loader and drop the background executor plumbing that slowed the editor initialisation
- freeze/thaw the requirements list while rebuilding rows and add a regression test plus stub cleanups so the optimisation is covered by the GUI suite
- remove the obsolete async directory loading regression and prune the related architecture note

## Testing
- pytest --suite gui-smoke -q tests/gui/test_list_panel.py tests/gui/test_main_directory_errors.py tests/gui/test_recent_dirs.py tests/gui/test_main_mcp_base_path.py tests/gui/test_agent_context.py tests/gui/test_agent_chat_history_location.py tests/gui/test_agent_tool_updates.py

------
https://chatgpt.com/codex/tasks/task_e_68e0bfabc5d8832092346a26429747aa