### PR TITLE
Add live documentation path hint in MCP settings

### DIFF
--- a/app/locale/en/LC_MESSAGES/CookaReq.po
+++ b/app/locale/en/LC_MESSAGES/CookaReq.po
@@ -2252,3 +2252,27 @@ msgstr "{used} / {limit}"
 
 msgid "Загрузка…"
 msgstr "Загрузка…"
+
+msgid "Documentation root: disabled"
+msgstr "Documentation root: disabled"
+
+msgid "Documentation root: base path is required for relative folders"
+msgstr "Documentation root: base path is required for relative folders"
+
+msgid "Documentation root: invalid path"
+msgstr "Documentation root: invalid path"
+
+msgid "Documentation root: {source} → {path}"
+msgstr "Documentation root: {source} → {path}"
+
+msgid "Documentation root: {source} → {path} (missing)"
+msgstr "Documentation root: {source} → {path} (missing)"
+
+msgid "Documentation root: {path}"
+msgstr "Documentation root: {path}"
+
+msgid "Documentation root: {path} (missing)"
+msgstr "Documentation root: {path} (missing)"
+
+msgid "Select documentation folder"
+msgstr "Select documentation folder"

--- a/app/locale/ru/LC_MESSAGES/CookaReq.po
+++ b/app/locale/ru/LC_MESSAGES/CookaReq.po
@@ -2268,3 +2268,27 @@ msgstr "{used} / {limit}"
 
 msgid "Загрузка…"
 msgstr "Загрузка…"
+
+msgid "Documentation root: disabled"
+msgstr "Корневая папка документации: отключена"
+
+msgid "Documentation root: base path is required for relative folders"
+msgstr "Корневая папка документации: для относительных путей требуется базовый каталог"
+
+msgid "Documentation root: invalid path"
+msgstr "Корневая папка документации: некорректный путь"
+
+msgid "Documentation root: {source} → {path}"
+msgstr "Корневая папка документации: {source} → {path}"
+
+msgid "Documentation root: {source} → {path} (missing)"
+msgstr "Корневая папка документации: {source} → {path} (не существует)"
+
+msgid "Documentation root: {path}"
+msgstr "Корневая папка документации: {path}"
+
+msgid "Documentation root: {path} (missing)"
+msgstr "Корневая папка документации: {path} (не существует)"
+
+msgid "Select documentation folder"
+msgstr "Выберите папку документации"

--- a/app/mcp/paths.py
+++ b/app/mcp/paths.py
@@ -3,8 +3,21 @@
 from __future__ import annotations
 
 import logging
+from dataclasses import dataclass
 from pathlib import Path
+from typing import Literal
+
 logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True, slots=True)
+class DocumentsRootDescription:
+    """Metadata about the resolved documentation directory."""
+
+    status: Literal["disabled", "missing_base", "invalid", "resolved"]
+    input_path: str = ""
+    resolved: Path | None = None
+    is_relative: bool = False
 
 
 def normalize_documents_path(value: str | Path | None) -> str:
@@ -19,33 +32,64 @@ def normalize_documents_path(value: str | Path | None) -> str:
     return text.strip()
 
 
+def describe_documents_root(
+    base_path: str | Path | None,
+    documents_path: str | Path | None,
+) -> DocumentsRootDescription:
+    """Return a structured description of the documentation directory."""
+
+    text = normalize_documents_path(documents_path)
+    if not text:
+        return DocumentsRootDescription(status="disabled")
+    try:
+        candidate = Path(text).expanduser()
+    except Exception as exc:  # pragma: no cover - defensive logging
+        logger.warning("Invalid documents path %s: %s", documents_path, exc)
+        return DocumentsRootDescription(status="invalid", input_path=text)
+    if candidate.is_absolute():
+        return DocumentsRootDescription(
+            status="resolved",
+            input_path=text,
+            resolved=candidate,
+            is_relative=False,
+        )
+    if base_path in (None, ""):
+        return DocumentsRootDescription(
+            status="missing_base",
+            input_path=text,
+            is_relative=True,
+        )
+    try:
+        base = Path(base_path).expanduser()
+    except Exception as exc:  # pragma: no cover - defensive logging
+        logger.warning("Invalid requirements base %s: %s", base_path, exc)
+        return DocumentsRootDescription(
+            status="invalid", input_path=text, is_relative=True
+        )
+    resolved = (base / candidate).resolve(strict=False)
+    return DocumentsRootDescription(
+        status="resolved",
+        input_path=text,
+        resolved=resolved,
+        is_relative=True,
+    )
+
+
 def resolve_documents_root(
     base_path: str | Path | None,
     documents_path: str | Path | None,
 ) -> Path | None:
     """Resolve the documentation directory combining base and document paths."""
 
-    text = normalize_documents_path(documents_path)
-    if not text:
+    description = describe_documents_root(base_path, documents_path)
+    if description.status != "resolved":
         return None
-    try:
-        candidate = Path(text).expanduser()
-    except Exception as exc:  # pragma: no cover - defensive logging
-        logger.warning("Invalid documents path %s: %s", documents_path, exc)
-        return None
-    if candidate.is_absolute():
-        return candidate
-    if base_path in (None, ""):
-        return None
-    try:
-        base = Path(base_path).expanduser()
-    except Exception as exc:  # pragma: no cover - defensive logging
-        logger.warning("Invalid requirements base %s: %s", base_path, exc)
-        return None
-    return (base / candidate).resolve(strict=False)
+    return description.resolved
 
 
 __all__ = [
+    "DocumentsRootDescription",
+    "describe_documents_root",
     "normalize_documents_path",
     "resolve_documents_root",
 ]

