### PR TITLE
Add user documents service for filesystem interactions

### DIFF
--- a/app/services/__init__.py
+++ b/app/services/__init__.py
@@ -16,6 +16,7 @@ from .requirements import (
     rid_for,
     stable_color,
 )
+from .user_documents import UserDocumentsService
 
 __all__ = [
     "RequirementsService",
@@ -32,4 +33,5 @@ __all__ = [
     "parse_rid",
     "rid_for",
     "stable_color",
+    "UserDocumentsService",
 ]

--- a/app/services/user_documents.py
+++ b/app/services/user_documents.py
@@ -1,0 +1,281 @@
+"""Service helpers for managing user-provided documentation files."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterable, Iterator
+
+from ..llm.tokenizer import TokenCountResult, combine_token_counts, count_text_tokens
+
+MAX_READ_BYTES = 10_240
+
+
+@dataclass(slots=True)
+class UserDocumentEntry:
+    """Representation of a single filesystem entry within the user tree."""
+
+    name: str
+    relative_path: Path
+    is_dir: bool
+    size_bytes: int | None = None
+    token_count: TokenCountResult | None = None
+    percent_of_context: float | None = None
+    children: list["UserDocumentEntry"] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, object]:
+        payload: dict[str, object] = {
+            "name": self.name,
+            "path": self.relative_path.as_posix(),
+            "type": "directory" if self.is_dir else "file",
+        }
+        if self.size_bytes is not None:
+            payload["size_bytes"] = self.size_bytes
+        if self.token_count is not None:
+            payload["token_count"] = self.token_count.to_dict()
+        if self.percent_of_context is not None:
+            payload["percent_of_context"] = self.percent_of_context
+        if self.children:
+            payload["children"] = [child.to_dict() for child in self.children]
+        return payload
+
+
+class UserDocumentsService:
+    """Manage user documentation files under a dedicated root directory."""
+
+    def __init__(
+        self,
+        root: Path | str,
+        *,
+        max_context_tokens: int,
+        token_model: str | None = None,
+    ) -> None:
+        if max_context_tokens <= 0:
+            raise ValueError("max_context_tokens must be positive")
+        self.root = Path(root).expanduser().resolve()
+        self.max_context_tokens = int(max_context_tokens)
+        self.token_model = token_model
+
+    # ------------------------------------------------------------------
+    def list_tree(self) -> dict[str, object]:
+        """Return a structured description of the documentation directory."""
+
+        if self.root.exists():
+            entry = self._build_directory(self.root, Path("."))
+        else:
+            entry = UserDocumentEntry(
+                name=self.root.name or ".",
+                relative_path=Path("."),
+                is_dir=True,
+            )
+        text_tree = self._render_tree(entry)
+
+        return {
+            "root": str(self.root),
+            "token_model": self.token_model,
+            "max_context_tokens": self.max_context_tokens,
+            "root_entry": entry.to_dict(),
+            "entries": [child.to_dict() for child in entry.children],
+            "tree_text": text_tree,
+        }
+
+    # ------------------------------------------------------------------
+    def read_file(
+        self,
+        relative_path: str | Path,
+        *,
+        start_line: int = 1,
+        max_bytes: int = MAX_READ_BYTES,
+    ) -> dict[str, object]:
+        """Return a chunk of the target file capped at ``max_bytes`` bytes."""
+
+        file_path = self._ensure_file(relative_path)
+        if start_line < 1:
+            raise ValueError("start_line must be >= 1")
+        if max_bytes <= 0 or max_bytes > MAX_READ_BYTES:
+            raise ValueError("max_bytes must be within 1..10_240")
+
+        collected: list[str] = []
+        consumed = 0
+        current_line = 0
+        end_line = start_line - 1
+        truncated = False
+        with file_path.open("r", encoding="utf-8", errors="replace") as stream:
+            for raw_line in stream:
+                current_line += 1
+                if current_line < start_line:
+                    continue
+                encoded = raw_line.encode("utf-8")
+                remaining = max_bytes - consumed
+                if remaining <= 0:
+                    truncated = True
+                    break
+                if len(encoded) > remaining:
+                    segment = encoded[:remaining].decode("utf-8", errors="ignore")
+                    collected.append(f"{current_line:>6}: {segment}")
+                    consumed = max_bytes
+                    end_line = current_line
+                    truncated = True
+                    break
+                collected.append(f"{current_line:>6}: {raw_line.rstrip('\n')}\n")
+                consumed += len(encoded)
+                end_line = current_line
+            else:
+                truncated = False
+
+            # Determine if there is more content after finishing the loop.
+            if not truncated:
+                remainder = stream.read(1)
+                if remainder:
+                    truncated = True
+
+        content = "".join(collected)
+        return {
+            "path": self._relative_path(file_path).as_posix(),
+            "start_line": start_line,
+            "end_line": end_line,
+            "bytes_consumed": consumed,
+            "content": content,
+            "truncated": truncated,
+        }
+
+    # ------------------------------------------------------------------
+    def create_file(
+        self,
+        relative_path: str | Path,
+        *,
+        content: str = "",
+        exist_ok: bool = False,
+    ) -> Path:
+        """Create a new file under the documents root with optional content."""
+
+        target = self._resolve_path(relative_path)
+        if target.exists():
+            if target.is_dir():
+                raise IsADirectoryError(f"{target} is a directory")
+            if not exist_ok:
+                raise FileExistsError(target)
+        else:
+            target.parent.mkdir(parents=True, exist_ok=True)
+        mode = "w" if exist_ok else "x"
+        with target.open(mode, encoding="utf-8") as stream:
+            stream.write(content)
+        return target
+
+    # ------------------------------------------------------------------
+    def delete_file(self, relative_path: str | Path) -> None:
+        """Remove a file inside the documents root."""
+
+        target = self._ensure_file(relative_path)
+        target.unlink()
+
+    # ------------------------------------------------------------------
+    def _build_directory(self, directory: Path, relative: Path) -> UserDocumentEntry:
+        entries: list[UserDocumentEntry] = []
+        child_results: list[TokenCountResult] = []
+        for child in sorted(directory.iterdir(), key=lambda item: (not item.is_dir(), item.name.lower())):
+            if child.is_symlink():
+                raise RuntimeError(f"Symlink entries are not supported: {child}")
+            child_relative = relative / child.name
+            if child.is_dir():
+                entry = self._build_directory(child, child_relative)
+            else:
+                entry = self._build_file(child, child_relative)
+            entries.append(entry)
+            if entry.token_count is not None:
+                child_results.append(entry.token_count)
+
+        aggregate_tokens = combine_token_counts(child_results) if child_results else None
+        percent = self._percent_of_context(aggregate_tokens.tokens if aggregate_tokens else None)
+        return UserDocumentEntry(
+            name=directory.name or ".",
+            relative_path=relative,
+            is_dir=True,
+            token_count=aggregate_tokens,
+            percent_of_context=percent,
+            children=entries,
+        )
+
+    def _build_file(self, path: Path, relative: Path) -> UserDocumentEntry:
+        text = path.read_text(encoding="utf-8", errors="replace")
+        tokens = count_text_tokens(text, model=self.token_model)
+        percent = self._percent_of_context(tokens.tokens)
+        size = path.stat().st_size
+        return UserDocumentEntry(
+            name=path.name,
+            relative_path=relative,
+            is_dir=False,
+            size_bytes=size,
+            token_count=tokens,
+            percent_of_context=percent,
+        )
+
+    def _render_tree(self, entry: UserDocumentEntry) -> str:
+        if not entry.children:
+            suffix = " (empty)" if entry.is_dir else ""
+            return f"{self._format_entry(entry)}{suffix}"
+
+        lines = [self._format_entry(entry)]
+        for line in self._iter_tree_lines(entry.children, prefix=""):
+            lines.append(line)
+        return "\n".join(lines)
+
+    def _iter_tree_lines(
+        self,
+        entries: Iterable[UserDocumentEntry],
+        *,
+        prefix: str,
+    ) -> Iterator[str]:
+        entries = list(entries)
+        for index, entry in enumerate(entries):
+            is_last = index == len(entries) - 1
+            connector = "└── " if is_last else "├── "
+            current_prefix = prefix + ("    " if is_last else "│   ")
+            line = prefix + connector + self._format_entry(entry)
+            yield line
+            if entry.children:
+                yield from self._iter_tree_lines(entry.children, prefix=current_prefix)
+
+    def _format_entry(self, entry: UserDocumentEntry) -> str:
+        parts: list[str] = [entry.name or "."]
+        if entry.is_dir:
+            parts.append("[dir]")
+        else:
+            parts.append("[file]")
+        if entry.size_bytes is not None:
+            parts.append(f"{entry.size_bytes} B")
+        if entry.token_count is not None and entry.token_count.tokens is not None:
+            approx = "~" if entry.token_count.approximate else ""
+            parts.append(f"{approx}{entry.token_count.tokens} tokens")
+        if entry.percent_of_context is not None:
+            parts.append(f"{entry.percent_of_context:.2f}% context")
+        return " ".join(parts)
+
+    def _percent_of_context(self, tokens: int | None) -> float | None:
+        if tokens is None:
+            return None
+        return round((tokens / self.max_context_tokens) * 100, 2)
+
+    def _resolve_path(self, relative_path: str | Path) -> Path:
+        relative = Path(relative_path)
+        if relative.is_absolute():
+            candidate = relative
+        else:
+            candidate = (self.root / relative).resolve()
+        try:
+            candidate.relative_to(self.root)
+        except ValueError as exc:  # pragma: no cover - path traversal guard
+            raise PermissionError("Attempted to access path outside of documents root") from exc
+        return candidate
+
+    def _ensure_file(self, relative_path: str | Path) -> Path:
+        path = self._resolve_path(relative_path)
+        if not path.exists():
+            raise FileNotFoundError(path)
+        if path.is_dir():
+            raise IsADirectoryError(path)
+        return path
+
+    def _relative_path(self, absolute: Path) -> Path:
+        return absolute.relative_to(self.root)
+

--- a/app/ui/agent_chat_panel/project_settings.py
+++ b/app/ui/agent_chat_panel/project_settings.py
@@ -13,24 +13,43 @@ from collections.abc import Mapping
 logger = logging.getLogger(__name__)
 
 
+def _normalize_documents_path(value: str) -> str:
+    """Return normalised representation of *value* suitable for persistence."""
+
+    text = value.strip()
+    if not text:
+        return ""
+    try:
+        normalized = Path(text).expanduser()
+    except Exception as exc:  # pragma: no cover - defensive logging
+        logger.warning("Failed to normalise documents path %s: %s", value, exc)
+        return text
+    return str(normalized)
+
+
 @dataclass(frozen=True, slots=True)
 class AgentProjectSettings:
     """Immutable container with project-specific agent options."""
 
     custom_system_prompt: str = ""
+    documents_path: str = ""
 
     def normalized(self) -> AgentProjectSettings:
         """Return settings with whitespace-normalised fields."""
 
-        return AgentProjectSettings(custom_system_prompt=self.custom_system_prompt.strip())
+        return AgentProjectSettings(
+            custom_system_prompt=self.custom_system_prompt.strip(),
+            documents_path=_normalize_documents_path(self.documents_path),
+        )
 
     def to_dict(self) -> dict[str, Any]:
         """Serialise settings into a JSON-compatible mapping."""
 
         normalized = self.normalized()
         return {
-            "version": 1,
+            "version": 2,
             "custom_system_prompt": normalized.custom_system_prompt,
+            "documents_path": normalized.documents_path,
         }
 
     @classmethod
@@ -40,7 +59,15 @@ class AgentProjectSettings:
         prompt = payload.get("custom_system_prompt", "")
         if not isinstance(prompt, str):
             prompt = ""
-        return cls(custom_system_prompt=prompt.strip())
+
+        documents_path = payload.get("documents_path", "")
+        if not isinstance(documents_path, str):
+            documents_path = ""
+
+        return cls(
+            custom_system_prompt=prompt.strip(),
+            documents_path=_normalize_documents_path(documents_path),
+        )
 
 
 def load_agent_project_settings(path: Path) -> AgentProjectSettings:

--- a/app/ui/agent_chat_panel/settings_dialog.py
+++ b/app/ui/agent_chat_panel/settings_dialog.py
@@ -38,6 +38,39 @@ class AgentProjectSettingsDialog(wx.Dialog):
         )
         self._prompt.SetMinSize(wx.Size(dip(self, 360), dip(self, 160)))
 
+        documents_label = wx.StaticText(
+            self,
+            label=_("User documentation folder"),
+        )
+        documents_hint = wx.StaticText(
+            self,
+            label=_(
+                "Optional path where the agent can read and write project "
+                "documentation. Relative values are resolved from the active "
+                "requirements folder."
+            ),
+        )
+        documents_hint.Wrap(dip(self, 360))
+
+        self._documents_path = wx.TextCtrl(
+            self,
+            value=settings.documents_path,
+            style=wx.TE_PROCESS_ENTER,
+        )
+        self._documents_path.SetMinSize(wx.Size(dip(self, 360), -1))
+        browse_label = _("Browse…")
+        self._documents_browse = wx.Button(self, label=browse_label)
+        self._documents_browse.Bind(wx.EVT_BUTTON, self._on_browse_documents_path)
+
+        documents_path_sizer = wx.BoxSizer(wx.HORIZONTAL)
+        documents_path_sizer.Add(
+            self._documents_path,
+            1,
+            wx.RIGHT | wx.EXPAND,
+            spacing,
+        )
+        documents_path_sizer.Add(self._documents_browse, 0)
+
         buttons = self.CreateStdDialogButtonSizer(wx.OK | wx.CANCEL)
         ok_button = self.FindWindowById(wx.ID_OK)
         if isinstance(ok_button, wx.Button):
@@ -46,6 +79,9 @@ class AgentProjectSettingsDialog(wx.Dialog):
         sizer = wx.BoxSizer(wx.VERTICAL)
         sizer.Add(message, 0, wx.ALL | wx.EXPAND, spacing)
         sizer.Add(self._prompt, 1, wx.LEFT | wx.RIGHT | wx.BOTTOM | wx.EXPAND, spacing)
+        sizer.Add(documents_label, 0, wx.LEFT | wx.RIGHT | wx.EXPAND, spacing)
+        sizer.Add(documents_hint, 0, wx.LEFT | wx.RIGHT | wx.BOTTOM | wx.EXPAND, spacing)
+        sizer.Add(documents_path_sizer, 0, wx.LEFT | wx.RIGHT | wx.BOTTOM | wx.EXPAND, spacing)
         if buttons is not None:
             sizer.Add(buttons, 0, wx.ALL | wx.ALIGN_RIGHT, spacing)
 
@@ -56,6 +92,30 @@ class AgentProjectSettingsDialog(wx.Dialog):
         """Return the configured custom system prompt."""
 
         return self._prompt.GetValue().strip()
+
+    def get_documents_path(self) -> str:
+        """Return the configured user documentation path."""
+
+        return self._documents_path.GetValue().strip()
+
+    def _on_browse_documents_path(self, _event: wx.Event) -> None:
+        """Ask the user to select a documentation directory."""
+
+        current = self.get_documents_path()
+        start_path = current or ""
+        style = getattr(wx, "DD_DEFAULT_STYLE", 0) | getattr(wx, "DD_NEW_DIR_BUTTON", 0)
+        dialog = wx.DirDialog(
+            self,
+            _("Select documentation folder"),
+            start_path,
+            style=style,
+        )
+        try:
+            if dialog.ShowModal() != wx.ID_OK:
+                return
+            self._documents_path.SetValue(dialog.GetPath())
+        finally:
+            dialog.Destroy()
 
 
 __all__ = ["AgentProjectSettingsDialog"]

--- a/tests/gui/test_agent_chat_panel.py
+++ b/tests/gui/test_agent_chat_panel.py
@@ -567,6 +567,28 @@ def test_agent_custom_system_prompt_appended(tmp_path, wx_app):
         assert entry.diagnostic["history_messages"][0]["content"] == custom_prompt
     finally:
         destroy_panel(frame, panel)
+
+
+def test_agent_project_settings_dialog_handles_documents_path(tmp_path, wx_app):
+    wx = pytest.importorskip("wx")
+    from app.ui.agent_chat_panel.settings_dialog import AgentProjectSettingsDialog
+
+    frame = wx.Frame(None)
+    settings = AgentProjectSettings(
+        custom_system_prompt="Existing",
+        documents_path=str(tmp_path / "docs"),
+    )
+
+    try:
+        dialog = AgentProjectSettingsDialog(frame, settings=settings)
+        try:
+            assert dialog.get_documents_path().endswith("docs")
+            dialog._documents_path.SetValue("   relative/manuals   ")
+            assert dialog.get_documents_path() == "relative/manuals"
+        finally:
+            dialog.Destroy()
+    finally:
+        frame.Destroy()
 def test_agent_chat_panel_sends_and_saves_history(tmp_path, wx_app):
     class DummyAgent:
         def run_command(self, text, *, history=None, context=None, cancellation=None, on_tool_result=None, on_llm_step=None):

--- a/tests/unit/test_agent_project_settings.py
+++ b/tests/unit/test_agent_project_settings.py
@@ -1,3 +1,5 @@
+import json
+
 from app.ui.agent_chat_panel.project_settings import (
     AgentProjectSettings,
     load_agent_project_settings,
@@ -11,14 +13,34 @@ def test_agent_project_settings_roundtrip(tmp_path):
     # missing file -> defaults
     settings = load_agent_project_settings(settings_path)
     assert settings.custom_system_prompt == ""
+    assert settings.documents_path == ""
 
     # corrupted payload -> defaults
     settings_path.write_text("not json", encoding="utf-8")
     settings = load_agent_project_settings(settings_path)
     assert settings.custom_system_prompt == ""
+    assert settings.documents_path == ""
 
-    desired = AgentProjectSettings(custom_system_prompt="  Keep naming short  ")
+    desired = AgentProjectSettings(
+        custom_system_prompt="  Keep naming short  ",
+        documents_path="  docs/manuals  ",
+    )
     save_agent_project_settings(settings_path, desired)
 
     loaded = load_agent_project_settings(settings_path)
     assert loaded.custom_system_prompt == "Keep naming short"
+    assert loaded.documents_path.endswith("docs/manuals")
+    assert "  " not in loaded.documents_path
+
+
+def test_agent_project_settings_loads_version_one_payload(tmp_path):
+    settings_path = tmp_path / "agent_settings.json"
+    payload = {
+        "version": 1,
+        "custom_system_prompt": "Legacy prompt",
+    }
+    settings_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    loaded = load_agent_project_settings(settings_path)
+    assert loaded.custom_system_prompt == "Legacy prompt"
+    assert loaded.documents_path == ""

--- a/tests/unit/test_user_documents_service.py
+++ b/tests/unit/test_user_documents_service.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from app.services.user_documents import MAX_READ_BYTES, UserDocumentsService
+
+
+def create_service(tmp_path: Path, *, model: str | None = None) -> UserDocumentsService:
+    root = tmp_path / "docs"
+    root.mkdir()
+    return UserDocumentsService(root, max_context_tokens=100, token_model=model)
+
+
+def test_list_tree_reports_tokens_and_percentages(tmp_path: Path) -> None:
+    service = create_service(tmp_path)
+    (service.root / "guide").mkdir()
+    (service.root / "guide" / "intro.txt").write_text("hello world", encoding="utf-8")
+    (service.root / "guide" / "details.md").write_text("line one\nline two\n", encoding="utf-8")
+    (service.root / "notes.txt").write_text("alpha beta gamma", encoding="utf-8")
+
+    payload = service.list_tree()
+
+    assert payload["root"] == str(service.root)
+    assert payload["max_context_tokens"] == 100
+    root_entry = payload["root_entry"]
+    assert root_entry["name"] == service.root.name
+    entries = payload["entries"]
+    assert len(entries) == 2
+    notes = next(item for item in entries if item["name"] == "notes.txt")
+    assert notes["type"] == "file"
+    assert notes["token_count"]["tokens"] is not None
+    assert notes["percent_of_context"] > 0
+    guide = next(item for item in entries if item["name"] == "guide")
+    assert guide["type"] == "directory"
+    assert guide["token_count"]["tokens"] >= notes["token_count"]["tokens"]
+    assert "guide" in payload["tree_text"]
+    assert "tokens" in payload["tree_text"]
+
+
+def test_read_file_applies_line_numbers_and_limits(tmp_path: Path) -> None:
+    service = create_service(tmp_path)
+    content = "\n".join(f"line {idx}" for idx in range(1, 21))
+    target = service.create_file("chapter.txt", content=content)
+
+    result = service.read_file(target.name, start_line=5, max_bytes=40)
+
+    assert result["start_line"] == 5
+    assert result["end_line"] >= 5
+    assert result["bytes_consumed"] <= 40
+    assert result["truncated"] is True
+    assert "     5:" in result["content"]
+
+
+def test_create_file_rejects_existing_paths_without_flag(tmp_path: Path) -> None:
+    service = create_service(tmp_path)
+    service.create_file("report.txt", content="initial")
+
+    with pytest.raises(FileExistsError):
+        service.create_file("report.txt", content="overwrite")
+
+
+def test_delete_file_and_traversal_guard(tmp_path: Path) -> None:
+    service = create_service(tmp_path)
+    created = service.create_file("folder/data.txt", content="payload")
+    assert created.exists()
+
+    service.delete_file("folder/data.txt")
+    assert not created.exists()
+
+    outside = tmp_path / "other.txt"
+    outside.write_text("danger", encoding="utf-8")
+    with pytest.raises(PermissionError):
+        service.delete_file(outside)
+
+
+def test_read_file_rejects_invalid_arguments(tmp_path: Path) -> None:
+    service = create_service(tmp_path)
+    target = service.create_file("notes.txt", content="text")
+
+    with pytest.raises(ValueError):
+        service.read_file(target.name, start_line=0)
+    with pytest.raises(ValueError):
+        service.read_file(target.name, max_bytes=MAX_READ_BYTES + 1)
+


### PR DESCRIPTION
## Summary
- introduce a user documents service that can list, read, create, and delete files under the documentation root
- compute token statistics and context usage percentages for files and directories and render a textual tree representation
- cover the new service with unit tests for listing, reading limits, creation, deletion, and argument validation

## Testing
- pytest --suite core -q

------
https://chatgpt.com/codex/tasks/task_e_68e51f9061b083209058932eb9887ad7