### PR TITLE
Fix documentation hint visibility in MCP settings

### DIFF
--- a/app/ui/settings_dialog.py
+++ b/app/ui/settings_dialog.py
@@ -541,7 +541,11 @@ class SettingsDialog(wx.Dialog):
         self._documents_browse.Bind(
             wx.EVT_BUTTON, self._on_browse_documents_path
         )
-        self._documents_hint = wx.StaticText(mcp, style=wx.ST_NO_AUTORESIZE)
+        default_documents_hint = _("Documentation root: disabled")
+        self._documents_hint = wx.StaticText(
+            mcp,
+            label=default_documents_hint,
+        )
         self._documents_hint_default_colour = self._documents_hint.GetForegroundColour()
         self._documents_hint_success_colour = wx.Colour(0, 128, 0)
         self._documents_hint_error_colour = wx.Colour(178, 34, 34)


### PR DESCRIPTION
## Summary
- initialize the MCP documentation hint label with text so it keeps a non-zero size and stays visible

## Testing
- pytest --suite core -q
- pytest --suite gui-smoke -q tests/gui/test_settings_dialog.py

------
https://chatgpt.com/codex/tasks/task_e_68e55dfe964c8320b93048d0de7c8d38