### PR TITLE
Remove unused describe_error helper from history utils

### DIFF
--- a/app/ui/agent_chat_panel/history_utils.py
+++ b/app/ui/agent_chat_panel/history_utils.py
@@ -172,17 +172,6 @@ def shorten_text(text: str, *, limit: int = 120) -> str:
     return _shorten_text(text, limit=limit)
 
 
-def describe_error(error: Any) -> str:
-    """Return a localized string describing ``error`` payload."""
-
-    from .tool_summaries import summarize_error_details
-
-    details = summarize_error_details(error)
-    if not details:
-        return ""
-    return "\n".join(normalize_for_display(line) for line in details)
-
-
 __all__ = [
     "history_json_safe",
     "stringify_payload",
@@ -194,5 +183,4 @@ __all__ = [
     "update_tool_results",
     "format_value_snippet",
     "shorten_text",
-    "describe_error",
 ]


### PR DESCRIPTION
## Summary
- remove the unused describe_error helper from the agent chat history utilities
- leave the remaining exports untouched so other helpers continue to be available

## Testing
- pytest --suite gui-smoke -q tests/gui/test_agent_chat_panel.py

------
https://chatgpt.com/codex/tasks/task_e_68e35294e49883208a31f8de3c5e8ba2