### PR TITLE
Show previous and new values for update tool calls

### DIFF
--- a/app/ui/agent_chat_panel/tool_summaries.py
+++ b/app/ui/agent_chat_panel/tool_summaries.py
@@ -434,6 +434,27 @@ def summarize_specific_tool(
                 _("Requirement: {rid}").format(rid=format_value_snippet(rid))
             )
             consumed_args.add("rid")
+
+        change_field: str | None = None
+        previous_display: str | None = None
+        current_display: str | None = None
+        if isinstance(result, Mapping):
+            change_section = result.get("field_change")
+            if isinstance(change_section, Mapping):
+                raw_change_field = change_section.get("field")
+                if isinstance(raw_change_field, str):
+                    text = raw_change_field.strip()
+                    if text:
+                        change_field = normalize_for_display(text)
+                if "previous" in change_section:
+                    previous_display = format_value_snippet(
+                        change_section.get("previous")
+                    )
+                if "current" in change_section:
+                    current_display = format_value_snippet(
+                        change_section.get("current")
+                    )
+
         if isinstance(arguments, Mapping):
             field = arguments.get("field")
             if field is not None:
@@ -443,13 +464,32 @@ def summarize_specific_tool(
                     )
                 )
                 consumed_args.add("field")
-            if "value" in arguments:
+            elif change_field is not None:
                 lines.append(
-                    _("New value: {value}").format(
-                        value=format_value_snippet(arguments.get("value"))
+                    _("Field: {field}").format(
+                        field=format_value_snippet(change_field)
                     )
                 )
+            if "value" in arguments:
                 consumed_args.add("value")
+                if current_display is None:
+                    current_display = format_value_snippet(arguments.get("value"))
+        elif change_field is not None:
+            lines.append(
+                _("Field: {field}").format(
+                    field=format_value_snippet(change_field)
+                )
+            )
+
+        if previous_display is not None:
+            lines.append(
+                _("Previous value: {value}").format(value=previous_display)
+            )
+        if current_display is not None:
+            lines.append(
+                _("New value: {value}").format(value=current_display)
+            )
+
         if isinstance(result, Mapping):
             revision = result.get("revision")
             if revision is not None:

--- a/docs/architecture/integrations.md
+++ b/docs/architecture/integrations.md
@@ -42,6 +42,11 @@
 - The `fields` parameter limits the reply to two key fields (`title`, `statement`) to reduce payload size during asynchronous context requests.
 - Responses always include `result.items` with `{rid, ...}` objects and an optional `missing` list. The agent skips missing RIDs and continues even when the tool returns an empty set.
 
+### `update_requirement_field`
+
+- The tool now returns a `field_change` block alongside the updated requirement payload. The structure mirrors `{"field": ..., "previous": ..., "current": ...}` and is derived from the persisted requirement state prior to the mutation.
+- GUI summaries (`app/ui/agent_chat_panel/tool_summaries.py`) rely on this metadata to render “previous/new value” lines in tool bubbles, so the agent chat transcript explicitly shows what changed.
+
 ## 3. Filesystem and OS interaction
 - [ ] File dialogs, permissions, and path handling.
 - [ ] Environment requirements (wxPython, Python 3.12, dependencies).

--- a/tests/unit/test_mcp_tools_write.py
+++ b/tests/unit/test_mcp_tools_write.py
@@ -37,6 +37,11 @@ def test_create_update_delete(tmp_path: Path) -> None:
     )
     assert res2["title"] == "N"
     assert res2["revision"] == 2
+    assert res2["field_change"] == {
+        "field": "title",
+        "previous": "T",
+        "current": "N",
+    }
     res3 = tools_write.delete_requirement(tmp_path, "SYS1")
     assert res3 == {"rid": "SYS1"}
 


### PR DESCRIPTION
## Summary
- capture the previous field value when update_requirement_field runs and expose it via a new field_change block
- render the previous/new values in the agent chat tool summary so edit bubbles display what changed
- document the contract update and cover it with unit tests

## Testing
- pytest --suite core -q

------
https://chatgpt.com/codex/tasks/task_e_68e2de26d0c08320856617cf6874c5c6