### PR TITLE
Add close control for agent batch panel

### DIFF
--- a/app/locale/en/LC_MESSAGES/CookaReq.po
+++ b/app/locale/en/LC_MESSAGES/CookaReq.po
@@ -2029,6 +2029,15 @@ msgstr "Step {index}"
 msgid "Stop batch"
 msgstr "Stop batch"
 
+msgid "Hide batch queue"
+msgstr "Hide batch queue"
+
+msgid "Batch processing is still running. Stop and close the queue?"
+msgstr "Batch processing is still running. Stop and close the queue?"
+
+msgid "Stop batch processing?"
+msgstr "Stop batch processing?"
+
 msgid "System message"
 msgstr "System message"
 

--- a/app/locale/ru/LC_MESSAGES/CookaReq.po
+++ b/app/locale/ru/LC_MESSAGES/CookaReq.po
@@ -2045,6 +2045,15 @@ msgstr "Шаг {index}"
 msgid "Stop batch"
 msgstr "Остановить пакет"
 
+msgid "Hide batch queue"
+msgstr "Скрыть очередь пакета"
+
+msgid "Batch processing is still running. Stop and close the queue?"
+msgstr "Пакетная обработка ещё выполняется. Остановить и закрыть очередь?"
+
+msgid "Stop batch processing?"
+msgstr "Остановить пакетную обработку?"
+
 msgid "System message"
 msgstr "Системное сообщение"
 

--- a/app/ui/agent_chat_panel/batch_ui.py
+++ b/app/ui/agent_chat_panel/batch_ui.py
@@ -29,6 +29,7 @@ class BatchControls:
     """Widgets composing the batch queue section."""
 
     panel: wx.Panel
+    close_button: wx.Button
     run_button: wx.Button
     stop_button: wx.Button
     status_label: wx.StaticText
@@ -60,6 +61,7 @@ class AgentBatchSection:
         )
         controls.run_button.Bind(wx.EVT_BUTTON, self._handle_run_request)
         controls.stop_button.Bind(wx.EVT_BUTTON, self._handle_stop_request)
+        controls.close_button.Bind(wx.EVT_BUTTON, self._handle_close_request)
         self.update_ui()
 
     # ------------------------------------------------------------------
@@ -110,6 +112,26 @@ class AgentBatchSection:
     # ------------------------------------------------------------------
     def request_skip_current(self) -> None:
         self._runner.request_skip_current()
+
+    # ------------------------------------------------------------------
+    def close_panel(self) -> None:
+        """Reset the batch queue and hide the panel."""
+
+        runner = self._runner
+        if runner.is_running:
+            dialog = wx.MessageDialog(
+                self._controls.panel,
+                _("Batch processing is still running. Stop and close the queue?"),
+                _("Stop batch processing?"),
+                style=wx.YES_NO | wx.NO_DEFAULT | wx.ICON_WARNING,
+            )
+            try:
+                if dialog.ShowModal() != wx.ID_YES:
+                    return
+            finally:
+                dialog.Destroy()
+            self.stop_batch()
+        runner.reset()
 
     # ------------------------------------------------------------------
     def notify_completion(
@@ -259,6 +281,10 @@ class AgentBatchSection:
     # ------------------------------------------------------------------
     def _handle_stop_request(self, _event: wx.Event) -> None:
         self.stop_batch()
+
+    # ------------------------------------------------------------------
+    def _handle_close_request(self, _event: wx.Event) -> None:
+        self.close_panel()
 
 
 __all__ = ["AgentBatchSection", "BatchControls"]

--- a/app/ui/agent_chat_panel/layout.py
+++ b/app/ui/agent_chat_panel/layout.py
@@ -286,6 +286,17 @@ class AgentChatLayoutBuilder:
         batch_status_label = wx.StaticText(
             batch_panel, label=_("Select requirements and run a batch")
         )
+        close_bitmap = wx.ArtProvider.GetBitmap(
+            wx.ART_CLOSE, wx.ART_BUTTON, wx.Size(dip(panel, 16), dip(panel, 16))
+        )
+        close_button = wx.BitmapButton(
+            batch_panel,
+            bitmap=close_bitmap,
+            style=wx.BU_EXACTFIT | wx.BORDER_NONE,
+        )
+        close_button.SetToolTip(_("Hide batch queue"))
+        close_button.SetBackgroundColour(batch_panel.GetBackgroundColour())
+        close_button.SetForegroundColour(batch_panel.GetForegroundColour())
         batch_progress = wx.Gauge(batch_panel, range=1, style=wx.GA_HORIZONTAL)
         batch_progress.SetValue(0)
         batch_progress.SetMinSize(wx.Size(-1, dip(panel, 12)))
@@ -294,7 +305,10 @@ class AgentChatLayoutBuilder:
         batch_list.AppendTextColumn(_("RID"), mode=dv.DATAVIEW_CELL_INERT, width=dip(panel, 120))
         batch_list.AppendTextColumn(_("Title"), mode=dv.DATAVIEW_CELL_INERT, width=dip(panel, 200))
         batch_list.AppendTextColumn(_("Status"), mode=dv.DATAVIEW_CELL_INERT, width=dip(panel, 220))
-        batch_box.Add(batch_status_label, 0, wx.BOTTOM, spacing)
+        batch_header = wx.BoxSizer(wx.HORIZONTAL)
+        batch_header.Add(batch_status_label, 1, wx.ALIGN_CENTER_VERTICAL | wx.RIGHT, spacing)
+        batch_header.Add(close_button, 0, wx.ALIGN_CENTER_VERTICAL)
+        batch_box.Add(batch_header, 0, wx.EXPAND | wx.BOTTOM, spacing)
         batch_box.Add(batch_progress, 0, wx.EXPAND | wx.BOTTOM, spacing)
         batch_box.Add(batch_list, 1, wx.EXPAND)
         batch_panel.SetSizer(batch_box)
@@ -378,6 +392,7 @@ class AgentChatLayoutBuilder:
             panel=batch_panel,
             run_button=run_batch_btn,
             stop_button=stop_batch_btn,
+            close_button=close_button,
             status_label=batch_status_label,
             progress=batch_progress,
             list_ctrl=batch_list,


### PR DESCRIPTION
## Summary
- add a close button to the batch queue panel and wire it to the batch section controller
- confirm with the user before closing while a batch run is in progress and clear the queue afterwards
- adjust layout, translations, and GUI test doubles to cover the new close behaviour

## Testing
- pytest --suite gui-smoke -q tests/gui/test_agent_batch_section.py

------
https://chatgpt.com/codex/tasks/task_e_68e4d76b382c8320b9306e3204c0f520