### PR TITLE
Fix regenerate button disabled after cancelling generation

### DIFF
--- a/app/ui/agent_chat_panel/panel.py
+++ b/app/ui/agent_chat_panel/panel.py
@@ -692,8 +692,8 @@ class AgentChatPanel(ConfirmPreferencesMixin, wx.Panel):
         handle = coordinator.cancel_active_run()
         if handle is None:
             return
-        self._finalize_cancelled_run(handle)
         self._set_wait_state(False)
+        self._finalize_cancelled_run(handle)
         self._view.update_status_label(_("Generation cancelled"))
         self.input.SetValue(handle.prompt)
         self.input.SetInsertionPointEnd()


### PR DESCRIPTION
## Summary
- clear the wait state before finalizing a cancelled agent run so the transcript re-renders with regeneration enabled
- extend the stop-cancels-generation GUI test to confirm the regenerate button remains available after cancellation

## Testing
- pytest --suite gui-smoke -q tests/gui/test_agent_chat_panel.py::test_agent_chat_panel_stop_cancels_generation

------
https://chatgpt.com/codex/tasks/task_e_68e152599f7c832085814468c1b29814