--- a/tests/gui/test_settings_dialog.py
+++ b/tests/gui/test_settings_dialog.py
@@ -473,12 +473,17 @@ def test_documents_hint_tracks_filesystem(wx_app, tmp_path):
 
     wx.YieldIfNeeded()
     hint = dlg._documents_hint
-    assert str(docs_dir.resolve()) in hint.GetLabel()
+    expected_path = str(docs_dir.resolve())
+    assert hint.GetLabel() == f"Documentation root: docs → {expected_path}"
     assert hint.GetForegroundColour() == wx.Colour(0, 128, 0)
 
     dlg._documents_path.SetValue("missing")
     wx.YieldIfNeeded()
-    assert "missing" in hint.GetLabel()
+    missing_path = str((base_dir / "missing").resolve())
+    assert (
+        hint.GetLabel()
+        == f"Documentation root: missing → {missing_path} (missing)"
+    )
     assert hint.GetForegroundColour() == wx.Colour(178, 34, 34)
 
     dlg._documents_path.SetValue("")
@@ -487,5 +492,53 @@ def test_documents_hint_tracks_filesystem(wx_app, tmp_path):
     assert (
         hint.GetForegroundColour() == dlg._documents_hint_default_colour
     )
+
+    dlg.Destroy()
+
+
+def test_documents_hint_supports_absolute_path(wx_app, tmp_path):
+    wx = pytest.importorskip("wx")
+    from app.ui.settings_dialog import SettingsDialog
+
+    docs_dir = tmp_path / "absolute"
+    docs_dir.mkdir()
+
+    dlg = SettingsDialog(
+        None,
+        open_last=False,
+        remember_sort=False,
+        language="en",
+        base_url="http://api",
+        model="gpt-test",
+        message_format="openai-chat",
+        api_key="",
+        max_retries=3,
+        max_context_tokens=DEFAULT_MAX_CONTEXT_TOKENS,
+        timeout_minutes=10,
+        use_custom_temperature=False,
+        temperature=DEFAULT_LLM_TEMPERATURE,
+        stream=False,
+        auto_start=True,
+        host="localhost",
+        port=8123,
+        base_path=str(tmp_path / "requirements"),
+        documents_path=str(docs_dir),
+        log_dir="",
+        require_token=False,
+        token="",
+        mcp_controller_factory=lambda: IdleMCPController(),
+    )
+
+    wx.YieldIfNeeded()
+    hint = dlg._documents_hint
+    absolute_text = str(docs_dir)
+    assert hint.GetLabel() == f"Documentation root: {absolute_text}"
+    assert hint.GetForegroundColour() == wx.Colour(0, 128, 0)
+
+    dlg._documents_path.SetValue(str(docs_dir / "missing"))
+    wx.YieldIfNeeded()
+    missing_abs = str(docs_dir / "missing")
+    assert hint.GetLabel() == f"Documentation root: {missing_abs} (missing)"
+    assert hint.GetForegroundColour() == wx.Colour(178, 34, 34)
 
     dlg.Destroy()

--- a/tests/unit/test_mcp_paths.py
+++ b/tests/unit/test_mcp_paths.py
@@ -1,6 +1,10 @@
 from pathlib import Path
 
-from app.mcp.paths import normalize_documents_path, resolve_documents_root
+from app.mcp.paths import (
+    describe_documents_root,
+    normalize_documents_path,
+    resolve_documents_root,
+)
 
 
 def test_normalize_documents_path_handles_various_inputs(tmp_path):
@@ -23,3 +27,24 @@ def test_resolve_documents_root_with_absolute_path(tmp_path):
 def test_resolve_documents_root_without_base(tmp_path):
     assert resolve_documents_root(None, "docs") is None
     assert resolve_documents_root("", "docs") is None
+
+
+def test_describe_documents_root_relative_and_absolute(tmp_path):
+    relative = describe_documents_root(tmp_path, "./manuals")
+    assert relative.status == "resolved"
+    assert relative.is_relative
+    assert relative.input_path == "./manuals"
+    assert relative.resolved == (Path(tmp_path) / "manuals").resolve()
+
+    absolute_target = (tmp_path / "absdocs").resolve()
+    absolute = describe_documents_root(tmp_path / "ignored", absolute_target)
+    assert absolute.status == "resolved"
+    assert not absolute.is_relative
+    assert absolute.input_path == str(absolute_target)
+    assert absolute.resolved == absolute_target
+
+
+def test_describe_documents_root_missing_base():
+    info = describe_documents_root("", "./docs")
+    assert info.status == "missing_base"
+    assert info.is_relative


### PR DESCRIPTION
## Summary
- add a live status hint above the MCP documentation folder input showing the resolved absolute path
- validate the documentation directory as the user edits it and colour the hint based on availability
- cover the new behaviour with a GUI smoke test that exercises the colour transitions

## Testing
- pytest --suite gui-smoke -q tests/gui/test_settings_dialog.py

------
https://chatgpt.com/codex/tasks/task_e_68e54ca733f88320a8dadf2468930360