### PR TITLE
Refactor chat tool result storage

### DIFF
--- a/app/ui/agent_chat_panel/panel.py
+++ b/app/ui/agent_chat_panel/panel.py
@@ -43,10 +43,13 @@ from .history import AgentChatHistory
 from .history_view import HistoryView
 from .history_utils import (
     clone_streamed_tool_results,
+    extract_tool_results,
     history_json_safe,
     looks_like_tool_payload,
+    normalise_tool_payloads,
     sort_tool_payloads,
     stringify_payload,
+    update_tool_results,
 )
 from .log_export import compose_transcript_log_text, compose_transcript_text
 from .paths import (
@@ -1023,20 +1026,18 @@ class AgentChatPanel(ConfirmPreferencesMixin, wx.Panel):
                     display_text = latest_response
             if not reasoning_segments and handle.latest_reasoning_segments:
                 reasoning_segments = handle.latest_reasoning_segments
-            if not tool_results and handle.streamed_tool_results:
-                tool_results = list(
+            resolved_tool_results = normalise_tool_payloads(tool_results)
+            if not resolved_tool_results and handle.streamed_tool_results:
+                resolved_tool_results = normalise_tool_payloads(
                     clone_streamed_tool_results(handle.streamed_tool_results)
                 )
-            if tool_results:
-                tool_results = sort_tool_payloads(tool_results)
             merged_tool_results = self._merge_tool_result_timelines(
-                tool_results, handle.streamed_tool_results
+                resolved_tool_results, handle.streamed_tool_results
             )
             if merged_tool_results is not None:
-                tool_results = sort_tool_payloads(merged_tool_results)
-                if isinstance(raw_result, Mapping):
-                    raw_result = dict(raw_result)
-                    raw_result["tool_results"] = tool_results
+                resolved_tool_results = normalise_tool_payloads(merged_tool_results)
+            raw_result = update_tool_results(raw_result, resolved_tool_results)
+            tool_results = resolved_tool_results
             response_tokens = count_text_tokens(
                 conversation_text,
                 model=self._token_model(),
@@ -1056,7 +1057,6 @@ class AgentChatPanel(ConfirmPreferencesMixin, wx.Panel):
                     response=conversation_text,
                     display_response=display_text,
                     raw_result=raw_result,
-                    tool_results=tool_results,
                     token_info=final_tokens,
                     prompt_at=prompt_at,
                     response_at=response_at,
@@ -1070,7 +1070,6 @@ class AgentChatPanel(ConfirmPreferencesMixin, wx.Panel):
                     conversation_text,
                     display_text,
                     raw_result,
-                    tool_results,
                     final_tokens,
                     prompt_at=prompt_at,
                     response_at=response_at,
@@ -1162,15 +1161,10 @@ class AgentChatPanel(ConfirmPreferencesMixin, wx.Panel):
                     conversation_parts.append(display_text)
 
             extras = result.get("tool_results")
-            if extras:
-                safe_extras = history_json_safe(extras)
-                if isinstance(safe_extras, list):
-                    normalized_extras = list(safe_extras)
-                else:
-                    normalized_extras = [safe_extras]
-                sorted_extras = sort_tool_payloads(normalized_extras)
-                tool_results = sorted_extras
-                extras_text = stringify_payload(sorted_extras)
+            tool_results = normalise_tool_payloads(extras)
+            if tool_results:
+                raw_payload = update_tool_results(raw_payload, tool_results)
+                extras_text = stringify_payload(tool_results)
                 if extras_text:
                     conversation_parts.append(extras_text)
             reasoning_segments = self._normalise_reasoning_segments(
@@ -1305,7 +1299,6 @@ class AgentChatPanel(ConfirmPreferencesMixin, wx.Panel):
             tokens=0,
             display_response=_("Waiting for agent response…"),
             raw_result=None,
-            tool_results=None,
             token_info=TokenCountResult.exact(0),
             prompt_at=prompt_at,
             response_at=None,
@@ -1320,7 +1313,6 @@ class AgentChatPanel(ConfirmPreferencesMixin, wx.Panel):
         response: str,
         display_response: str,
         raw_result: Any | None,
-        tool_results: list[Any] | None,
         token_info: TokenCountResult | None,
         *,
         prompt_at: str | None = None,
@@ -1345,13 +1337,13 @@ class AgentChatPanel(ConfirmPreferencesMixin, wx.Panel):
         reasoning_clone = self._normalise_reasoning_segments(reasoning_segments)
         if not reasoning_clone:
             reasoning_clone = None
+        resolved_tool_results = extract_tool_results(raw_result)
         entry = ChatEntry(
             prompt=prompt_text,
             response=response_text,
             tokens=tokens,
             display_response=display_text,
             raw_result=raw_result,
-            tool_results=tool_results,
             token_info=token_info,
             prompt_at=prompt_at,
             response_at=response_at,
@@ -1364,7 +1356,7 @@ class AgentChatPanel(ConfirmPreferencesMixin, wx.Panel):
                 display_response=display_text,
                 stored_response=response_text,
                 raw_result=raw_result,
-                tool_results=tool_results,
+                tool_results=resolved_tool_results,
                 history_snapshot=history_snapshot,
                 context_snapshot=context_clone,
                 custom_system_prompt=self._custom_system_prompt(),
@@ -1383,7 +1375,6 @@ class AgentChatPanel(ConfirmPreferencesMixin, wx.Panel):
         response: str,
         display_response: str,
         raw_result: Any | None,
-        tool_results: list[Any] | None,
         token_info: TokenCountResult | None,
         prompt_at: str,
         response_at: str,
@@ -1398,7 +1389,6 @@ class AgentChatPanel(ConfirmPreferencesMixin, wx.Panel):
         entry.response = response_text
         entry.display_response = display_text
         entry.raw_result = raw_result
-        entry.tool_results = tool_results
         tokens_info = token_info if token_info is not None else TokenCountResult.exact(0)
         entry.token_info = tokens_info
         entry.tokens = tokens_info.tokens or 0
@@ -1408,6 +1398,7 @@ class AgentChatPanel(ConfirmPreferencesMixin, wx.Panel):
         entry.context_messages = context_clone
         reasoning_clone = self._normalise_reasoning_segments(reasoning_segments)
         entry.reasoning = reasoning_clone or None
+        resolved_tool_results = extract_tool_results(raw_result)
         existing_diagnostic = entry.diagnostic if isinstance(entry.diagnostic, Mapping) else None
         entry.diagnostic = self._build_entry_diagnostic(
             prompt=prompt_text,
@@ -1416,7 +1407,7 @@ class AgentChatPanel(ConfirmPreferencesMixin, wx.Panel):
             display_response=display_text,
             stored_response=response_text,
             raw_result=raw_result,
-            tool_results=tool_results,
+            tool_results=resolved_tool_results,
             history_snapshot=history_snapshot,
             context_snapshot=context_clone,
             custom_system_prompt=self._custom_system_prompt(),
@@ -1512,7 +1503,11 @@ class AgentChatPanel(ConfirmPreferencesMixin, wx.Panel):
         prompt_at = getattr(handle, "prompt_at", None) or response_at
         token_info = combine_token_counts([handle.prompt_tokens])
         tool_results_payload = handle.prepare_tool_results_payload()
-        tool_results = list(tool_results_payload) if tool_results_payload else None
+        tool_results = (
+            normalise_tool_payloads(tool_results_payload)
+            if tool_results_payload
+            else None
+        )
         response_text = handle.latest_llm_response or ""
         reasoning_segments: tuple[dict[str, str], ...] | None = (
             handle.latest_reasoning_segments
@@ -1550,6 +1545,8 @@ class AgentChatPanel(ConfirmPreferencesMixin, wx.Panel):
         if handle.llm_steps:
             raw_result["diagnostic"] = {"llm_steps": list(handle.llm_steps)}
 
+        raw_result = update_tool_results(raw_result, tool_results)
+
         self._complete_pending_entry(
             conversation,
             entry,
@@ -1557,7 +1554,6 @@ class AgentChatPanel(ConfirmPreferencesMixin, wx.Panel):
             response=response_text,
             display_response=combined_display,
             raw_result=raw_result,
-            tool_results=tool_results,
             token_info=token_info,
             prompt_at=prompt_at,
             response_at=response_at,
@@ -1850,13 +1846,18 @@ class AgentChatPanel(ConfirmPreferencesMixin, wx.Panel):
                             elif safe_calls is not None:
                                 planned_tool_calls = [safe_calls]
 
-        tool_payloads: list[Any] = []
-        if tool_results:
-            for payload in tool_results:
-                tool_payloads.append(history_json_safe(payload))
-        elif raw_result_mapping and looks_like_tool_payload(raw_result_mapping):
-            tool_payloads.append(raw_result_mapping)
-        tool_payloads = sort_tool_payloads(tool_payloads)
+        tool_payloads = normalise_tool_payloads(tool_results)
+        if not tool_payloads and raw_result_mapping is not None:
+            tool_payloads = extract_tool_results(raw_result_mapping)
+        if (
+            not tool_payloads
+            and raw_result_mapping
+            and looks_like_tool_payload(raw_result_mapping)
+        ):
+            fallback_payloads = normalise_tool_payloads(raw_result_mapping)
+            if fallback_payloads:
+                tool_payloads = fallback_payloads
+        tool_payloads = tool_payloads or []
 
         diagnostic_payload = {
             "prompt_text": prompt_text,

--- a/docs/chat_history_migration.md
+++ b/docs/chat_history_migration.md
@@ -62,8 +62,9 @@ the backup and rerun the migration after addressing the reported issue.
   used.
 - Severely corrupted files (for instance, entries that are not dictionaries) are
   skipped. If no valid records remain, the utility raises an exception.
-- The script copies `raw_result` and `tool_results` verbatim. If those fields
-  changed between versions, review the output manually.
+- The script copies `raw_result` verbatim (including any embedded
+  `tool_results` payloads). If the structure changes between releases, review
+  the output manually.
 
 ## Testing and maintenance
 

--- a/tests/gui/test_agent_chat_panel.py
+++ b/tests/gui/test_agent_chat_panel.py
@@ -69,6 +69,13 @@ def build_entry_timeline(
     raw_payload: Any | None = None,
     regenerated: bool = False,
 ) -> tuple[ChatConversation, TranscriptEntry]:
+    tool_payloads = list(tool_results or ())
+    if tool_payloads:
+        if isinstance(raw_payload, Mapping):
+            raw_payload = {**raw_payload, "tool_results": tool_payloads}
+        else:
+            raw_payload = {"tool_results": tool_payloads}
+
     entry = ChatEntry(
         prompt=prompt,
         response=response,
@@ -78,7 +85,6 @@ def build_entry_timeline(
         response_at=response_at,
         context_messages=tuple(context_messages or ()),
         reasoning=tuple(reasoning_segments or ()),
-        tool_results=list(tool_results or ()),
         raw_result=raw_payload,
         regenerated=regenerated,
     )

--- a/tests/unit/test_agent_chat_history_store.py
+++ b/tests/unit/test_agent_chat_history_store.py
@@ -13,7 +13,6 @@ def _entry_payload(*, prompt: str, response: str) -> dict[str, object]:
         "tokens": 0,
         "display_response": response,
         "raw_result": None,
-        "tool_results": None,
         "token_info": {"tokens": 1, "approximate": False, "model": "cl100k_base"},
         "prompt_at": "2024-01-01T00:00:00Z",
         "response_at": "2024-01-01T00:01:00Z",

--- a/tests/unit/test_agent_chat_log_export.py
+++ b/tests/unit/test_agent_chat_log_export.py
@@ -81,7 +81,7 @@ def _conversation_with_failed_updates() -> ChatConversation:
         tokens=0,
         prompt_at=_iso("2025-10-02T11:19:15+00:00"),
         response_at=_iso("2025-10-02T11:38:04+00:00"),
-        tool_results=_build_tool_payloads(),
+        raw_result={"tool_results": _build_tool_payloads()},
         diagnostic={
             "llm_request_messages": (
                 {"role": "system", "content": _SYSTEM_PROMPT_TEXT},

--- a/tests/unit/test_agent_chat_view_model.py
+++ b/tests/unit/test_agent_chat_view_model.py
@@ -37,15 +37,17 @@ def test_build_conversation_timeline_compiles_turn() -> None:
         reasoning=(
             {"type": "thought", "text": "Нужно пройтись по каждому требованию"},
         ),
-        tool_results=(
-            {
-                "tool_name": "get_requirement",
-                "started_at": "2025-09-30T20:50:10+00:00",
-                "completed_at": "2025-09-30T20:50:11+00:00",
-                "tool_call_id": "tool-1",
-            },
-        ),
-        raw_result={"answer": "Готово"},
+        raw_result={
+            "answer": "Готово",
+            "tool_results": [
+                {
+                    "tool_name": "get_requirement",
+                    "started_at": "2025-09-30T20:50:10+00:00",
+                    "completed_at": "2025-09-30T20:50:11+00:00",
+                    "tool_call_id": "tool-1",
+                }
+            ],
+        },
         layout_hints={"user": "140", "agent": 220, "invalid": 0},
     )
     conversation = _conversation_with_entry(entry)
@@ -116,28 +118,30 @@ def test_tool_calls_sorted_by_timestamp() -> None:
         tokens=1,
         prompt_at="2025-09-30T20:50:10+00:00",
         response_at="2025-09-30T20:52:58+00:00",
-        tool_results=(
-            {
-                "tool_name": "update_requirement_field",
-                "agent_status": "failed",
-                "started_at": "2025-09-30T20:52:57+00:00",
-                "completed_at": "2025-09-30T20:52:58+00:00",
-                "tool_call_id": "tool-6",
-            },
-            {
-                "tool_name": "get_requirement",
-                "started_at": "2025-09-30T20:50:10+00:00",
-                "completed_at": "2025-09-30T20:50:11+00:00",
-                "tool_call_id": "tool-1",
-            },
-            {
-                "tool_name": "update_requirement_field",
-                "agent_status": "failed",
-                "started_at": "2025-09-30T20:52:05+00:00",
-                "completed_at": "2025-09-30T20:52:05+00:00",
-                "tool_call_id": "tool-4",
-            },
-        ),
+        raw_result={
+            "tool_results": [
+                {
+                    "tool_name": "update_requirement_field",
+                    "agent_status": "failed",
+                    "started_at": "2025-09-30T20:52:57+00:00",
+                    "completed_at": "2025-09-30T20:52:58+00:00",
+                    "tool_call_id": "tool-6",
+                },
+                {
+                    "tool_name": "get_requirement",
+                    "started_at": "2025-09-30T20:50:10+00:00",
+                    "completed_at": "2025-09-30T20:50:11+00:00",
+                    "tool_call_id": "tool-1",
+                },
+                {
+                    "tool_name": "update_requirement_field",
+                    "agent_status": "failed",
+                    "started_at": "2025-09-30T20:52:05+00:00",
+                    "completed_at": "2025-09-30T20:52:05+00:00",
+                    "tool_call_id": "tool-4",
+                },
+            ]
+        },
     )
     conversation = _conversation_with_entry(entry)
 
@@ -164,16 +168,16 @@ def test_tool_call_event_includes_llm_request_payload() -> None:
         tokens=1,
         prompt_at="2025-10-01T08:52:30+00:00",
         response_at="2025-10-01T08:52:40+00:00",
-        tool_results=[
-            {
-                "tool_name": "update_requirement_field",
-                "tool_call_id": "call-1",
-                "started_at": "2025-10-01T08:52:35+00:00",
-                "completed_at": "2025-10-01T08:52:39+00:00",
-                "ok": False,
-            }
-        ],
         raw_result={
+            "tool_results": [
+                {
+                    "tool_name": "update_requirement_field",
+                    "tool_call_id": "call-1",
+                    "started_at": "2025-10-01T08:52:35+00:00",
+                    "completed_at": "2025-10-01T08:52:39+00:00",
+                    "ok": False,
+                }
+            ],
             "diagnostic": {
                 "llm_steps": [
                     {
@@ -257,22 +261,24 @@ def test_tool_call_event_without_recorded_request_relies_on_tool_result() -> Non
         tokens=1,
         prompt_at="2025-10-01T09:00:00+00:00",
         response_at="2025-10-01T09:00:05+00:00",
-        tool_results=[
-            {
-                "tool_name": "update_requirement_field",
-                "tool_call_id": "call-42",
-                "arguments": {
-                    "rid": "REQ-9",
-                    "field": "title",
-                    "value": "Updated title",
-                },
-                "ok": False,
-                "error": {
-                    "code": "VALIDATION_ERROR",
-                    "message": VALIDATION_ERROR_MESSAGE,
-                },
-            }
-        ],
+        raw_result={
+            "tool_results": [
+                {
+                    "tool_name": "update_requirement_field",
+                    "tool_call_id": "call-42",
+                    "arguments": {
+                        "rid": "REQ-9",
+                        "field": "title",
+                        "value": "Updated title",
+                    },
+                    "ok": False,
+                    "error": {
+                        "code": "VALIDATION_ERROR",
+                        "message": VALIDATION_ERROR_MESSAGE,
+                    },
+                }
+            ]
+        },
     )
     conversation = _conversation_with_entry(entry)
 
@@ -304,16 +310,16 @@ def test_tool_call_event_includes_llm_error_arguments() -> None:
         prompt="",
         response="",
         tokens=1,
-        tool_results=[
-            {
-                "tool_name": "update_requirement_field",
-                "tool_call_id": "call-error",
-                "agent_status": "failed",
-                "ok": False,
-                "error": {"message": "invalid arguments"},
-            }
-        ],
         raw_result={
+            "tool_results": [
+                {
+                    "tool_name": "update_requirement_field",
+                    "tool_call_id": "call-error",
+                    "agent_status": "failed",
+                    "ok": False,
+                    "error": {"message": "invalid arguments"},
+                }
+            ],
             "diagnostic": {
                 "llm_steps": [
                     {
@@ -383,15 +389,15 @@ def test_tool_call_event_includes_aggregated_diagnostics() -> None:
         prompt="",
         response="",
         tokens=1,
-        tool_results=[
-            {
-                "tool_name": "update_requirement_field",
-                "tool_call_id": "call-diagnostics",
-                "agent_status": "failed",
-                "ok": False,
-            }
-        ],
         raw_result={
+            "tool_results": [
+                {
+                    "tool_name": "update_requirement_field",
+                    "tool_call_id": "call-diagnostics",
+                    "agent_status": "failed",
+                    "ok": False,
+                }
+            ],
             "diagnostic": {
                 "tool_calls": [
                     {
@@ -450,8 +456,11 @@ def test_tool_call_event_handles_real_llm_validation_snapshot() -> None:
         tokens=0,
         prompt_at="2025-10-01T08:52:30+00:00",
         response_at="2025-10-01T08:52:40+00:00",
-        tool_results=[snapshot],
-        raw_result={"diagnostic": diagnostic, "error": snapshot.get("error")},
+        raw_result={
+            "tool_results": [snapshot],
+            "diagnostic": diagnostic,
+            "error": snapshot.get("error"),
+        },
     )
     if isinstance(diagnostic, dict):
         entry.diagnostic = dict(diagnostic)
@@ -524,16 +533,16 @@ def test_streamed_responses_in_turn() -> None:
         tokens=1,
         prompt_at="2025-10-01T08:00:00+00:00",
         response_at="2025-10-01T08:05:00+00:00",
-        tool_results=[
-            {
-                "tool_name": "update_requirement_field",
-                "tool_call_id": "call-1",
-                "started_at": "2025-10-01T08:01:00+00:00",
-                "completed_at": "2025-10-01T08:02:00+00:00",
-                "ok": False,
-            }
-        ],
         raw_result={
+            "tool_results": [
+                {
+                    "tool_name": "update_requirement_field",
+                    "tool_call_id": "call-1",
+                    "started_at": "2025-10-01T08:01:00+00:00",
+                    "completed_at": "2025-10-01T08:02:00+00:00",
+                    "ok": False,
+                }
+            ],
             "diagnostic": {
                 "llm_steps": [
                     {
@@ -598,14 +607,14 @@ def test_promotes_last_stream_when_final_missing() -> None:
                         },
                     }
                 ]
-            }
+            },
+            "tool_results": [
+                {
+                    "tool_name": "demo_tool",
+                    "completed_at": "2025-10-01T08:00:09+00:00",
+                }
+            ],
         },
-        tool_results=[
-            {
-                "tool_name": "demo_tool",
-                "completed_at": "2025-10-01T08:00:09+00:00",
-            }
-        ],
     )
     conversation = _conversation_with_entry(entry)
 
@@ -628,20 +637,22 @@ def test_tool_summary_compacts_error_details() -> None:
         tokens=1,
         prompt_at="2025-10-01T08:00:00+00:00",
         response_at="2025-10-01T08:05:00+00:00",
-        tool_results=[
-            {
-                "tool_name": "update_requirement_field",
-                "tool_call_id": "tool-1",
-                "agent_status": f"failed: {VALIDATION_ERROR_MESSAGE}",
-                "started_at": "2025-10-01T08:01:00+00:00",
-                "completed_at": "2025-10-01T08:01:05+00:00",
-                "ok": False,
-                "error": {
-                    "code": "VALIDATION_ERROR",
-                    "message": VALIDATION_ERROR_MESSAGE,
-                },
-            }
-        ],
+        raw_result={
+            "tool_results": [
+                {
+                    "tool_name": "update_requirement_field",
+                    "tool_call_id": "tool-1",
+                    "agent_status": f"failed: {VALIDATION_ERROR_MESSAGE}",
+                    "started_at": "2025-10-01T08:01:00+00:00",
+                    "completed_at": "2025-10-01T08:01:05+00:00",
+                    "ok": False,
+                    "error": {
+                        "code": "VALIDATION_ERROR",
+                        "message": VALIDATION_ERROR_MESSAGE,
+                    },
+                }
+            ]
+        },
     )
     conversation = _conversation_with_entry(entry)
 
@@ -662,19 +673,21 @@ def test_tool_summary_includes_diagnostics_metadata() -> None:
         tokens=1,
         prompt_at="2025-10-01T08:00:00+00:00",
         response_at="2025-10-01T08:05:00+00:00",
-        tool_results=[
-            {
-                "tool_name": "update_requirement_field",
-                "tool_call_id": "tool-42",
-                "arguments": {"rid": "REQ-9", "field": "title"},
-                "started_at": "2025-10-01T08:01:00+00:00",
-                "completed_at": "2025-10-01T08:01:02+00:00",
-                "duration_ms": 2150,
-                "cost": {"display": "$0.01"},
-                "ok": False,
-                "error": {"message": "validation failed"},
-            }
-        ],
+        raw_result={
+            "tool_results": [
+                {
+                    "tool_name": "update_requirement_field",
+                    "tool_call_id": "tool-42",
+                    "arguments": {"rid": "REQ-9", "field": "title"},
+                    "started_at": "2025-10-01T08:01:00+00:00",
+                    "completed_at": "2025-10-01T08:01:02+00:00",
+                    "duration_ms": 2150,
+                    "cost": {"display": "$0.01"},
+                    "ok": False,
+                    "error": {"message": "validation failed"},
+                }
+            ]
+        },
     )
     conversation = _conversation_with_entry(entry)
 
@@ -727,7 +740,7 @@ def test_missing_timestamps_reported_as_missing() -> None:
         prompt="hello",
         response="",
         tokens=1,
-        tool_results=[{"tool_name": "noop"}],
+        raw_result={"tool_results": [{"tool_name": "noop"}]},
     )
     conversation = _conversation_with_entry(entry)
 


### PR DESCRIPTION
## Summary
- persist chat tool call payloads inside `raw_result` and expose them through `ChatEntry` accessors
- normalize and consume tool payloads through new helpers in the agent chat panel/view model
- update GUI/unit tests and history documentation for the revised transcript schema

## Testing
- pytest --suite core -q

------
https://chatgpt.com/codex/tasks/task_e_68e11faf62508320877a4ba6f0209c0a