### PR TITLE
Clean MCP utilities and add LLM parser docs

### DIFF
--- a/app/application.py
+++ b/app/application.py
@@ -1,6 +1,8 @@
 """Composition root building shared dependencies for CookaReq."""
 from __future__ import annotations
+
 from collections.abc import Callable
+
 from pathlib import Path
 from typing import TYPE_CHECKING, Protocol
 from .config import ConfigManager
@@ -65,9 +67,10 @@ class ApplicationContext:
         config_factory: Callable[[str], ConfigManager] | None = None,
         requirement_model_factory: Callable[[], RequirementModel] | None = None,
         requirements_service_cls: type[RequirementsService] = RequirementsService,
-        local_agent_cls: type["LocalAgent"] | None = None,
+        local_agent_cls: type[LocalAgent] | None = None,
         mcp_controller_cls: type[MCPController] = MCPController,
     ) -> None:
+        """Initialise the dependency container shared across frontends."""
         self._app_name = app_name
         self._config_factory = config_factory or (lambda name: ConfigManager(name))
         self._requirement_model_factory = (
@@ -127,7 +130,7 @@ class ApplicationContext:
                 confirm_override: ConfirmCallback | None = None,
                 confirm_requirement_update_override: RequirementUpdateConfirmCallback
                 | None = None,
-            ) -> "LocalAgent":
+            ) -> LocalAgent:
                 kwargs: dict[str, object] = {"settings": settings}
                 if confirm_override is not None:
                     kwargs["confirm"] = confirm_override
@@ -153,7 +156,7 @@ class ApplicationContext:
         return self._mcp_controller_factory
 
     @classmethod
-    def for_gui(cls, *, app_name: str = "CookaReq") -> "ApplicationContext":
+    def for_gui(cls, *, app_name: str = "CookaReq") -> ApplicationContext:
         """Return context configured for the wx-based GUI."""
         from .confirm import wx_confirm, wx_confirm_requirement_update
 
@@ -164,7 +167,7 @@ class ApplicationContext:
         )
 
     @classmethod
-    def for_cli(cls, *, app_name: str = "CookaReq") -> "ApplicationContext":
+    def for_cli(cls, *, app_name: str = "CookaReq") -> ApplicationContext:
         """Return context configured for non-interactive CLI usage."""
         from .confirm import auto_confirm, auto_confirm_requirement_update
 

--- a/app/application.py
+++ b/app/application.py
@@ -1,5 +1,4 @@
 """Composition root building shared dependencies for CookaReq."""
-
 from __future__ import annotations
 from collections.abc import Callable
 from pathlib import Path
@@ -41,7 +40,7 @@ class LocalAgentFactory(Protocol):
         confirm_override: ConfirmCallback | None = None,
         confirm_requirement_update_override: RequirementUpdateConfirmCallback
         | None = None,
-    ) -> "LocalAgent":
+    ) -> LocalAgent:
         """Build an agent for ``settings`` optionally overriding confirmations."""
         raise NotImplementedError
 
@@ -89,7 +88,6 @@ class ApplicationContext:
     @property
     def config(self) -> ConfigManager:
         """Return lazily initialised :class:`ConfigManager`."""
-
         if self._config is None:
             self._config = self._config_factory(self._app_name)
         return self._config
@@ -97,7 +95,6 @@ class ApplicationContext:
     @property
     def requirement_model(self) -> RequirementModel:
         """Return shared :class:`RequirementModel` instance."""
-
         if self._requirement_model is None:
             self._requirement_model = self._requirement_model_factory()
         return self._requirement_model
@@ -105,7 +102,6 @@ class ApplicationContext:
     @property
     def requirements_service_factory(self) -> RequirementsServiceFactory:
         """Return factory constructing :class:`RequirementsService` objects."""
-
         if self._requirements_service_factory is None:
             service_cls = self._requirements_service_cls
 
@@ -118,7 +114,6 @@ class ApplicationContext:
     @property
     def local_agent_factory(self) -> LocalAgentFactory:
         """Return factory creating :class:`LocalAgent` instances."""
-
         if self._local_agent_factory is None:
             agent_cls = self._local_agent_cls
             if agent_cls is None:
@@ -148,7 +143,6 @@ class ApplicationContext:
     @property
     def mcp_controller_factory(self) -> MCPControllerFactory:
         """Return factory creating :class:`MCPController` instances."""
-
         if self._mcp_controller_factory is None:
             controller_cls = self._mcp_controller_cls
 
@@ -161,7 +155,6 @@ class ApplicationContext:
     @classmethod
     def for_gui(cls, *, app_name: str = "CookaReq") -> "ApplicationContext":
         """Return context configured for the wx-based GUI."""
-
         from .confirm import wx_confirm, wx_confirm_requirement_update
 
         return cls(
@@ -173,7 +166,6 @@ class ApplicationContext:
     @classmethod
     def for_cli(cls, *, app_name: str = "CookaReq") -> "ApplicationContext":
         """Return context configured for non-interactive CLI usage."""
-
         from .confirm import auto_confirm, auto_confirm_requirement_update
 
         return cls(

--- a/app/cli/commands.py
+++ b/app/cli/commands.py
@@ -89,7 +89,6 @@ class ItemPayload:
 
     def validate(self) -> None:
         """Ensure payload contains supported values."""
-
         errors: list[str] = []
         for field_name, enum_cls, message in (
             ("type", RequirementType, _("unknown requirement type: {value}")),
@@ -121,7 +120,6 @@ class ItemPayload:
 
     def to_payload(self) -> dict[str, Any]:
         """Convert dataclass into dictionary suitable for persistence."""
-
         data = asdict(self)
         if self.revision is None:
             data.pop("revision", None)
@@ -160,7 +158,6 @@ def _service_for(
     context: ApplicationContext, directory: str | Path
 ) -> RequirementsService:
     """Return requirements service rooted at ``directory``."""
-
     factory = context.requirements_service_factory
     return factory(Path(directory))
 
@@ -463,7 +460,6 @@ def build_item_payload(
     args: argparse.Namespace, base: Mapping[str, Any] | None
 ) -> dict[str, Any]:
     """Combine CLI arguments and base data into payload for creation."""
-
     base_data: Mapping[str, Any] = base or {}
     values: dict[str, Any] = {}
     for field_def in fields(ItemPayload):
@@ -493,7 +489,6 @@ def cmd_doc_create(
     args: argparse.Namespace, context: ApplicationContext
 ) -> None:
     """Create new document within requirements root."""
-
     service = _service_for(context, args.directory)
     doc = service.create_document(
         prefix=args.prefix,
@@ -507,7 +502,6 @@ def cmd_doc_list(
     args: argparse.Namespace, context: ApplicationContext
 ) -> None:
     """List documents configured under requirements root."""
-
     service = _service_for(context, args.directory)
     docs = service.load_documents(refresh=True)
     for prefix in sorted(docs):
@@ -519,7 +513,6 @@ def cmd_doc_delete(
     args: argparse.Namespace, context: ApplicationContext
 ) -> None:
     """Delete document ``prefix`` and its descendants."""
-
     service = _service_for(context, args.directory)
     if getattr(args, "dry_run", False):
         doc_list, item_list = service.plan_delete_document(args.prefix)
@@ -548,7 +541,6 @@ def cmd_doc_delete(
 
 def add_doc_arguments(p: argparse.ArgumentParser) -> None:
     """Configure parser for ``doc`` subcommands."""
-
     sub = p.add_subparsers(dest="doc_command", required=True)
 
     create = sub.add_parser("create", help=_("create document"))
@@ -601,7 +593,6 @@ def cmd_item_edit(
     args: argparse.Namespace, context: ApplicationContext
 ) -> None:
     """Update an existing requirement without changing its RID."""
-
     prefix, item_id = parse_rid(args.rid)
     service = _service_for(context, args.directory)
     try:
@@ -648,7 +639,6 @@ def cmd_item_move(
     args: argparse.Namespace, context: ApplicationContext
 ) -> None:
     """Move existing item ``rid`` to document ``new_prefix``."""
-
     service = _service_for(context, args.directory)
     try:
         current = service.get_requirement(args.rid)
@@ -699,7 +689,6 @@ def cmd_item_delete(
     args: argparse.Namespace, context: ApplicationContext
 ) -> None:
     """Delete requirement ``rid`` and update references."""
-
     service = _service_for(context, args.directory)
     if getattr(args, "dry_run", False):
         exists, refs = service.plan_delete_requirement(args.rid)
@@ -734,7 +723,6 @@ def cmd_item_delete(
 
 def _add_item_payload_arguments(parser: argparse.ArgumentParser) -> None:
     """Add common requirement field arguments to ``parser``."""
-
     parser.add_argument("--title", help=_("item title"))
     parser.add_argument("--statement", help=_("item statement"))
     parser.add_argument(
@@ -774,7 +762,6 @@ def _add_item_payload_arguments(parser: argparse.ArgumentParser) -> None:
 
 def add_item_arguments(p: argparse.ArgumentParser) -> None:
     """Configure parser for ``item`` subcommands."""
-
     sub = p.add_subparsers(dest="item_command", required=True)
 
     add_p = sub.add_parser("add", help=_("create new item"))
@@ -829,7 +816,6 @@ def cmd_link(
     args: argparse.Namespace, context: ApplicationContext
 ) -> None:
     """Add links from requirement ``rid`` to ``parents``."""
-
     service = _service_for(context, args.directory)
     try:
         prefix, item_id = parse_rid(args.rid)
@@ -888,7 +874,6 @@ def cmd_link(
 
 def add_link_arguments(p: argparse.ArgumentParser) -> None:
     """Configure parser for the ``link`` command."""
-
     p.add_argument("directory", help=_("requirements root"))
     p.add_argument("rid", help=_("requirement identifier"))
     p.add_argument("parents", nargs="+", help=_("parent requirement identifiers"))
@@ -921,7 +906,6 @@ def cmd_trace(
     args: argparse.Namespace, context: ApplicationContext
 ) -> None:
     """Export traceability matrix in the requested format."""
-
     row_axis = _build_axis_config(args, "row")
     column_axis = _build_axis_config(args, "column")
 
@@ -965,7 +949,6 @@ def cmd_export_requirements(
     args: argparse.Namespace, context: ApplicationContext
 ) -> None:
     """Export requirements into Markdown, HTML, or PDF."""
-
     selected_docs = tuple(_flatten_arg_list(getattr(args, "documents", []))) or None
 
     try:
@@ -1011,7 +994,6 @@ def cmd_export_requirements(
 
 def add_export_arguments(p: argparse.ArgumentParser) -> None:
     """Configure parser for the ``export`` command."""
-
     sub = p.add_subparsers(dest="export_command", required=True)
 
     req = sub.add_parser("requirements", help=_("export requirements"))
@@ -1038,7 +1020,6 @@ def add_export_arguments(p: argparse.ArgumentParser) -> None:
 
 def add_trace_arguments(p: argparse.ArgumentParser) -> None:
     """Configure parser for the ``trace`` command."""
-
     p.add_argument("directory", help=_("requirements root"))
     p.add_argument(
         "-r",

--- a/app/columns.py
+++ b/app/columns.py
@@ -1,4 +1,4 @@
-"""Shared column metadata reused by GUI and configuration."""
+"""Column selection utilities for requirements list views."""
 
 from __future__ import annotations
 
@@ -62,13 +62,11 @@ DEFAULT_COLUMN_WIDTHS = MappingProxyType(_DEFAULT_COLUMN_WIDTHS)
 
 def available_columns() -> list[str]:
     """Return toggleable columns for requirement lists."""
-
     return list(AVAILABLE_COLUMNS)
 
 
 def sanitize_columns(columns: Sequence[str]) -> list[str]:
     """Filter ``columns`` to valid, unique entries preserving order."""
-
     seen: set[str] = set()
     sanitized: list[str] = []
     for name in columns:
@@ -80,7 +78,6 @@ def sanitize_columns(columns: Sequence[str]) -> list[str]:
 
 def default_column_width(field: str) -> int:
     """Return a sensible default width for ``field`` in requirement lists."""
-
     width = _DEFAULT_COLUMN_WIDTHS.get(field)
     if width is not None:
         return width

--- a/app/config.py
+++ b/app/config.py
@@ -107,6 +107,7 @@ class ConfigManager:
         app_name: str = "CookaReq",
         path: Path | str | None = None,
     ) -> None:
+        """Initialise configuration manager and load persisted state."""
         self._path = Path(path) if path is not None else _default_config_path(app_name)
         self._path.parent.mkdir(parents=True, exist_ok=True)
         self._settings = AppSettings()
@@ -177,7 +178,6 @@ class ConfigManager:
     # persistence
     def flush(self) -> None:
         """Persist configuration to disk."""
-
         payload = {
             "settings": self._serialize_overrides(),
             "raw": {key: deepcopy(value) for key, value in self._raw.items()},
@@ -190,6 +190,7 @@ class ConfigManager:
     # ------------------------------------------------------------------
     # schema access helpers
     def get_value(self, name: str, default: Any = _MISSING) -> Any:
+        """Return configuration value by *name* honouring overrides."""
         binding = self._binding_for(name)
         if binding is not None:
             value = deepcopy(
@@ -205,6 +206,7 @@ class ConfigManager:
         raise KeyError(name)
 
     def set_value(self, name: str, value: Any) -> None:
+        """Set configuration entry *name* to *value*."""
         binding = self._binding_for(name)
         if binding is not None:
             self._set_override(binding, value)
@@ -214,6 +216,7 @@ class ConfigManager:
     # ------------------------------------------------------------------
     # columns
     def get_column_width(self, index: int, default: int = -1) -> int:
+        """Return persisted width for column *index* or *default* when unset."""
         key = f"col_width_{index}"
         value = self._raw.get(key, _MISSING)
         if value is _MISSING:
@@ -224,9 +227,11 @@ class ConfigManager:
             return int(default)
 
     def set_column_width(self, index: int, width: int) -> None:
+        """Persist width *width* for column *index*."""
         self._raw[f"col_width_{index}"] = int(width)
 
     def get_column_order(self) -> list[str]:
+        """Return configured ordering of visible columns."""
         raw = self._raw.get("col_order")
         if isinstance(raw, str):
             candidates = raw.split(",")
@@ -237,25 +242,31 @@ class ConfigManager:
         return [str(entry) for entry in candidates if str(entry)]
 
     def set_column_order(self, fields: Sequence[str]) -> None:
+        """Persist ordering for visible *fields*."""
         self._raw["col_order"] = [str(field) for field in fields]
 
     def get_columns(self) -> list[str]:
+        """Return sanitised list of configured columns."""
         return sanitize_columns(self.get_value("list_columns"))
 
     def set_columns(self, fields: list[str]) -> None:
+        """Persist sanitized *fields* as visible columns and flush to disk."""
         self.set_value("list_columns", sanitize_columns(fields))
         self.flush()
 
     # ------------------------------------------------------------------
     # recent directories
     def get_recent_dirs(self) -> list[str]:
+        """Return history of recently opened directories."""
         return list(self.get_value("recent_dirs"))
 
     def set_recent_dirs(self, dirs: list[str]) -> None:
+        """Persist list of recent directories and flush to disk."""
         self.set_value("recent_dirs", list(dirs))
         self.flush()
 
     def add_recent_dir(self, path: Path) -> list[str]:
+        """Add *path* to the MRU directory list returning the updated value."""
         dirs = self.get_recent_dirs()
         p = str(path)
         if p in dirs:
@@ -268,32 +279,40 @@ class ConfigManager:
     # ------------------------------------------------------------------
     # flags and language
     def get_auto_open_last(self) -> bool:
+        """Return whether the last document should open automatically."""
         return bool(self.get_value("auto_open_last"))
 
     def set_auto_open_last(self, value: bool) -> None:
+        """Persist auto-open preference and flush."""
         self.set_value("auto_open_last", bool(value))
         self.flush()
 
     def get_remember_sort(self) -> bool:
+        """Return whether table sorting should be remembered."""
         return bool(self.get_value("remember_sort"))
 
     def set_remember_sort(self, value: bool) -> None:
+        """Persist remember-sort preference and flush."""
         self.set_value("remember_sort", bool(value))
         self.flush()
 
     def get_language(self) -> str | None:
+        """Return configured UI language code."""
         return self.get_value("language")
 
     def set_language(self, language: str | None) -> None:
+        """Persist UI *language* preference and flush."""
         self.set_value("language", language)
         self.flush()
 
     # ------------------------------------------------------------------
     # MCP server settings
     def get_mcp_settings(self) -> MCPSettings:
+        """Return deep copy of stored MCP configuration."""
         return self._settings.mcp.model_copy(deep=True)
 
     def set_mcp_settings(self, settings: MCPSettings) -> None:
+        """Persist MCP *settings* and rebuild derived state."""
         self._overrides["mcp"] = settings.model_dump(mode="python")
         self._rebuild_settings()
         self.flush()
@@ -301,9 +320,11 @@ class ConfigManager:
     # ------------------------------------------------------------------
     # LLM client settings
     def get_llm_settings(self) -> LLMSettings:
+        """Return deep copy of stored LLM configuration."""
         return self._settings.llm.model_copy(deep=True)
 
     def set_llm_settings(self, settings: LLMSettings) -> None:
+        """Persist LLM *settings* and rebuild derived state."""
         self._overrides["llm"] = settings.model_dump(mode="python")
         self._rebuild_settings()
         self.flush()
@@ -311,17 +332,21 @@ class ConfigManager:
     # ------------------------------------------------------------------
     # composite dataclasses
     def get_ui_settings(self) -> UISettings:
+        """Return deep copy of UI settings payload."""
         return self._settings.ui.model_copy(deep=True)
 
     def set_ui_settings(self, settings: UISettings) -> None:
+        """Persist UI *settings* and rebuild derived state."""
         self._overrides["ui"] = settings.model_dump(mode="python")
         self._rebuild_settings()
         self.flush()
 
     def get_app_settings(self) -> AppSettings:
+        """Return deep copy of the composite application settings."""
         return self._settings.model_copy(deep=True)
 
     def set_app_settings(self, settings: AppSettings) -> None:
+        """Persist full *settings* payload splitting it into sub-sections."""
         self.set_llm_settings(settings.llm)
         self.set_mcp_settings(settings.mcp)
         self.set_ui_settings(settings.ui)
@@ -329,9 +354,11 @@ class ConfigManager:
     # ------------------------------------------------------------------
     # sort settings
     def get_sort_settings(self) -> tuple[int, bool]:
+        """Return stored sort column index and ascending flag."""
         return int(self.get_value("sort_column")), bool(self.get_value("sort_ascending"))
 
     def set_sort_settings(self, column: int, ascending: bool) -> None:
+        """Persist sort configuration for list presentations."""
         self.set_value("sort_column", int(column))
         self.set_value("sort_ascending", bool(ascending))
         self.flush()
@@ -339,54 +366,67 @@ class ConfigManager:
     # ------------------------------------------------------------------
     # log console
     def get_log_sash(self, default: int) -> int:
+        """Return stored log console sash position with *default* fallback."""
         return int(self.get_value("log_sash", default=default))
 
     def set_log_sash(self, pos: int) -> None:
+        """Persist log console sash position and flush."""
         self.set_value("log_sash", int(pos))
         self.flush()
 
     def set_log_shown(self, shown: bool) -> None:
+        """Persist log console visibility flag."""
         self.set_value("log_shown", bool(shown))
         self.flush()
 
     def get_log_level(self) -> int:
+        """Return configured log level with INFO fallback."""
         level = int(self.get_value("log_level"))
         if level not in (logging.DEBUG, logging.INFO, logging.WARNING, logging.ERROR):
             return logging.INFO
         return level
 
     def set_log_level(self, level: int) -> None:
+        """Persist chosen log *level* and flush."""
         self.set_value("log_level", int(level))
         self.flush()
 
     def get_agent_chat_shown(self) -> bool:
+        """Return whether the agent chat panel is visible."""
         return bool(self.get_value("agent_chat_shown"))
 
     def set_agent_chat_shown(self, shown: bool) -> None:
+        """Persist agent chat visibility flag and flush."""
         self.set_value("agent_chat_shown", bool(shown))
         self.flush()
 
     def get_agent_chat_sash(self, default: int) -> int:
+        """Return stored agent chat sash position with *default* fallback."""
         return int(self.get_value("agent_chat_sash", default=default))
 
     def set_agent_chat_sash(self, pos: int) -> None:
+        """Persist agent chat sash position and flush."""
         self.set_value("agent_chat_sash", int(pos))
         self.flush()
 
     def get_agent_history_sash(self, default: int) -> int:
+        """Return stored agent history sash position with *default* fallback."""
         return int(self.get_value("agent_history_sash", default=default))
 
     def get_agent_confirm_mode(self) -> str:
+        """Return mode controlling confirmation prompts."""
         value = str(self.get_value("agent_confirm_mode", default="prompt"))
         if value not in {"prompt", "never"}:
             return "prompt"
         return value
 
     def set_agent_history_sash(self, pos: int) -> None:
+        """Persist agent history sash position and flush."""
         self.set_value("agent_history_sash", int(pos))
         self.flush()
 
     def set_agent_confirm_mode(self, mode: str) -> None:
+        """Persist confirmation *mode* coercing invalid values to ``"prompt"``."""
         if mode not in {"prompt", "never"}:
             mode = "prompt"
         self.set_value("agent_confirm_mode", mode)
@@ -395,37 +435,47 @@ class ConfigManager:
     # ------------------------------------------------------------------
     # requirement editor panel
     def get_editor_sash(self, default: int) -> int:
+        """Return stored editor sash position with *default* fallback."""
         return int(self.get_value("editor_sash_pos", default=default))
 
     def set_editor_sash(self, pos: int) -> None:
+        """Persist editor sash position and flush."""
         self.set_value("editor_sash_pos", int(pos))
         self.flush()
 
     def get_editor_shown(self) -> bool:
+        """Return whether the editor panel is visible."""
         return bool(self.get_value("editor_shown"))
 
     def set_editor_shown(self, shown: bool) -> None:
+        """Persist editor visibility flag and flush."""
         self.set_value("editor_shown", bool(shown))
         self.flush()
 
     def get_doc_tree_collapsed(self) -> bool:
+        """Return whether the document tree is collapsed."""
         return bool(self.get_value("doc_tree_collapsed"))
 
     def set_doc_tree_collapsed(self, collapsed: bool) -> None:
+        """Persist collapsed state for the document tree and flush."""
         self.set_value("doc_tree_collapsed", bool(collapsed))
         self.flush()
 
     def get_doc_tree_shown(self) -> bool:
+        """Return whether the document tree is currently shown."""
         return not self.get_doc_tree_collapsed()
 
     def set_doc_tree_shown(self, shown: bool) -> None:
+        """Toggle document tree collapsed flag based on *shown*."""
         self.set_doc_tree_collapsed(not shown)
 
     def get_doc_tree_sash(self, default: int) -> int:
+        """Return clamped sash position for the document tree."""
         value = int(self.get_value("sash_pos", default=default))
         return max(value, 0)
 
     def set_doc_tree_sash(self, pos: int) -> None:
+        """Persist document tree sash position and flush."""
         self.set_value("sash_pos", int(pos))
         self.flush()
 
@@ -442,6 +492,7 @@ class ConfigManager:
         *,
         editor_splitter: wx.SplitterWindow | None = None,
     ) -> None:
+        """Restore persisted window geometry and splitter positions."""
         w = max(400, min(int(self.get_value("win_w")), 3000))
         h = max(300, min(int(self.get_value("win_h")), 2000))
         frame.SetSize((w, h))
@@ -508,6 +559,7 @@ class ConfigManager:
         agent_chat_sash: int | None = None,
         agent_history_sash: int | None = None,
     ) -> None:
+        """Persist current window geometry, splitter positions and column layout."""
         w, h = frame.GetSize()
         x, y = frame.GetPosition()
         self.set_value("win_w", int(w))

--- a/app/config.py
+++ b/app/config.py
@@ -23,7 +23,6 @@ _MISSING = object()
 
 def _default_config_path(app_name: str) -> Path:
     """Return platform-appropriate config path for *app_name*."""
-
     base = os.environ.get("XDG_CONFIG_HOME")
     root = Path(base) if base else Path.home() / ".config"
     return root / app_name / "config.json"

--- a/app/confirm.py
+++ b/app/confirm.py
@@ -58,7 +58,6 @@ def set_requirement_update_confirm(
     callback: RequirementUpdateConfirmCallback,
 ) -> None:
     """Register specialised confirmation for MCP requirement updates."""
-
     global _requirement_update_callback, _requirement_update_always
     _requirement_update_callback = callback
     # Reset stored preference when the UI provides a new handler.
@@ -67,13 +66,13 @@ def set_requirement_update_confirm(
 
 def reset_requirement_update_preference() -> None:
     """Clear session-wide "always" confirmation for requirement updates."""
-
     global _requirement_update_always
     _requirement_update_always = False
 
 
 def confirm(message: str) -> bool:
     """Invoke registered confirmation callback with *message*.
+
     Raises ``RuntimeError`` if no callback configured.
     """
     if _callback is None:
@@ -83,7 +82,6 @@ def confirm(message: str) -> bool:
 
 def confirm_requirement_update(prompt: RequirementUpdatePrompt) -> ConfirmDecision:
     """Return confirmation decision for an MCP requirement update."""
-
     global _requirement_update_always
 
     if _requirement_update_always:
@@ -103,7 +101,6 @@ def _call_in_wx_main_thread(
     func: Callable[_P, _T], /, *args: _P.args, **kwargs: _P.kwargs
 ) -> _T:
     """Execute *func* on the wx main thread and return its result."""
-
     import wx  # type: ignore
 
     is_main_thread = True
@@ -153,8 +150,7 @@ def _call_in_wx_main_thread(
 def _fallback_requirement_update_confirm(
     prompt: RequirementUpdatePrompt,
 ) -> ConfirmDecision:
-    """Default requirement update confirmation using the generic callback."""
-
+    """Return fallback requirement update confirmation via the generic callback."""
     message = format_requirement_update_prompt(prompt)
     if _callback is None:
         return ConfirmDecision.YES
@@ -166,7 +162,6 @@ def format_requirement_update_prompt(
     prompt: RequirementUpdatePrompt, *, include_changes: bool = True
 ) -> str:
     """Return a human-readable confirmation message for *prompt*."""
-
     from .i18n import _
 
     rid = prompt.rid or _("(unknown requirement)")
@@ -194,7 +189,6 @@ def summarise_requirement_changes(
     changes: Sequence[RequirementChange] | Iterable[RequirementChange],
 ) -> Iterable[str]:
     """Yield textual descriptions for requirement updates in *changes*."""
-
     from .i18n import _
 
     for index, change in enumerate(changes, start=1):
@@ -245,7 +239,6 @@ def summarise_requirement_changes(
 
 def _format_change_value(value: Any) -> str:
     """Return short preview of change *value* suitable for prompts."""
-
     if isinstance(value, str):
         formatted = json.dumps(value, ensure_ascii=False)
     else:
@@ -260,7 +253,6 @@ def _format_change_value(value: Any) -> str:
 
 def wx_confirm(message: str) -> bool:
     """GUI confirmation dialog using wxWidgets."""
-
     from .i18n import _
 
     def _show_dialog() -> bool:
@@ -293,7 +285,6 @@ def wx_confirm_requirement_update(
     prompt: RequirementUpdatePrompt,
 ) -> ConfirmDecision:
     """Show a rich confirmation dialog for MCP requirement updates."""
-
     if _requirement_update_always:
         return ConfirmDecision.ALWAYS
 
@@ -383,13 +374,12 @@ def wx_confirm_requirement_update(
 
 
 def auto_confirm(_message: str) -> bool:
-    """Confirmation callback that always returns True."""
+    """Return ``True`` for every confirmation request."""
     return True
 
 
 def auto_confirm_requirement_update(
     _prompt: RequirementUpdatePrompt,
 ) -> ConfirmDecision:
-    """Requirement update confirmation that always approves changes."""
-
+    """Approve requirement update prompts unconditionally."""
     return ConfirmDecision.ALWAYS

--- a/app/core/document_store/__init__.py
+++ b/app/core/document_store/__init__.py
@@ -81,7 +81,6 @@ class Document:
         **extra: Any,
     ) -> None:
         """Create a document definition."""
-
         if extra:
             unexpected = ", ".join(sorted(extra))
             raise TypeError(f"unexpected keyword argument(s): {unexpected}")

--- a/app/core/document_store/documents.py
+++ b/app/core/document_store/documents.py
@@ -15,7 +15,6 @@ def _read_json(path: Path) -> dict:
 
 def stable_color(name: str) -> str:
     """Return a pastel color generated from ``name``."""
-
     from hashlib import sha256
 
     digest = sha256(name.encode("utf-8")).hexdigest()
@@ -27,13 +26,11 @@ def stable_color(name: str) -> str:
 
 def label_color(label: LabelDef) -> str:
     """Return explicit label color or a generated one."""
-
     return label.color or stable_color(label.key)
 
 
 def load_document(directory: str | Path) -> Document:
     """Load document configuration from ``directory``."""
-
     directory_path = Path(directory)
     prefix = directory_path.name
     path = directory_path / "document.json"
@@ -60,7 +57,6 @@ def load_document(directory: str | Path) -> Document:
 
 def save_document(directory: str | Path, doc: Document) -> Path:
     """Persist ``doc`` configuration into ``directory``."""
-
     directory_path = Path(directory)
     expected_prefix = directory_path.name
     if doc.prefix != expected_prefix:
@@ -85,7 +81,6 @@ def save_document(directory: str | Path, doc: Document) -> Path:
 
 def load_documents(root: str | Path) -> dict[str, Document]:
     """Load all document configurations under ``root``."""
-
     root_path = Path(root)
     docs: dict[str, Document] = {}
     if not root_path.is_dir():
@@ -102,7 +97,6 @@ def is_ancestor(
     child_prefix: str, ancestor_prefix: str, docs: Mapping[str, Document]
 ) -> bool:
     """Return ``True`` if ``ancestor_prefix`` is an ancestor of ``child_prefix``."""
-
     if child_prefix == ancestor_prefix:
         return True
     current = docs.get(child_prefix)
@@ -117,7 +111,6 @@ def collect_label_defs(
     prefix: str, docs: Mapping[str, Document]
 ) -> tuple[list[LabelDef], bool]:
     """Return label definitions and freeform flag for ``prefix``."""
-
     labels: list[LabelDef] = []
     allow_freeform = False
     chain: list[Document] = []
@@ -136,7 +129,6 @@ def collect_label_defs(
 
 def collect_labels(prefix: str, docs: Mapping[str, Document]) -> tuple[set[str], bool]:
     """Return allowed label keys and freeform flag for ``prefix``."""
-
     defs, freeform = collect_label_defs(prefix, docs)
     return {d.key for d in defs}, freeform
 
@@ -145,7 +137,6 @@ def validate_labels(
     prefix: str, labels: list[str], docs: Mapping[str, Document]
 ) -> str | None:
     """Validate ``labels`` for items under document ``prefix``."""
-
     allowed, freeform = collect_labels(prefix, docs)
     if labels and not freeform:
         unknown = [lbl for lbl in labels if lbl not in allowed]

--- a/app/core/document_store/items.py
+++ b/app/core/document_store/items.py
@@ -165,7 +165,6 @@ def _read_json(path: Path) -> dict:
 
 def rid_for(doc: Document, item_id: int) -> str:
     """Return requirement identifier for ``item_id`` within ``doc``."""
-
     return f"{doc.prefix}{item_id}"
 
 
@@ -182,7 +181,6 @@ def _canonical_rid(docs: Mapping[str, Document], rid: str) -> str | None:
 
 def parse_rid(rid: str) -> tuple[str, int]:
     """Split ``rid`` into document prefix and numeric id."""
-
     match = RID_RE.match(rid)
     if not match:
         raise ValueError(f"invalid requirement id: {rid}")
@@ -192,14 +190,12 @@ def parse_rid(rid: str) -> tuple[str, int]:
 
 def item_path(directory: str | Path, doc: Document, item_id: int) -> Path:
     """Return filesystem path for ``item_id`` inside ``doc`` using new naming."""
-
     directory_path = Path(directory)
     return directory_path / "items" / canonical_item_name(item_id)
 
 
 def save_item(directory: str | Path, doc: Document, data: dict) -> Path:
     """Save requirement ``data`` within ``doc`` and return file path."""
-
     root = Path(directory).parent
     docs = load_documents(root)
     from .links import validate_item_links  # local import to avoid cycle
@@ -218,7 +214,6 @@ def save_item(directory: str | Path, doc: Document, data: dict) -> Path:
 
 def load_item(directory: str | Path, doc: Document, item_id: int) -> tuple[dict, float]:
     """Load requirement ``item_id`` from ``doc`` and return data with mtime."""
-
     path = item_path(directory, doc, item_id)
     if not path.exists():
         raise FileNotFoundError(path)
@@ -229,7 +224,6 @@ def load_item(directory: str | Path, doc: Document, item_id: int) -> tuple[dict,
 
 def list_item_ids(directory: str | Path, doc: Document) -> set[int]:
     """Return numeric ids of requirements present in ``doc``."""
-
     items_dir = Path(directory) / "items"
     ids: set[int] = set()
     if not items_dir.is_dir():
@@ -244,7 +238,6 @@ def list_item_ids(directory: str | Path, doc: Document) -> set[int]:
 
 def next_item_id(directory: str | Path, doc: Document) -> int:
     """Return the next available numeric id for ``doc``."""
-
     ids = list_item_ids(directory, doc)
     return max(ids, default=0) + 1
 
@@ -294,7 +287,6 @@ def load_requirements(
     current fingerprint state) in the same way as ``search_requirements`` and
     other high level helpers.
     """
-
     root_path = Path(root)
     if docs is None and not root_path.is_dir():
         raise FileNotFoundError(root_path)
@@ -577,7 +569,6 @@ def move_requirement(
     docs: Mapping[str, Document] | None = None,
 ) -> Requirement:
     """Relocate requirement ``rid`` under ``new_prefix`` keeping referential integrity."""
-
     root_path = Path(root)
     docs_map = _ensure_documents(root_path, docs)
     (

--- a/app/core/document_store/layout.py
+++ b/app/core/document_store/layout.py
@@ -7,5 +7,4 @@ __all__ = ["canonical_item_name"]
 
 def canonical_item_name(item_id: int) -> str:
     """Return canonical JSON filename for ``item_id``."""
-
     return f"{int(item_id)}.json"

--- a/app/core/document_store/links.py
+++ b/app/core/document_store/links.py
@@ -58,7 +58,6 @@ def validate_item_links(
 
 def iter_links(root: str | Path) -> Iterable[tuple[str, str]]:
     """Yield pairs of (child_rid, parent_rid) for all links under ``root``."""
-
     docs = load_documents(root)
     for prefix in sorted(docs):
         doc = docs[prefix]
@@ -86,7 +85,6 @@ def plan_delete_item(
     docs: Mapping[str, Document] | None = None,
 ) -> tuple[bool, list[str]]:
     """Return items referencing ``rid`` without deleting anything."""
-
     root_path = Path(root)
     if docs is None:
         docs = load_documents(root_path)
@@ -125,7 +123,6 @@ def plan_delete_document(
     docs: Mapping[str, Document] | None = None,
 ) -> tuple[list[str], list[str]]:
     """Return document prefixes and item ids that would be removed."""
-
     root_path = Path(root)
     if docs is None:
         docs = load_documents(root_path)
@@ -153,7 +150,6 @@ def delete_item(
     docs: Mapping[str, Document] | None = None,
 ) -> bool:
     """Remove requirement ``rid`` and drop links pointing to it."""
-
     root_path = Path(root)
     if docs is None:
         docs = load_documents(root_path)
@@ -202,7 +198,6 @@ def delete_document(
     docs: Mapping[str, Document] | None = None,
 ) -> bool:
     """Remove document ``prefix`` and all its items."""
-
     root_path = Path(root)
     if docs is None:
         docs = load_documents(root_path)
@@ -233,7 +228,6 @@ def link_requirements(
     docs: Mapping[str, Document] | None = None,
 ) -> Requirement:
     """Link ``derived_rid`` to ``source_rid`` when hierarchy permits."""
-
     if link_type != "parent":
         raise ValidationError(f"invalid link_type: {link_type}")
 

--- a/app/core/model.py
+++ b/app/core/model.py
@@ -93,7 +93,6 @@ def requirement_from_dict(
     into their respective dataclasses. Missing optional fields fall back to
     sensible defaults.
     """
-
     required = [
         "id",
         "statement",
@@ -273,7 +272,6 @@ def _fingerprint_value(payload: Requirement | Mapping[str, Any], field: str) -> 
 
 def requirement_fingerprint(payload: Requirement | Mapping[str, Any]) -> str:
     """Compute fingerprint for ``payload`` based on key textual fields."""
-
     data = {field: _fingerprint_value(payload, field) for field in FINGERPRINT_FIELDS}
     serialized = json.dumps(data, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
     return hashlib.sha256(serialized.encode("utf-8")).hexdigest()
@@ -288,7 +286,6 @@ class Link:
     @classmethod
     def from_raw(cls, raw: Any) -> Link:
         """Create :class:`Link` from ``raw`` representation."""
-
         if isinstance(raw, str):
             rid = raw.strip()
             if not rid:
@@ -320,7 +317,6 @@ class Link:
 
     def to_dict(self) -> dict[str, Any]:
         """Return JSON-friendly representation of the link."""
-
         data: dict[str, Any] = {"rid": self.rid}
         if self.fingerprint:
             data["fingerprint"] = self.fingerprint

--- a/app/core/requirement_export.py
+++ b/app/core/requirement_export.py
@@ -95,7 +95,6 @@ def build_requirement_export(
     prefixes: Sequence[str] | None = None,
 ) -> RequirementExport:
     """Load requirements and assemble a deterministic export representation."""
-
     root_path = Path(root)
     docs = load_documents(root_path)
     if not docs and not root_path.is_dir():
@@ -146,7 +145,6 @@ def _format_markdown_block(text: str) -> list[str]:
 
 def render_requirements_markdown(export: RequirementExport, *, title: str | None = None) -> str:
     """Render export data as Markdown."""
-
     heading = title or "Requirements export"
     parts: list[str] = [f"# {heading}", ""]
     parts.append(
@@ -233,7 +231,6 @@ def _html_paragraphs(value: str) -> str:
 
 def render_requirements_html(export: RequirementExport, *, title: str | None = None) -> str:
     """Render export data as standalone HTML."""
-
     heading = title or "Requirements export"
     parts: list[str] = [
         "<!DOCTYPE html>",
@@ -365,7 +362,6 @@ def _pdf_text(value: str) -> str:
 
 def render_requirements_pdf(export: RequirementExport, *, title: str | None = None) -> bytes:
     """Render export data as a PDF document."""
-
     buffer = BytesIO()
     heading = title or "Requirements export"
     styles = _ensure_stylesheet()

--- a/app/core/requirement_import.py
+++ b/app/core/requirement_import.py
@@ -225,7 +225,6 @@ class SequentialIDAllocator:
 
 def detect_format(path: str | Path) -> TabularFileFormat:
     """Infer tabular format from file extension."""
-
     suffix = Path(path).suffix.lower()
     if suffix in {".csv", ".tsv"}:
         return TabularFileFormat.CSV
@@ -244,7 +243,6 @@ def _normalize_delimiter(delimiter: str) -> str:
 
 def load_csv_dataset(path: str | Path, *, delimiter: str = ",") -> TabularDataset:
     """Load CSV/TSV file into a :class:`TabularDataset`."""
-
     norm_delim = _normalize_delimiter(delimiter)
     rows: list[list[Any]] = []
     with Path(path).open(encoding="utf-8") as fh:
@@ -256,7 +254,6 @@ def load_csv_dataset(path: str | Path, *, delimiter: str = ",") -> TabularDatase
 
 def list_excel_sheets(path: str | Path) -> list[str]:
     """Return sheet names available within an Excel workbook."""
-
     if load_workbook is None:
         raise RequirementImportError("openpyxl is not available")
     workbook = load_workbook(filename=Path(path), read_only=True, data_only=True)
@@ -272,7 +269,6 @@ def load_excel_dataset(
     sheet: str | None = None,
 ) -> TabularDataset:
     """Load Excel sheet into a :class:`TabularDataset`."""
-
     if load_workbook is None:
         raise RequirementImportError("openpyxl is not available")
     workbook = load_workbook(filename=Path(path), read_only=True, data_only=True)
@@ -432,7 +428,6 @@ def build_requirements(
     max_rows: int | None = None,
 ) -> RequirementImportResult:
     """Convert a dataset into Requirement objects using ``config`` mapping."""
-
     requirements: list[Requirement] = []
     issues: list[RequirementImportIssue] = []
     processed = 0

--- a/app/core/search.py
+++ b/app/core/search.py
@@ -24,7 +24,6 @@ def filter_by_status(
     status: str | Status | None,
 ) -> list[Requirement]:
     """Filter ``requirements`` by ``status`` if provided."""
-
     reqs = list(requirements)
     if not status:
         return reqs
@@ -94,7 +93,6 @@ def filter_text_fields(
     :data:`SEARCHABLE_FIELDS` or empty query strings are ignored. A requirement
     must satisfy *all* provided field queries to be included in the result.
     """
-
     reqs = list(requirements)
     if not queries:
         return reqs
@@ -108,7 +106,6 @@ def filter_text_fields(
 
 def filter_is_derived(requirements: Iterable[Requirement]) -> list[Requirement]:
     """Return only requirements that link to other requirements."""
-
     return [r for r in requirements if getattr(r, "links", [])]
 
 
@@ -117,7 +114,6 @@ def filter_has_derived(
     all_requirements: Iterable[Requirement],
 ) -> list[Requirement]:
     """Return requirements that are referenced by other requirements."""
-
     reqs = list(requirements)
     sources: set[str] = set()
     for req in all_requirements:

--- a/app/core/trace_matrix.py
+++ b/app/core/trace_matrix.py
@@ -117,7 +117,6 @@ def build_trace_matrix(
     docs: Mapping[str, Document] | None = None,
 ) -> TraceMatrix:
     """Return a traceability matrix for ``config`` rooted at ``root``."""
-
     root_path = Path(root)
     docs_map = docs or load_documents(root_path)
     row_prefixes = _resolve_prefixes(config.rows, docs_map)

--- a/app/i18n.py
+++ b/app/i18n.py
@@ -28,31 +28,26 @@ _TRANSLATION: NullTranslations = NullTranslations()
 
 def get_translation() -> NullTranslations:
     """Return the currently active translation object."""
-
     return _TRANSLATION
 
 
 def gettext(message: str) -> str:
     """Translate *message* using the active gettext catalogue."""
-
     return _TRANSLATION.gettext(message)
 
 
 def ngettext(singular: str, plural: str, number: int) -> str:
     """Translate pluralisable message based on *number*."""
-
     return _TRANSLATION.ngettext(singular, plural, number)
 
 
 def pgettext(context: str, message: str) -> str:
     """Translate *message* for the supplied *context*."""
-
     return _TRANSLATION.pgettext(context, message)
 
 
 def npgettext(context: str, singular: str, plural: str, number: int) -> str:
     """Translate pluralisable message tied to *context*."""
-
     return _TRANSLATION.npgettext(context, singular, plural, number)
 
 
@@ -66,7 +61,6 @@ def translate_resource(message: str | Iterable[str]) -> str:
     the fragments are joined with a single space before translation so that the
     catalogue sees the full sentence.
     """
-
     if isinstance(message, str):
         combined = message
     else:
@@ -80,7 +74,6 @@ def install(
     languages: Iterable[str] | None = None,
 ) -> NullTranslations:
     """Load translations for *domain* and make them globally available."""
-
     localedir_path = Path(localedir)
     requested = _prepare_language_list(languages)
     translation = _gettext.translation(

--- a/app/llm/__init__.py
+++ b/app/llm/__init__.py
@@ -10,7 +10,6 @@ if TYPE_CHECKING:  # pragma: no cover - typing helper
 
 def __getattr__(name: str) -> Any:
     """Lazily expose heavy modules to avoid import cycles."""
-
     if name == "LLMClient":
         from .client import LLMClient
 

--- a/app/llm/client.py
+++ b/app/llm/client.py
@@ -34,7 +34,6 @@ class LLMClient:
 
     def __init__(self, settings: LLMSettings) -> None:
         """Initialize client with LLM configuration ``settings``."""
-
         import openai
 
         self.settings = settings
@@ -61,12 +60,10 @@ class LLMClient:
     # ------------------------------------------------------------------
     def check_llm(self) -> dict[str, Any]:
         """Perform a minimal request to verify connectivity."""
-
         return self._check_llm()
 
     async def check_llm_async(self) -> dict[str, Any]:
         """Asynchronous counterpart to :meth:`check_llm`."""
-
         return await asyncio.to_thread(self._check_llm)
 
     # ------------------------------------------------------------------
@@ -78,7 +75,6 @@ class LLMClient:
         cancellation: CancellationEvent | None = None,
     ) -> LLMResponse:
         """Interpret *text* into an assistant reply with optional tool calls."""
-
         conversation: list[Mapping[str, Any]] = list(history or [])
         conversation.append({"role": "user", "content": text})
         return self.respond(conversation, cancellation=cancellation)
@@ -91,7 +87,6 @@ class LLMClient:
         cancellation: CancellationEvent | None = None,
     ) -> LLMResponse:
         """Asynchronous counterpart to :meth:`parse_command`."""
-
         conversation: list[Mapping[str, Any]] = list(history or [])
         conversation.append({"role": "user", "content": text})
         return await self.respond_async(conversation, cancellation=cancellation)
@@ -104,7 +99,6 @@ class LLMClient:
         cancellation: CancellationEvent | None = None,
     ) -> LLMResponse:
         """Send the full *conversation* to the model and return its reply."""
-
         return self._respond(list(conversation or []), cancellation=cancellation)
 
     async def respond_async(
@@ -114,7 +108,6 @@ class LLMClient:
         cancellation: CancellationEvent | None = None,
     ) -> LLMResponse:
         """Asynchronous counterpart to :meth:`respond`."""
-
         return await asyncio.to_thread(
             self._respond,
             list(conversation or []),
@@ -338,7 +331,6 @@ class LLMClient:
 
     def _apply_reasoning_defaults(self, request_args: dict[str, Any]) -> None:
         """Inject reasoning flags so compatible models emit their thoughts."""
-
         request_args.pop("reasoning_effort", None)
         raw_extra = request_args.get("extra_body")
         if isinstance(raw_extra, Mapping):
@@ -498,7 +490,6 @@ class LLMClient:
         request_messages: Sequence[Mapping[str, Any]] | None,
     ) -> tuple[LLMToolCall, ...]:
         """Fill missing get_requirement arguments using workspace context."""
-
         if not tool_calls:
             return ()
 
@@ -553,7 +544,6 @@ class LLMClient:
     # ------------------------------------------------------------------
     def _chat_completion(self, **request_args: Any) -> Any:
         """Call the chat completions endpoint with normalized arguments."""
-
         try:
             return self._client.chat.completions.create(**request_args)
         except TypeError as exc:

--- a/app/llm/context.py
+++ b/app/llm/context.py
@@ -23,7 +23,6 @@ def extract_selected_rids_from_text(content: str) -> list[str]:
     and returns the canonical identifiers. Invalid tokens are ignored so that
     partially malformed selections still yield useful information for the LLM.
     """
-
     if not isinstance(content, str) or not content:
         return []
 
@@ -60,7 +59,6 @@ def extract_selected_rids_from_messages(
     messages: Sequence[Mapping[str, Any]] | None,
 ) -> list[str]:
     """Scan *messages* and return selected RIDs referenced in system snapshots."""
-
     if not messages:
         return []
 

--- a/app/llm/harmony.py
+++ b/app/llm/harmony.py
@@ -29,7 +29,6 @@ def convert_tools_for_harmony(
     the flattened representation. This helper preserves non-function tools and
     performs a deep copy so the caller can safely mutate the result.
     """
-
     if not tools:
         return []
 
@@ -77,7 +76,6 @@ class HarmonyPrompt:
 
     def snapshot(self) -> Mapping[str, Any]:
         """Return a serialisable snapshot for logging and debugging."""
-
         return {
             "format": "harmony",
             "system_message": self.system_message,
@@ -97,7 +95,6 @@ def render_harmony_prompt(
     knowledge_cutoff: str = HARMONY_KNOWLEDGE_CUTOFF,
 ) -> HarmonyPrompt:
     """Render conversation *history* into a Harmony prompt string."""
-
     system_message = _render_system_message(
         reasoning_level=reasoning_level,
         current_date=current_date or date.today().isoformat(),

--- a/app/llm/logging.py
+++ b/app/llm/logging.py
@@ -65,7 +65,6 @@ class _PromptLogState:
 
     def register(self, signature: PromptSignature | None) -> bool:
         """Return ``True`` when *signature* was logged before."""
-
         if signature is None:
             return False
         if not signature.system_parts and not signature.tool_names:
@@ -77,7 +76,6 @@ class _PromptLogState:
 
     def reset(self) -> None:
         """Forget previously seen signatures (testing helper)."""
-
         self._seen_signatures.clear()
 
 
@@ -86,13 +84,11 @@ _PROMPT_STATE = _PromptLogState()
 
 def _reset_prompt_log_state() -> None:
     """Reset internal cache used to de-duplicate prompt logging."""
-
     _PROMPT_STATE.reset()
 
 
 def log_request(payload: Mapping[str, Any]) -> None:
     """Record telemetry for an outbound LLM request."""
-
     prepared = _prepare_request_payload(payload)
     log_debug_payload("LLM_REQUEST", prepared)
     log_event("LLM_REQUEST", prepared)
@@ -102,7 +98,6 @@ def log_response(
     payload: Mapping[str, Any], *, start_time: float | None = None, direction: str = "inbound"
 ) -> None:
     """Record telemetry for an inbound LLM response."""
-
     log_event("LLM_RESPONSE", payload, start_time=start_time)
     debug_payload = {"direction": direction, **payload}
     log_debug_payload("LLM_RESPONSE", debug_payload)
@@ -110,7 +105,6 @@ def log_response(
 
 def _prepare_request_payload(payload: Mapping[str, Any]) -> Mapping[str, Any]:
     """Return a deep-copied payload with repeated prompts collapsed."""
-
     if not isinstance(payload, Mapping):
         return payload
 
@@ -133,7 +127,6 @@ def _prepare_request_payload(payload: Mapping[str, Any]) -> Mapping[str, Any]:
 
 def _analyze_chat_payload(payload: Mapping[str, Any]) -> ChatPromptAnalysis:
     """Extract metadata describing Chat Completions requests."""
-
     messages = payload.get("messages")
     if not isinstance(messages, Sequence):
         return ChatPromptAnalysis(signature=None, system_indices=(), has_tools=False)
@@ -172,7 +165,6 @@ def _apply_chat_placeholders(
     payload: Mapping[str, Any], analysis: ChatPromptAnalysis
 ) -> None:
     """Replace duplicated Chat Completions prompts with a placeholder."""
-
     messages = payload.get("messages")
     if isinstance(messages, list):
         for index in analysis.system_indices:
@@ -185,7 +177,6 @@ def _apply_chat_placeholders(
 
 def _replace_system_prompt_in_message(message: Mapping[str, Any]) -> None:
     """Trim the base system prompt from *message* preserving contextual tail."""
-
     if not isinstance(message, dict):
         return
     content = message.get("content")
@@ -200,7 +191,6 @@ def _replace_system_prompt_in_message(message: Mapping[str, Any]) -> None:
 
 def _rebuild_message_content(original: Any, new_text: str) -> Any:
     """Return message content mirroring *original* but with *new_text*."""
-
     if isinstance(original, list):
         return [{"type": "text", "text": new_text}]
     if isinstance(original, Mapping):
@@ -215,7 +205,6 @@ def _rebuild_message_content(original: Any, new_text: str) -> Any:
 
 def _analyze_harmony_payload(payload: Mapping[str, Any]) -> HarmonyPromptAnalysis:
     """Extract metadata describing Harmony Responses requests."""
-
     prompt = payload.get("input")
     if not isinstance(prompt, str):
         return HarmonyPromptAnalysis(
@@ -302,7 +291,6 @@ def _apply_harmony_placeholders(
     payload: Mapping[str, Any], analysis: HarmonyPromptAnalysis
 ) -> None:
     """Replace duplicated Harmony prompt fragments with a placeholder."""
-
     prompt = payload.get("input")
     if not isinstance(prompt, str):
         return
@@ -331,7 +319,6 @@ def _apply_harmony_placeholders(
 
 def _extract_text(content: Any) -> str:
     """Return best-effort textual representation of ``content``."""
-
     if content is None:
         return ""
     if isinstance(content, str):
@@ -354,7 +341,6 @@ def _extract_text(content: Any) -> str:
 
 def _extract_tool_names(value: Any) -> tuple[str, ...]:
     """Return ordered tool names extracted from ``value``."""
-
     if not isinstance(value, Sequence) or isinstance(value, (str, bytes, bytearray)):
         return ()
     names: list[str] = []
@@ -373,7 +359,6 @@ def _extract_tool_names(value: Any) -> tuple[str, ...]:
 
 def _find_system_prompt_slice(text: str | None) -> tuple[int, int] | None:
     """Locate the base system prompt within developer instructions."""
-
     if not text:
         return None
     stripped = text.lstrip()

--- a/app/llm/reasoning.py
+++ b/app/llm/reasoning.py
@@ -46,7 +46,6 @@ REASONING_KEYWORDS = ("reason", "think", "analysis", "reflect")
 
 def is_reasoning_type(value: Any) -> bool:
     """Return ``True`` when *value* denotes a reasoning segment."""
-
     if not isinstance(value, str):
         return False
     lowered = value.strip().lower()
@@ -59,7 +58,6 @@ def is_reasoning_type(value: Any) -> bool:
 
 def extract_reasoning_entries(payload: Any) -> list[Mapping[str, Any]]:
     """Return flattened reasoning segments from *payload*."""
-
     if not payload:
         return []
     if isinstance(payload, (str, bytes, bytearray)):
@@ -79,7 +77,6 @@ def extract_reasoning_entries(payload: Any) -> list[Mapping[str, Any]]:
 
 def collect_reasoning_fragments(payload: Any) -> list[ReasoningFragment]:
     """Return reasoning fragments with preserved edge whitespace."""
-
     fragments: list[ReasoningFragment] = []
     if not payload:
         return fragments
@@ -175,7 +172,6 @@ def merge_reasoning_fragments(
     fragments: Sequence[ReasoningFragment],
 ) -> list[ReasoningFragment]:
     """Collapse adjacent fragments of the same type preserving edge whitespace."""
-
     merged: list[ReasoningFragment] = []
     if not fragments:
         return merged
@@ -243,7 +239,6 @@ def merge_reasoning_fragments(
 
 def normalise_reasoning_segments(payload: Any) -> list[dict[str, Any]]:
     """Return sanitized reasoning segments suitable for JSON payloads."""
-
     normalized: list[dict[str, Any]] = []
     if not payload:
         return normalized

--- a/app/llm/request_builder.py
+++ b/app/llm/request_builder.py
@@ -1,5 +1,4 @@
 """Helpers responsible for preparing LLM request payloads."""
-
 from __future__ import annotations
 
 import json
@@ -33,6 +32,7 @@ class LLMRequestBuilder:
     """Prepare request arguments for the configured LLM backend."""
 
     def __init__(self, settings: "LLMSettings", message_format: str) -> None:
+        """Bind the request builder to explicit LLM settings and message format."""
         from ..settings import LLMSettings  # local import to avoid cycles
 
         if not isinstance(settings, LLMSettings):  # pragma: no cover - defensive
@@ -43,7 +43,6 @@ class LLMRequestBuilder:
     # ------------------------------------------------------------------
     def resolve_temperature(self) -> float | None:
         """Return the user-configured temperature or ``None`` when unset."""
-
         if getattr(self.settings, "use_custom_temperature", False):
             value = getattr(self.settings, "temperature", None)
             if value is None:
@@ -63,7 +62,6 @@ class LLMRequestBuilder:
         temperature: float | None = None,
     ) -> PreparedChatRequest:
         """Return normalized messages and arguments for the chat endpoint."""
-
         messages = self._prepare_messages(conversation or [])
         snapshot = self._snapshot_messages(messages)
         request_args = self._build_request_args(
@@ -84,12 +82,12 @@ class LLMRequestBuilder:
         **kwargs: Any,
     ) -> dict[str, Any]:
         """Expose low-level payload builder for health checks and tests."""
-
         return self._build_request_args(messages, **kwargs)
 
     def build_harmony_prompt(
         self, conversation: Sequence[Mapping[str, Any]]
     ) -> HarmonyPrompt:
+        """Render a Harmony prompt describing the provided conversation history."""
         system_parts, ordered_messages, _ = self._prepare_history_components(
             conversation
         )

--- a/app/llm/request_builder.py
+++ b/app/llm/request_builder.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import json
 from dataclasses import dataclass
 from datetime import date
-from typing import Any, Mapping, Sequence
+from typing import TYPE_CHECKING, Any, Mapping, Sequence
 
 from ..telemetry import log_event
 from .constants import DEFAULT_MAX_CONTEXT_TOKENS, MIN_MAX_CONTEXT_TOKENS
@@ -15,6 +15,9 @@ from .spec import SYSTEM_PROMPT, TOOLS
 from .tokenizer import count_text_tokens
 from .types import HistoryTrimResult, LLMReasoningSegment
 from .utils import extract_mapping
+
+if TYPE_CHECKING:  # pragma: no cover - import for type checking only
+    from ..settings import LLMSettings
 
 __all__ = ["LLMRequestBuilder", "PreparedChatRequest"]
 
@@ -31,7 +34,7 @@ class PreparedChatRequest:
 class LLMRequestBuilder:
     """Prepare request arguments for the configured LLM backend."""
 
-    def __init__(self, settings: "LLMSettings", message_format: str) -> None:
+    def __init__(self, settings: LLMSettings, message_format: str) -> None:
         """Bind the request builder to explicit LLM settings and message format."""
         from ..settings import LLMSettings  # local import to avoid cycles
 

--- a/app/llm/response_parser.py
+++ b/app/llm/response_parser.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import json
 import re
 from dataclasses import asdict, dataclass, is_dataclass
-from typing import Any, Iterable, Mapping, Sequence
+from typing import TYPE_CHECKING, Any, Iterable, Mapping, Sequence
 
 from ..telemetry import log_debug_payload, log_event
 from ..util.cancellation import CancellationEvent, OperationCancelledError
@@ -19,6 +19,9 @@ from .reasoning import (
 from .types import LLMReasoningSegment, LLMToolCall
 from .utils import extract_mapping
 from .validation import ToolValidationError
+
+if TYPE_CHECKING:  # pragma: no cover - import for type checking only
+    from ..settings import LLMSettings
 
 __all__ = [
     "LLMResponseParser",
@@ -179,7 +182,7 @@ def normalise_tool_calls(tool_calls: Any) -> list[dict[str, Any]]:
 class LLMResponseParser:
     """Convert raw LLM payloads into internal response structures."""
 
-    def __init__(self, settings: "LLMSettings", message_format: str) -> None:
+    def __init__(self, settings: LLMSettings, message_format: str) -> None:
         """Capture parser configuration shared across conversion helpers."""
         from ..settings import LLMSettings  # local import to avoid cycles
 

--- a/app/llm/response_parser.py
+++ b/app/llm/response_parser.py
@@ -1,5 +1,4 @@
 """Utilities for parsing LLM responses."""
-
 from __future__ import annotations
 
 import json
@@ -40,7 +39,6 @@ class _ToolArgumentRecovery:
 
 def _extract_tool_argument_mapping(arguments: Any) -> Mapping[str, Any] | None:
     """Return a mapping for tool arguments without relying on ``__dict__``."""
-
     if isinstance(arguments, Mapping):
         return arguments
     for attr in ("model_dump", "dict"):
@@ -67,7 +65,6 @@ def _extract_tool_argument_mapping(arguments: Any) -> Mapping[str, Any] | None:
 
 def _stringify_tool_arguments(arguments: Any) -> str:
     """Coerce tool arguments into a JSON text payload without dropping data."""
-
     if isinstance(arguments, str):
         return arguments or "{}"
     if isinstance(arguments, bytes):
@@ -131,7 +128,6 @@ def _stringify_tool_arguments(arguments: Any) -> str:
 
 def normalise_tool_calls(tool_calls: Any) -> list[dict[str, Any]]:
     """Normalize tool call payloads into the OpenAI function schema."""
-
     if not tool_calls:
         return []
     if isinstance(tool_calls, Mapping):  # pragma: no cover - defensive
@@ -184,6 +180,7 @@ class LLMResponseParser:
     """Convert raw LLM payloads into internal response structures."""
 
     def __init__(self, settings: "LLMSettings", message_format: str) -> None:
+        """Capture parser configuration shared across conversion helpers."""
         from ..settings import LLMSettings  # local import to avoid cycles
 
         if not isinstance(settings, LLMSettings):  # pragma: no cover - defensive
@@ -193,6 +190,7 @@ class LLMResponseParser:
 
     # ------------------------------------------------------------------
     def format_invalid_completion_error(self, prefix: str, completion: Any) -> str:
+        """Return a user-facing error message summarizing a malformed completion."""
         summary = self._summarize_completion_payload(completion)
         hint = (
             "Verify that the configured base URL "
@@ -214,6 +212,7 @@ class LLMResponseParser:
         return message
 
     def _summarize_completion_payload(self, completion: Any) -> str:
+        """Build a concise diagnostic summary for unexpected completion payloads."""
         def _clip(text: str, limit: int = 120) -> str:
             snippet = str(text).strip()
             if len(snippet) <= limit:
@@ -268,6 +267,7 @@ class LLMResponseParser:
         *,
         cancellation: CancellationEvent | None,
     ) -> tuple[str, list[dict[str, Any]], list[dict[str, str]]]:
+        """Consume streamed chat chunks into text, tool calls, and reasoning entries."""
         message_parts: list[str] = []
         tool_chunks: dict[tuple[int, object], dict[str, Any]] = {}
         order: list[tuple[int, object]] = []
@@ -418,6 +418,7 @@ class LLMResponseParser:
         self,
         completion: Any,
     ) -> tuple[str, list[dict[str, Any]], list[dict[str, str]]]:
+        """Extract assistant text, tool payloads, and reasoning notes from a response."""
         choices = getattr(completion, "choices", None)
         if not choices:
             raise ToolValidationError(
@@ -468,6 +469,7 @@ class LLMResponseParser:
         reasoning_accumulator: list[dict[str, str]] | None = None,
         tool_payload_sink: list[Any] | None = None,
     ) -> str:
+        """Unpack a message payload while capturing reasoning and tool metadata."""
         if isinstance(message, str):
             return message
         message_map = extract_mapping(message)
@@ -533,6 +535,7 @@ class LLMResponseParser:
         reasoning_accumulator: list[dict[str, str]] | None,
         tool_payload_sink: list[Any] | None,
     ) -> str:
+        """Flatten mixed content items into text while recording reasoning fragments."""
         if not content:
             return ""
         if isinstance(content, str):
@@ -611,6 +614,7 @@ class LLMResponseParser:
         *,
         reasoning_accumulator: list[dict[str, str]] | None,
     ) -> str:
+        """Remove ``<think>`` blocks and convert them into reasoning fragments."""
         if not text:
             return text
         lowered = text.lower()
@@ -676,6 +680,7 @@ class LLMResponseParser:
     def parse_harmony_output(
         self, completion: Any
     ) -> tuple[str, list[dict[str, Any]]]:
+        """Convert Harmony-style completions into assistant text and tool calls."""
         output = getattr(completion, "output", None)
         if output is None:
             completion_map = extract_mapping(completion)
@@ -735,6 +740,7 @@ class LLMResponseParser:
 
     # ------------------------------------------------------------------
     def parse_tool_calls(self, tool_calls: Any) -> tuple[LLMToolCall, ...]:
+        """Normalise arbitrary tool call payloads into :class:`LLMToolCall` objects."""
         if not tool_calls:
             return ()
 
@@ -821,6 +827,7 @@ class LLMResponseParser:
         call_id: str,
         tool_name: str,
     ) -> Mapping[str, Any]:
+        """Coerce a tool call payload into a JSON-safe mapping."""
         mapping_candidate = None
         if isinstance(payload, Mapping):
             mapping_candidate = payload
@@ -868,6 +875,7 @@ class LLMResponseParser:
 
     # ------------------------------------------------------------------
     def _extract_reasoning_tool_calls(self, payload: Any) -> list[dict[str, Any]]:
+        """Collect tool call structures embedded within reasoning fragments."""
         entries = extract_reasoning_entries(payload)
         fragments: dict[str, dict[str, Any]] = {}
         order: list[str] = []
@@ -940,6 +948,7 @@ class LLMResponseParser:
         aggregated: list[dict[str, Any]],
         fragments: Sequence[ReasoningFragment],
     ) -> None:
+        """Append normalized reasoning fragments to the accumulator."""
         for fragment in fragments:
             text = fragment.text
             if not text:
@@ -955,6 +964,7 @@ class LLMResponseParser:
     def finalize_reasoning_segments(
         self, segments: Sequence[Mapping[str, Any]]
     ) -> tuple[LLMReasoningSegment, ...]:
+        """Merge, deduplicate, and normalize reasoning fragments for storage."""
         finalized: list[LLMReasoningSegment] = []
         seen: set[tuple[str, str, str, str]] = set()
 
@@ -997,6 +1007,7 @@ class LLMResponseParser:
         choice_index: int,
         tool_index: int | None = None,
     ) -> None:
+        """Merge streaming tool call fragments into an ordered accumulator."""
         call_map = extract_mapping(tool_call)
         call_id = getattr(tool_call, "id", None)
         if call_map is not None and call_id is None:
@@ -1065,6 +1076,7 @@ class LLMResponseParser:
         *,
         choice_index: int,
     ) -> None:
+        """Accumulate streaming ``function_call`` deltas into the tool buffer."""
         func_map = extract_mapping(function_call)
         call_id = None
         if func_map is not None:
@@ -1111,6 +1123,7 @@ class LLMResponseParser:
         call_id: str,
         tool_name: str,
     ) -> Any:
+        """Decode JSON arguments and trigger recovery when parsing fails."""
         text = arguments_text or "{}"
         try:
             return json.loads(text)
@@ -1136,6 +1149,7 @@ class LLMResponseParser:
             ) from exc
 
     def _recover_tool_arguments(self, arguments_text: str) -> _ToolArgumentRecovery | None:
+        """Attempt to salvage structured arguments from concatenated JSON fragments."""
         stripped = (arguments_text or "").strip()
         if not stripped:
             return None
@@ -1195,6 +1209,7 @@ class LLMResponseParser:
         tool_name: str,
         error: json.JSONDecodeError,
     ) -> None:
+        """Log telemetry when tool arguments cannot be parsed or repaired."""
         text = arguments_text or ""
         preview, stripped = self._arguments_preview(text)
         classification: str | None = None
@@ -1232,6 +1247,7 @@ class LLMResponseParser:
         error: json.JSONDecodeError,
         recovery: _ToolArgumentRecovery,
     ) -> None:
+        """Log telemetry describing recovered tool argument fragments."""
         text = arguments_text or ""
         preview, _ = self._arguments_preview(text)
         error_info = {
@@ -1272,6 +1288,7 @@ class LLMResponseParser:
     def _arguments_preview(
         arguments_text: str, *, limit: int = 200
     ) -> tuple[str, str]:
+        """Return a short preview and stripped form of a tool argument string."""
         text = arguments_text or ""
         stripped = text.strip()
         preview = (

--- a/app/llm/spec.py
+++ b/app/llm/spec.py
@@ -9,7 +9,7 @@ testing and keeps the LLM contract consistent across components.
 from __future__ import annotations
 
 from textwrap import dedent
-from typing import Any, Mapping
+from typing import Any
 
 from ..core.model import Priority, RequirementType, Status, Verification
 from ..services.user_documents import (

--- a/app/llm/tokenizer.py
+++ b/app/llm/tokenizer.py
@@ -33,7 +33,6 @@ class TokenCountResult:
         reason: str | None = None,
     ) -> TokenCountResult:
         """Return a successful, precise token count."""
-
         return cls(tokens=max(tokens, 0), approximate=False, model=model, reason=reason)
 
     @classmethod
@@ -45,7 +44,6 @@ class TokenCountResult:
         reason: str | None = None,
     ) -> TokenCountResult:
         """Return an approximate token count."""
-
         return cls(tokens=max(tokens, 0), approximate=True, model=model, reason=reason)
 
     @classmethod
@@ -56,12 +54,10 @@ class TokenCountResult:
         reason: str | None = None,
     ) -> TokenCountResult:
         """Return a result indicating that tokenisation failed."""
-
         return cls(tokens=None, approximate=False, model=model, reason=reason)
 
     def to_dict(self) -> dict[str, object]:
         """Serialise the result for JSON storage."""
-
         payload: dict[str, object] = {}
         if self.tokens is not None:
             payload["tokens"] = int(self.tokens)
@@ -75,7 +71,6 @@ class TokenCountResult:
     @classmethod
     def from_dict(cls, payload: Mapping[str, object]) -> TokenCountResult:
         """Create :class:`TokenCountResult` from a mapping."""
-
         tokens_value = payload.get("tokens")
         tokens: int | None
         if isinstance(tokens_value, bool):
@@ -104,7 +99,6 @@ _TIKTOKEN_CACHE: object | None = None
 
 def _load_tiktoken() -> object | None:
     """Return the cached :mod:`tiktoken` module when available."""
-
     global _TIKTOKEN_CACHE
     if _TIKTOKEN_CACHE is not None:
         return None if _TIKTOKEN_CACHE is False else _TIKTOKEN_CACHE
@@ -123,7 +117,6 @@ def _load_tiktoken() -> object | None:
 
 def _whitespace_count(text: str) -> int:
     """Return a rough token estimate by splitting on whitespace."""
-
     stripped = text.strip()
     if not stripped:
         return 0
@@ -137,7 +130,6 @@ def count_text_tokens(text: object, *, model: str | None = None) -> TokenCountRe
     specific encoding.  Unknown models fall back to ``cl100k_base``.  If neither
     strategy works, a simple whitespace-based approximation is returned.
     """
-
     try:
         text_value = "" if text is None else str(text)
     except Exception as exc:  # pragma: no cover - defensive
@@ -190,7 +182,6 @@ def count_text_tokens(text: object, *, model: str | None = None) -> TokenCountRe
 
 def combine_token_counts(results: Iterable[TokenCountResult | None]) -> TokenCountResult:
     """Aggregate multiple token counts into a single result."""
-
     total = 0
     have_value = False
     approximate = False

--- a/app/llm/types.py
+++ b/app/llm/types.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass
-from typing import Any, Mapping
+from typing import Any
 
 __all__ = [
     "LLMToolCall",

--- a/app/llm/types.py
+++ b/app/llm/types.py
@@ -35,12 +35,10 @@ class LLMReasoningSegment:
     @property
     def text_with_whitespace(self) -> str:
         """Return ``text`` including preserved edge whitespace."""
-
         return f"{self.leading_whitespace}{self.text}{self.trailing_whitespace}"
 
     def preview(self, limit: int = 160) -> str:
         """Return a truncated representation retaining edge whitespace."""
-
         if limit <= 0:
             return ""
         return self.text_with_whitespace[:limit]

--- a/app/llm/utils.py
+++ b/app/llm/utils.py
@@ -11,7 +11,6 @@ __all__ = ["extract_mapping"]
 
 def extract_mapping(obj: Any) -> Mapping[str, Any] | None:
     """Return a mapping representation of *obj* when possible."""
-
     if isinstance(obj, Mapping):
         return obj
     for attr in ("model_dump", "dict"):

--- a/app/llm/utils.py
+++ b/app/llm/utils.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import asdict, is_dataclass
-from typing import Any, Mapping
+from typing import Any
 
 __all__ = ["extract_mapping"]
 

--- a/app/llm/validation.py
+++ b/app/llm/validation.py
@@ -7,5 +7,3 @@ __all__ = ["ToolValidationError"]
 
 class ToolValidationError(ValueError):
     """Raised when the agent cannot interpret an LLM tool invocation."""
-
-    pass

--- a/app/locale/en/LC_MESSAGES/CookaReq.po
+++ b/app/locale/en/LC_MESSAGES/CookaReq.po
@@ -2256,6 +2256,15 @@ msgstr "Загрузка…"
 msgid "Documentation disabled"
 msgstr "Documentation disabled"
 
+msgid " — default read limit: {limit} KiB"
+msgstr " — default read limit: {limit} KiB"
+
+msgid "Browse…"
+msgstr "Browse…"
+
+msgid "Default from MCP settings: {path}"
+msgstr "Default from MCP settings: {path}"
+
 msgid "Base path is required for relative folders"
 msgstr "Base path is required for relative folders"
 
@@ -2267,3 +2276,36 @@ msgstr "{path} (missing)"
 
 msgid "Select documentation folder"
 msgstr "Select documentation folder"
+
+msgid "Documentation directory visible to MCP tools. Example: share\nRelative paths are resolved from the active requirements folder.\nLeave empty to disable documentation access."
+msgstr "Documentation directory visible to MCP tools. Example: share\nRelative paths are resolved from the active requirements folder.\nLeave empty to disable documentation access."
+
+msgid "Documentation folder"
+msgstr "Documentation folder"
+
+msgid "Documentation folder (optional). Relative paths resolve against the current requirements directory when one is open."
+msgstr "Documentation folder (optional). Relative paths resolve against the current requirements directory when one is open."
+
+msgid "Documentation folder access disabled."
+msgstr "Documentation folder access disabled."
+
+msgid "Documentation folder pending: {path} (open a requirements folder)"
+msgstr "Documentation folder pending: {path} (open a requirements folder)"
+
+msgid "Documentation folder: {path}"
+msgstr "Documentation folder: {path}"
+
+msgid "Documentation root: {path}"
+msgstr "Documentation root: {path}"
+
+msgid "Documentation root: {path} (missing)"
+msgstr "Documentation root: {path} (missing)"
+
+msgid "Maximum amount of documentation text (in KiB) streamed by `read_user_document` when the model omits `max_bytes`. Increase only when necessary; higher limits mean longer MCP responses and more context usage."
+msgstr "Maximum amount of documentation text (in KiB) streamed by `read_user_document` when the model omits `max_bytes`. Increase only when necessary; higher limits mean longer MCP responses and more context usage."
+
+msgid "Project override: {path}"
+msgstr "Project override: {path}"
+
+msgid "Read chunk limit (KiB)"
+msgstr "Read chunk limit (KiB)"

--- a/app/locale/ru/LC_MESSAGES/CookaReq.po
+++ b/app/locale/ru/LC_MESSAGES/CookaReq.po
@@ -2272,6 +2272,15 @@ msgstr "Загрузка…"
 msgid "Documentation disabled"
 msgstr "Документация отключена"
 
+msgid " — default read limit: {limit} KiB"
+msgstr " — лимит чтения по умолчанию: {limit} КиБ"
+
+msgid "Browse…"
+msgstr "Обзор…"
+
+msgid "Default from MCP settings: {path}"
+msgstr "Значение из настроек MCP: {path}"
+
 msgid "Base path is required for relative folders"
 msgstr "Для относительных путей нужна папка требований"
 
@@ -2283,3 +2292,36 @@ msgstr "{path} (не существует)"
 
 msgid "Select documentation folder"
 msgstr "Выберите папку документации"
+
+msgid "Documentation directory visible to MCP tools. Example: share\nRelative paths are resolved from the active requirements folder.\nLeave empty to disable documentation access."
+msgstr "Каталог документации, доступный инструментам MCP. Пример: share\nОтносительные пути вычисляются от активной папки требований.\nОставьте пустым, чтобы отключить доступ к документации."
+
+msgid "Documentation folder"
+msgstr "Папка документации"
+
+msgid "Documentation folder (optional). Relative paths resolve against the current requirements directory when one is open."
+msgstr "Папка документации (необязательно). Относительные пути вычисляются относительно текущего каталога требований, если он открыт."
+
+msgid "Documentation folder access disabled."
+msgstr "Доступ к папке документации отключён."
+
+msgid "Documentation folder pending: {path} (open a requirements folder)"
+msgstr "Папка документации ожидает: {path} (откройте каталог требований)"
+
+msgid "Documentation folder: {path}"
+msgstr "Папка документации: {path}"
+
+msgid "Documentation root: {path}"
+msgstr "Корневая папка документации: {path}"
+
+msgid "Documentation root: {path} (missing)"
+msgstr "Корневая папка документации: {path} (нет)"
+
+msgid "Maximum amount of documentation text (in KiB) streamed by `read_user_document` when the model omits `max_bytes`. Increase only when necessary; higher limits mean longer MCP responses and more context usage."
+msgstr "Максимальный объём текста документации (в КиБ), который `read_user_document` передаёт, если модель не указывает `max_bytes`. Увеличивайте только при необходимости: больший лимит означает более долгие ответы MCP и больший расход контекста."
+
+msgid "Project override: {path}"
+msgstr "Переопределение проекта: {path}"
+
+msgid "Read chunk limit (KiB)"
+msgstr "Лимит чтения блока (КиБ)"

--- a/app/log.py
+++ b/app/log.py
@@ -31,9 +31,11 @@ class ConsoleFormatter(logging.Formatter):
     """Console formatter that surfaces structured payloads when available."""
 
     def __init__(self) -> None:
+        """Set up the formatter with the standard console template."""
         super().__init__("%(levelname)s: %(message)s")
 
     def format(self, record: logging.LogRecord) -> str:
+        """Render *record* optionally appending the structured payload."""
         base = super().format(record)
         payload = _extract_console_payload(record)
         if payload is None:

--- a/app/log.py
+++ b/app/log.py
@@ -51,7 +51,6 @@ class ConsoleFormatter(logging.Formatter):
 
 def _extract_console_payload(record: logging.LogRecord) -> Any | None:
     """Return payload that should be appended to console output."""
-
     extra_json = getattr(record, "json", None)
     if not isinstance(extra_json, dict):
         return None
@@ -70,7 +69,6 @@ def _rotate_if_already_full(
     handler: RotatingFileHandler, existing_size: int
 ) -> None:
     """Rotate *handler* if the pre-existing log already reaches the limit."""
-
     max_bytes = getattr(handler, "maxBytes", 0) or 0
     if max_bytes <= 0 or existing_size < max_bytes:
         return
@@ -140,6 +138,7 @@ class JsonlHandler(RotatingFileHandler):
         encoding: str = "utf-8",
         delay: bool = False,
     ) -> None:
+        """Initialise handler ensuring the log directory exists."""
         path = Path(filename)
         path.parent.mkdir(parents=True, exist_ok=True)
         if max_bytes is None:
@@ -156,14 +155,12 @@ class JsonlHandler(RotatingFileHandler):
 
 def _default_log_dir() -> Path:
     """Return default directory for application logs."""
-
     base = Path.home() / _DEFAULT_HOME_DIR
     return base / _DEFAULT_LOG_SUBDIR
 
 
 def _resolve_log_dir(log_dir: str | Path | None) -> Path:
     """Resolve effective log directory creating it if necessary."""
-
     if log_dir is not None:
         path = Path(log_dir).expanduser()
     else:
@@ -175,7 +172,6 @@ def _resolve_log_dir(log_dir: str | Path | None) -> Path:
 
 def configure_logging(level: int = logging.INFO, *, log_dir: str | Path | None = None) -> None:
     """Configure application logger once."""
-
     global _log_dir
 
     if logger.handlers:
@@ -222,7 +218,6 @@ def configure_logging(level: int = logging.INFO, *, log_dir: str | Path | None =
 
 def get_log_directory() -> Path:
     """Return directory where CookaReq writes log files."""
-
     if _log_dir is None:
         configure_logging()
     assert _log_dir is not None
@@ -231,7 +226,6 @@ def get_log_directory() -> Path:
 
 def get_log_file_paths() -> tuple[Path, Path]:
     """Return paths to text and JSONL log files, configuring logging if needed."""
-
     if _log_dir is None:
         configure_logging()
     assert _log_dir is not None
@@ -240,7 +234,6 @@ def get_log_file_paths() -> tuple[Path, Path]:
 
 def open_log_directory() -> bool:
     """Open the log directory in the system file browser."""
-
     directory = get_log_directory()
     try:  # pragma: no cover - platform-dependent side effect
         if sys.platform.startswith("win"):

--- a/app/mcp/client.py
+++ b/app/mcp/client.py
@@ -1,5 +1,4 @@
 """HTTP client for interacting with the MCP server."""
-
 from __future__ import annotations
 
 import logging
@@ -82,7 +81,6 @@ class MCPClient:
         self, name: str, arguments: Mapping[str, Any]
     ) -> bool:
         """Return ``True`` when the write operation should proceed."""
-
         prompt: RequirementUpdatePrompt | None = None
         confirm_payload: dict[str, Any] = {"tool": name}
         if name in self._UPDATE_TOOLS:
@@ -125,7 +123,6 @@ class MCPClient:
         result: Mapping[str, Any] | None,
     ) -> None:
         """Notify listeners about successful requirement-changing tools."""
-
         if name not in self._BROADCAST_TOOLS:
             return
         if result is None or not isinstance(result, Mapping):
@@ -144,7 +141,6 @@ class MCPClient:
         self, name: str, arguments: Mapping[str, Any]
     ) -> Any:
         """Return tool arguments without performing local validation."""
-
         if arguments is None:
             return {}
         if isinstance(arguments, Mapping):
@@ -171,7 +167,6 @@ class MCPClient:
         name: str, arguments: Mapping[str, Any]
     ) -> RequirementUpdatePrompt:
         """Create :class:`RequirementUpdatePrompt` from MCP tool *arguments*."""
-
         directory = arguments.get("directory")
         rid = arguments.get("rid")
         return RequirementUpdatePrompt(
@@ -186,7 +181,6 @@ class MCPClient:
         name: str, arguments: Mapping[str, Any]
     ) -> tuple[RequirementChange, ...]:
         """Return canonical representation of planned updates for prompts."""
-
         if name == "update_requirement_field":
             field = arguments.get("field")
             return (
@@ -215,7 +209,6 @@ class MCPClient:
     # ------------------------------------------------------------------
     def _build_base_url(self) -> str:
         """Return base URL for requests, wrapping IPv6 literals if required."""
-
         host = self.settings.host
         if ":" in host and not host.startswith("["):
             host = f"[{host}]"
@@ -223,7 +216,6 @@ class MCPClient:
 
     def _headers(self, *, json_body: bool = False) -> dict[str, str]:
         """Return default headers for requests."""
-
         headers: dict[str, str] = {}
         if json_body:
             headers["Content-Type"] = "application/json"
@@ -240,7 +232,6 @@ class MCPClient:
         json_body: Any | None = None,
     ) -> httpx.Response:
         """Execute *method* request synchronously and return the response."""
-
         request_headers = dict(headers or {})
         with httpx.Client(base_url=self._base_url, timeout=self._REQUEST_TIMEOUT) as client:
             return client.request(method, path, json=json_body, headers=request_headers)
@@ -254,7 +245,6 @@ class MCPClient:
         json_body: Any | None = None,
     ) -> httpx.Response:
         """Execute *method* request asynchronously and return the response."""
-
         request_headers = dict(headers or {})
         async with httpx.AsyncClient(
             base_url=self._base_url, timeout=self._REQUEST_TIMEOUT
@@ -272,7 +262,6 @@ class MCPClient:
             ``error`` contains the structured MCP error payload when
             ``ok`` is ``False`` and is ``None`` otherwise.
         """
-
         params = {
             "host": self.settings.host,
             "port": self.settings.port,
@@ -344,7 +333,6 @@ class MCPClient:
     # ------------------------------------------------------------------
     async def check_tools_async(self) -> dict[str, Any]:
         """Asynchronous counterpart to :meth:`check_tools`."""
-
         request_body = {"name": "list_requirements", "arguments": {"per_page": 1}}
         headers = self._headers(json_body=True)
         params = {
@@ -425,7 +413,6 @@ class MCPClient:
             structure as :meth:`check_tools`.  When ``ok`` is ``True`` the
             optional ``result`` key contains the payload returned by the server.
         """
-
         prepared_arguments = self._prepare_tool_arguments(name, arguments)
 
         if name == "delete_requirement" or name in self._UPDATE_TOOLS:
@@ -505,7 +492,6 @@ class MCPClient:
         self, name: str, arguments: Mapping[str, Any]
     ) -> dict[str, Any]:
         """Asynchronous counterpart to :meth:`call_tool`."""
-
         prepared_arguments = self._prepare_tool_arguments(name, arguments)
 
         if name == "delete_requirement" or name in self._UPDATE_TOOLS:
@@ -584,7 +570,6 @@ class MCPClient:
     # ------------------------------------------------------------------
     def ensure_ready(self, *, force: bool = False) -> None:
         """Raise :class:`MCPNotReadyError` if the MCP server is unavailable."""
-
         if (
             not force
             and self._last_ready_ok
@@ -687,7 +672,6 @@ class MCPClient:
     # ------------------------------------------------------------------
     async def ensure_ready_async(self, *, force: bool = False) -> None:
         """Asynchronous counterpart to :meth:`ensure_ready`."""
-
         if (
             not force
             and self._last_ready_ok
@@ -792,7 +776,6 @@ class MCPClient:
         self, ok: bool, error: Mapping[str, Any] | None
     ) -> None:
         """Remember the outcome of the most recent readiness probe."""
-
         self._last_ready_check = time.monotonic()
         self._last_ready_ok = ok
         self._last_ready_error = dict(error) if isinstance(error, Mapping) else None
@@ -804,7 +787,6 @@ class MCPClient:
         details: Mapping[str, Any] | None = None,
     ) -> dict[str, Any]:
         """Return MCP-formatted health check error payload."""
-
         payload = mcp_error(ErrorCode.INTERNAL, message, details)["error"]
         return payload
 

--- a/app/mcp/controller.py
+++ b/app/mcp/controller.py
@@ -41,7 +41,6 @@ class MCPController:
         token_model: str | None,
     ) -> None:
         """Launch the MCP server with ``settings``."""
-
         token = settings.token if settings.require_token else ""
         start_server(
             settings.host,
@@ -68,12 +67,10 @@ class MCPController:
 
     def is_running(self) -> bool:
         """Return ``True`` if MCP server is currently running."""
-
         return server_is_running()
 
     def check(self, settings: MCPSettings) -> MCPCheckResult:
         """Probe the MCP server health endpoint."""
-
         headers = {}
         if settings.require_token and settings.token:
             headers["Authorization"] = f"Bearer {settings.token}"

--- a/app/mcp/events.py
+++ b/app/mcp/events.py
@@ -1,5 +1,4 @@
 """Notification helpers for MCP tool results."""
-
 from __future__ import annotations
 
 import logging
@@ -32,7 +31,6 @@ class _ToolResultBus:
 
     def add_listener(self, listener: _Listener) -> Callable[[], None]:
         """Register *listener* and return a callable removing it."""
-
         with self._lock:
             self._listeners.add(listener)
 
@@ -43,13 +41,11 @@ class _ToolResultBus:
 
     def remove_listener(self, listener: _Listener) -> None:
         """Unregister *listener* ignoring unknown references."""
-
         with self._lock:
             self._listeners.discard(listener)
 
     def emit(self, event: ToolResultEvent) -> None:
         """Send *event* to all registered listeners."""
-
         with self._lock:
             listeners = tuple(self._listeners)
         for listener in listeners:
@@ -64,13 +60,11 @@ _bus = _ToolResultBus()
 
 def add_tool_result_listener(listener: _Listener) -> Callable[[], None]:
     """Register *listener* to receive :class:`ToolResultEvent` objects."""
-
     return _bus.add_listener(listener)
 
 
 def remove_tool_result_listener(listener: _Listener) -> None:
     """Unregister *listener* from receiving tool result events."""
-
     _bus.remove_listener(listener)
 
 
@@ -82,7 +76,6 @@ def notify_tool_success(
     result: Mapping[str, Any] | None,
 ) -> None:
     """Broadcast a successful tool invocation to registered listeners."""
-
     if not tool_name:
         return
 
@@ -113,7 +106,6 @@ def notify_tool_success_many(
     payloads: Sequence[Mapping[str, Any]],
 ) -> None:
     """Broadcast pre-built payloads to registered listeners."""
-
     if not payloads:
         return
     event = ToolResultEvent(

--- a/app/mcp/paths.py
+++ b/app/mcp/paths.py
@@ -1,5 +1,4 @@
 """Utilities for deriving MCP filesystem locations."""
-
 from __future__ import annotations
 
 import logging
@@ -22,13 +21,9 @@ class DocumentsRootDescription:
 
 def normalize_documents_path(value: str | Path | None) -> str:
     """Return ``value`` as a trimmed string suitable for persistence."""
-
     if value is None:
         return ""
-    if isinstance(value, Path):
-        text = str(value)
-    else:
-        text = str(value)
+    text = str(value)
     return text.strip()
 
 
@@ -37,7 +32,6 @@ def describe_documents_root(
     documents_path: str | Path | None,
 ) -> DocumentsRootDescription:
     """Return a structured description of the documentation directory."""
-
     text = normalize_documents_path(documents_path)
     if not text:
         return DocumentsRootDescription(status="disabled")
@@ -80,7 +74,6 @@ def resolve_documents_root(
     documents_path: str | Path | None,
 ) -> Path | None:
     """Resolve the documentation directory combining base and document paths."""
-
     description = describe_documents_root(base_path, documents_path)
     if description.status != "resolved":
         return None

--- a/app/mcp/server.py
+++ b/app/mcp/server.py
@@ -5,7 +5,6 @@ Context Protocol (MCP) server. The server is started with `start_server`
 which runs uvicorn in a background thread so that the wxPython GUI main
 loop remains responsive.
 """
-
 from __future__ import annotations
 
 import logging
@@ -170,7 +169,7 @@ async def auth_middleware(request: Request, call_next):
 
 @app.get("/health")
 async def health() -> dict[str, str]:
-    """Simple readiness probe used by external tools."""
+    """Report readiness information for external health probes."""
     return {"status": "ok"}
 
 
@@ -193,7 +192,6 @@ def register_tool(
     decorator returns the original function unchanged so regular unit testing
     remains straightforward.
     """
-
     def decorator(target: ToolCallable) -> ToolCallable:
         tool_name = name or target.__name__
         if tool_name in _TOOLS:
@@ -334,7 +332,6 @@ def _documents_service() -> UserDocumentsService | None:
 @register_tool()
 def list_user_documents() -> dict:
     """Return the structure of the configured user documentation directory."""
-
     service = _documents_service()
     return tools_documents.list_user_documents(service)
 
@@ -347,7 +344,6 @@ def read_user_document(
     max_bytes: int | None = None,
 ) -> dict:
     """Read a chunk from a user-provided document."""
-
     service = _documents_service()
     return tools_documents.read_user_document(
         service,
@@ -365,7 +361,6 @@ def create_user_document(
     exist_ok: bool = False,
 ) -> dict:
     """Create a user document relative to the configured root."""
-
     service = _documents_service()
     return tools_documents.create_user_document(
         service,
@@ -378,7 +373,6 @@ def create_user_document(
 @register_tool()
 def delete_user_document(path: str) -> dict:
     """Delete a user document relative to the configured root."""
-
     service = _documents_service()
     return tools_documents.delete_user_document(service, path)
 

--- a/app/mcp/tools_documents.py
+++ b/app/mcp/tools_documents.py
@@ -1,5 +1,4 @@
 """MCP tool helpers for user-provided documentation files."""
-
 from __future__ import annotations
 
 from typing import Any
@@ -30,6 +29,7 @@ def _normalize_max_bytes(service: UserDocumentsService, value: int | None) -> in
 
 
 def list_user_documents(service: UserDocumentsService | None) -> dict[str, Any]:
+    """Return a serialized tree of available user documents."""
     params: dict[str, Any] = {}
     if service is None:
         return _missing_root_error("list_user_documents", params)
@@ -52,6 +52,7 @@ def read_user_document(
     start_line: int = 1,
     max_bytes: int | None = None,
 ) -> dict[str, Any]:
+    """Read the requested document while enforcing configured limits."""
     params: dict[str, Any] = {"path": path, "start_line": start_line}
     if max_bytes is not None:
         params["max_bytes"] = max_bytes
@@ -94,6 +95,7 @@ def create_user_document(
     content: str = "",
     exist_ok: bool = False,
 ) -> dict[str, Any]:
+    """Persist a document under the configured root, optionally replacing it."""
     params: dict[str, Any] = {
         "path": path,
         "exist_ok": exist_ok,
@@ -132,6 +134,7 @@ def delete_user_document(
     service: UserDocumentsService | None,
     path: str,
 ) -> dict[str, Any]:
+    """Remove the specified document from the managed root."""
     params: dict[str, Any] = {"path": path}
     if service is None:
         return _missing_root_error("delete_user_document", params)

--- a/app/mcp/tools_read.py
+++ b/app/mcp/tools_read.py
@@ -1,3 +1,5 @@
+"""Read-oriented MCP tool implementations."""
+
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
@@ -24,7 +26,6 @@ def _normalize_rid_argument(
     rid: str | Sequence[str],
 ) -> tuple[list[str], str | list[str]]:
     """Return a deduplicated list of RIDs and a log-friendly representation."""
-
     if isinstance(rid, _SEQUENCE_STRING_TYPES):
         rid_value = str(rid).strip()
         if not rid_value:
@@ -59,7 +60,6 @@ def _prepare_field_selection(
     fields: Sequence[str] | None,
 ) -> tuple[list[str] | None, list[str] | None]:
     """Return normalized field names and a JSON-serialisable log copy."""
-
     if fields is None:
         return None, None
     if not isinstance(fields, Sequence) or isinstance(fields, _SEQUENCE_STRING_TYPES):
@@ -86,7 +86,6 @@ def _prepare_field_selection(
 
 def _apply_field_selection(data: Mapping[str, Any], fields: list[str] | None) -> dict:
     """Return ``data`` filtered by ``fields`` while preserving the RID."""
-
     rid = data.get("rid")
     if rid is None:
         raise KeyError("requirement payload missing rid")
@@ -158,6 +157,7 @@ def list_requirements(
     labels: Sequence[str] | None = None,
     fields: Sequence[str] | None = None,
 ) -> dict:
+    """Return a paginated requirements listing payload for MCP responses."""
     normalized_fields, logged_fields = _prepare_field_selection(fields)
     params = {
         "directory": str(directory),
@@ -197,6 +197,7 @@ def get_requirement(
     rid: str | Sequence[str],
     fields: Sequence[str] | None = None,
 ) -> dict:
+    """Return requirement details for one or more requirement identifiers."""
     normalized_fields, logged_fields = _prepare_field_selection(fields)
     params: dict[str, Any] = {
         "directory": str(directory),
@@ -285,6 +286,7 @@ def search_requirements(
     per_page: int = 50,
     fields: Sequence[str] | None = None,
 ) -> dict:
+    """Return search results from the MCP requirements store."""
     normalized_fields, logged_fields = _prepare_field_selection(fields)
     params = {
         "directory": str(directory),

--- a/app/mcp/tools_write.py
+++ b/app/mcp/tools_write.py
@@ -1,3 +1,5 @@
+"""Write-oriented MCP tool implementations."""
+
 from __future__ import annotations
 
 from pathlib import Path
@@ -53,7 +55,6 @@ def update_requirement_field(
     value: Any,
 ) -> dict:
     """Update a single field of a requirement."""
-
     params = {
         "directory": str(directory),
         "rid": rid,
@@ -118,7 +119,6 @@ def set_requirement_labels(
     labels: Sequence[str],
 ) -> dict:
     """Replace the label list of a requirement."""
-
     params = {
         "directory": str(directory),
         "rid": rid,
@@ -160,7 +160,6 @@ def set_requirement_attachments(
     attachments: Sequence[Mapping[str, Any]],
 ) -> dict:
     """Replace attachments of a requirement."""
-
     params = {
         "directory": str(directory),
         "rid": rid,
@@ -202,7 +201,6 @@ def set_requirement_links(
     links: Sequence[Mapping[str, Any] | str],
 ) -> dict:
     """Replace the outgoing links of a requirement."""
-
     params = {
         "directory": str(directory),
         "rid": rid,

--- a/app/mcp/utils.py
+++ b/app/mcp/utils.py
@@ -1,5 +1,4 @@
 """Shared helpers for MCP tools."""
-
 from __future__ import annotations
 
 from collections.abc import Iterator, Mapping
@@ -66,7 +65,6 @@ def log_tool(
         Maximum number of characters from the result to include in the log.
         ``None`` disables truncation.
     """
-
     entry = {
         "timestamp": utc_now_iso(),
         "tool": tool,
@@ -102,7 +100,6 @@ def mcp_error(
     details: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Return a structured error payload for MCP responses."""
-
     code_str = code.value if isinstance(code, ErrorCode) else str(code)
     err: dict[str, Any] = {"code": code_str, "message": message}
     if details:
@@ -112,7 +109,6 @@ def mcp_error(
 
 def _exception_chain(exc: BaseException) -> Iterator[BaseException]:
     """Yield *exc* and all linked exceptions from ``__cause__``/``__context__``."""
-
     seen: set[int] = set()
     queue: list[BaseException | None] = [exc]
     while queue:
@@ -136,7 +132,6 @@ def map_exception_to_error_code(exc: BaseException) -> ErrorCode:
     client, low-level HTTP stack or built-in connection exceptions are treated
     as :class:`ErrorCode.INTERNAL`, signalling that retrying later might help.
     """
-
     internal_failure = False
     for err in _exception_chain(exc):
         if isinstance(err, JSONDecodeError):
@@ -165,7 +160,6 @@ def map_exception_to_error_code(exc: BaseException) -> ErrorCode:
 
 def exception_to_mcp_error(exc: BaseException) -> dict[str, Any]:
     """Convert *exc* into an MCP-compatible error payload."""
-
     code = map_exception_to_error_code(exc)
     message = str(exc) or type(exc).__name__
     details: dict[str, Any] = {"type": type(exc).__name__}

--- a/app/services/user_documents.py
+++ b/app/services/user_documents.py
@@ -1,4 +1,4 @@
-"""Service helpers for managing user-provided documentation files."""
+"""Utilities for exposing curated views over user-provided documentation."""
 
 from __future__ import annotations
 
@@ -25,6 +25,7 @@ class UserDocumentEntry:
     children: list["UserDocumentEntry"] = field(default_factory=list)
 
     def to_dict(self) -> dict[str, object]:
+        """Serialise the entry and its children into primitive structures."""
         payload: dict[str, object] = {
             "name": self.name,
             "path": self.relative_path.as_posix(),
@@ -52,6 +53,7 @@ class UserDocumentsService:
         token_model: str | None = None,
         max_read_bytes: int = DEFAULT_MAX_READ_BYTES,
     ) -> None:
+        """Validate configuration and capture the resolved root path."""
         if max_context_tokens <= 0:
             raise ValueError("max_context_tokens must be positive")
         if max_read_bytes <= 0:
@@ -68,7 +70,6 @@ class UserDocumentsService:
     # ------------------------------------------------------------------
     def list_tree(self) -> dict[str, object]:
         """Return a structured description of the documentation directory."""
-
         if self.root.exists():
             entry = self._build_directory(self.root, Path("."))
         else:
@@ -99,7 +100,6 @@ class UserDocumentsService:
         max_bytes: int | None = None,
     ) -> dict[str, object]:
         """Return a chunk of the target file capped at ``max_bytes`` bytes."""
-
         file_path = self._ensure_file(relative_path)
         if start_line < 1:
             raise ValueError("start_line must be >= 1")
@@ -163,7 +163,6 @@ class UserDocumentsService:
         exist_ok: bool = False,
     ) -> Path:
         """Create a new file under the documents root with optional content."""
-
         target = self._resolve_path(relative_path)
         if target.exists():
             if target.is_dir():
@@ -180,7 +179,6 @@ class UserDocumentsService:
     # ------------------------------------------------------------------
     def delete_file(self, relative_path: str | Path) -> None:
         """Remove a file inside the documents root."""
-
         target = self._ensure_file(relative_path)
         target.unlink()
 

--- a/app/services/user_documents.py
+++ b/app/services/user_documents.py
@@ -22,7 +22,7 @@ class UserDocumentEntry:
     size_bytes: int | None = None
     token_count: TokenCountResult | None = None
     percent_of_context: float | None = None
-    children: list["UserDocumentEntry"] = field(default_factory=list)
+    children: list[UserDocumentEntry] = field(default_factory=list)
 
     def to_dict(self) -> dict[str, object]:
         """Serialise the entry and its children into primitive structures."""

--- a/app/settings.py
+++ b/app/settings.py
@@ -76,7 +76,6 @@ class LLMSettings(BaseModel):
     @classmethod
     def _normalize_max_context_tokens(cls, value: int | str | None) -> int:
         """Clamp misconfigured prompt context limits to supported ranges."""
-
         return cls._normalize_token_limit(
             value,
             default=DEFAULT_MAX_CONTEXT_TOKENS,
@@ -87,7 +86,6 @@ class LLMSettings(BaseModel):
     @classmethod
     def _normalize_temperature(cls, value: float | str | None) -> float:
         """Coerce *value* to the supported temperature range."""
-
         if value is None:
             return DEFAULT_LLM_TEMPERATURE
         if isinstance(value, str):
@@ -111,7 +109,6 @@ class LLMSettings(BaseModel):
 
 def default_requirements_path() -> str:
     """Return bundled requirements directory if present."""
-
     try:
         candidate = Path(__file__).resolve().parents[1] / "requirements"
     except OSError:  # pragma: no cover - very defensive
@@ -138,7 +135,6 @@ class MCPSettings(BaseModel):
     @classmethod
     def _normalize_log_dir(cls, value: str | Path | None) -> str | None:
         """Convert empty strings to ``None`` and normalise paths."""
-
         if value is None:
             return None
         text = str(value).strip()
@@ -150,7 +146,6 @@ class MCPSettings(BaseModel):
         cls, value: str | Path | None
     ) -> str:
         """Return a whitespace-normalised representation of ``value``."""
-
         if value is None:
             return ""
         text = str(value).strip()
@@ -162,7 +157,6 @@ class MCPSettings(BaseModel):
         cls, value: int | str | None
     ) -> int:
         """Coerce ``value`` into the supported documentation read window."""
-
         if value is None:
             return DEFAULT_DOCUMENT_MAX_READ_KB
         if isinstance(value, str):
@@ -201,7 +195,6 @@ class AgentSettings(BaseModel):
         cls, value: int | str | None
     ) -> int | None:
         """Coerce *value* into a positive limit or ``None`` for unlimited loops."""
-
         if value is None:
             return None
         if isinstance(value, str):
@@ -226,7 +219,6 @@ class AgentSettings(BaseModel):
         cls, value: int | str | None
     ) -> int | None:
         """Coerce *value* into a positive limit or ``None`` to disable the cap."""
-
         if value is None:
             return None
         if isinstance(value, str):
@@ -309,7 +301,6 @@ def load_app_settings(path: str | Path) -> AppSettings:
     everything else is treated as JSON.  Any validation errors are wrapped into
     :class:`ValueError` with a human-friendly message.
     """
-
     p = Path(path)
     with p.open("rb") as fh:
         data = tomllib.load(fh) if p.suffix.lower() == ".toml" else json.load(fh)

--- a/app/telemetry.py
+++ b/app/telemetry.py
@@ -26,7 +26,6 @@ REDACTED = "[REDACTED]"
 
 def _sanitize_value(value: Any) -> Any:
     """Recursively sanitize ``value``."""
-
     if isinstance(value, Mapping):
         return {
             k: (REDACTED if k.lower() in SENSITIVE_KEYS else _sanitize_value(v))
@@ -41,7 +40,6 @@ def _sanitize_value(value: Any) -> Any:
 
 def sanitize(data: Mapping[str, Any]) -> dict[str, Any]:
     """Return a deep copy of *data* with sensitive keys replaced by ``[REDACTED]``."""
-
     return _sanitize_value(dict(data))
 
 
@@ -67,7 +65,6 @@ def log_event(
     level:
         Logging level used for the emitted record. Defaults to ``logging.INFO``.
     """
-
     data: dict[str, Any] = {"event": event}
     if payload:
         sanitized = sanitize(dict(payload))
@@ -89,7 +86,6 @@ def log_debug_payload(
     payload: Mapping[str, Any] | Sequence[Any] | str | None = None,
 ) -> None:
     """Emit debug-level log entry with full payload details."""
-
     if not logger.isEnabledFor(logging.DEBUG):
         return
 

--- a/app/ui/agent_chat_panel/attachment_utils.py
+++ b/app/ui/agent_chat_panel/attachment_utils.py
@@ -1,5 +1,4 @@
 """Helpers for validating chat attachments."""
-
 from __future__ import annotations
 
 from typing import Iterable
@@ -15,7 +14,6 @@ def looks_like_plain_text(
     allowed_controls: Iterable[str] | None = None,
 ) -> bool:
     """Heuristically determine whether ``text`` represents plain UTF-8 content."""
-
     if not text:
         return True
 

--- a/app/ui/agent_chat_panel/batch_runner.py
+++ b/app/ui/agent_chat_panel/batch_runner.py
@@ -89,7 +89,6 @@ class AgentBatchRunner:
     @property
     def items(self) -> tuple[BatchItem, ...]:
         """Return immutable snapshot of queued items."""
-
         return tuple(self._items)
 
     # ------------------------------------------------------------------
@@ -110,7 +109,6 @@ class AgentBatchRunner:
     # ------------------------------------------------------------------
     def reset(self) -> None:
         """Clear the queue without notifying the controller."""
-
         self._items.clear()
         self._prompt = None
         self._active_index = None
@@ -121,7 +119,6 @@ class AgentBatchRunner:
     # ------------------------------------------------------------------
     def start(self, prompt: str, targets: Sequence[BatchTarget]) -> bool:
         """Initialise queue with *targets* and launch the first run."""
-
         normalized = prompt.strip()
         if not normalized:
             return False
@@ -142,7 +139,6 @@ class AgentBatchRunner:
     # ------------------------------------------------------------------
     def cancel_all(self) -> None:
         """Request cancellation of the active item and mark queue as cancelled."""
-
         if not self._items:
             return
 
@@ -156,7 +152,6 @@ class AgentBatchRunner:
     # ------------------------------------------------------------------
     def request_skip_current(self) -> None:
         """Request cancellation of current item while keeping queue running."""
-
         if not self._running:
             return
         self._cancel_mode = CancelMode.SKIP_CURRENT
@@ -170,7 +165,6 @@ class AgentBatchRunner:
         error: str | None,
     ) -> None:
         """Update queue state after controller finalises the prompt."""
-
         if not conversation_id:
             return
         item = self._item_by_conversation(conversation_id)
@@ -190,7 +184,6 @@ class AgentBatchRunner:
     # ------------------------------------------------------------------
     def handle_cancellation(self, *, conversation_id: str | None) -> None:
         """React to cancelled prompt and continue if needed."""
-
         if not conversation_id:
             return
         item = self._item_by_conversation(conversation_id)
@@ -211,7 +204,6 @@ class AgentBatchRunner:
     # ------------------------------------------------------------------
     def progress_counts(self) -> tuple[int, int]:
         """Return tuple ``(completed, total)`` ignoring skipped entries."""
-
         total = len(self._items)
         completed = sum(
             1

--- a/app/ui/agent_chat_panel/batch_ui.py
+++ b/app/ui/agent_chat_panel/batch_ui.py
@@ -1,7 +1,4 @@
 """User-interface helpers for managing batch agent runs."""
-
-from __future__ import annotations
-
 from __future__ import annotations
 
 from dataclasses import dataclass
@@ -48,6 +45,7 @@ class AgentBatchSection:
         runner: AgentBatchRunner | None = None,
         target_provider: Callable[[], Sequence[BatchTarget]] | None = None,
     ) -> None:
+        """Bind batch controls to the panel, creating a runner when needed."""
         self._panel = panel
         self._controls = controls
         self._target_provider = target_provider
@@ -67,10 +65,12 @@ class AgentBatchSection:
     # ------------------------------------------------------------------
     @property
     def runner(self) -> AgentBatchRunner:
+        """Expose the batch runner handling work execution."""
         return self._runner
 
     # ------------------------------------------------------------------
     def start_batch(self) -> None:
+        """Start processing the configured batch queue if idle."""
         if self._panel.is_running:
             return
         runner = self._runner
@@ -99,6 +99,7 @@ class AgentBatchSection:
 
     # ------------------------------------------------------------------
     def stop_batch(self) -> None:
+        """Cancel all pending work and stop any active agent run."""
         runner = self._runner
         if not runner.items:
             return
@@ -111,12 +112,12 @@ class AgentBatchSection:
 
     # ------------------------------------------------------------------
     def request_skip_current(self) -> None:
+        """Skip the currently running batch item if possible."""
         self._runner.request_skip_current()
 
     # ------------------------------------------------------------------
     def close_panel(self) -> None:
         """Reset the batch queue and hide the panel."""
-
         runner = self._runner
         if runner.is_running:
             dialog = wx.MessageDialog(
@@ -141,6 +142,7 @@ class AgentBatchSection:
         success: bool,
         error: str | None,
     ) -> None:
+        """Record completion state for ``conversation_id`` and refresh controls."""
         self._runner.handle_completion(
             conversation_id=conversation_id,
             success=success,
@@ -150,11 +152,13 @@ class AgentBatchSection:
 
     # ------------------------------------------------------------------
     def notify_cancellation(self, *, conversation_id: str) -> None:
+        """Record cancellation for ``conversation_id`` and refresh controls."""
         self._runner.handle_cancellation(conversation_id=conversation_id)
         self.update_ui()
 
     # ------------------------------------------------------------------
     def update_ui(self) -> None:
+        """Synchronize button state, status text, and progress indicators."""
         panel = self._controls.panel
         runner = self._runner
         status_label = self._controls.status_label

--- a/app/ui/agent_chat_panel/components/__init__.py
+++ b/app/ui/agent_chat_panel/components/__init__.py
@@ -1,0 +1,8 @@
+"""Reusable widgets for the agent chat panel."""
+
+from . import segments, view
+
+__all__ = [
+    "segments",
+    "view",
+]

--- a/app/ui/agent_chat_panel/components/segments.py
+++ b/app/ui/agent_chat_panel/components/segments.py
@@ -1,10 +1,8 @@
-"""Segment-based widgets for the agent chat transcript."""
+"""Widgets and helpers for rendering transcript segments inside the chat panel."""
 
 from __future__ import annotations
 
 from collections.abc import Callable, Collection, Mapping, Sequence
-"""Widgets and helpers for rendering transcript segments inside the chat panel."""
-
 from contextlib import suppress
 import json
 from typing import Any, Literal

--- a/app/ui/agent_chat_panel/components/segments.py
+++ b/app/ui/agent_chat_panel/components/segments.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 from collections.abc import Callable, Collection, Mapping, Sequence
+"""Widgets and helpers for rendering transcript segments inside the chat panel."""
+
 from contextlib import suppress
 import json
 from typing import Any, Literal
@@ -49,10 +51,8 @@ class _LabeledCollapsiblePane(wx.CollapsiblePane):
             return
         callback = getattr(self, "_cookareq_on_expand", None)
         if callable(callback):
-            try:
+            with suppress(Exception):
                 callback()
-            except Exception:
-                pass
 
 
 def _format_context_messages(
@@ -403,6 +403,7 @@ class MessageSegmentPanel(wx.Panel):
         segment_kind: Literal["user", "agent"],
         on_layout_hint: Callable[[str, int], None] | None,
     ) -> None:
+        """Initialise panel bookkeeping for a chat segment."""
         super().__init__(parent)
         self.SetBackgroundColour(parent.GetBackgroundColour())
         self.SetForegroundColour(parent.GetForegroundColour())
@@ -427,6 +428,7 @@ class MessageSegmentPanel(wx.Panel):
         regenerate_enabled: bool,
         on_regenerate: Callable[[], None] | None,
     ) -> None:
+        """Populate the panel with widgets for the supplied ``payload``."""
         self._capture_collapsed_state()
         self._collapsible.clear()
         sizer = self.GetSizer()
@@ -590,10 +592,7 @@ class MessageSegmentPanel(wx.Panel):
         summary = details.summary
         tool_name = summary.tool_name or "Tool"
         status = summary.status or "returned data"
-        heading = "Tool call {tool} — {status}".format(
-            tool=normalize_for_display(tool_name),
-            status=normalize_for_display(status),
-        )
+        heading = f"Tool call {normalize_for_display(tool_name)} — {normalize_for_display(status)}"
 
         bullet_lines = self._collect_tool_bullet_lines(summary)
         text_lines = [heading]
@@ -639,15 +638,11 @@ class MessageSegmentPanel(wx.Panel):
 
         if summary.cost:
             add_bullet_line(
-                "Cost: {cost}".format(
-                    cost=normalize_for_display(summary.cost)
-                )
+                f"Cost: {normalize_for_display(summary.cost)}"
             )
         if summary.error_message:
             add_bullet_line(
-                "Error: {message}".format(
-                    message=normalize_for_display(summary.error_message)
-                )
+                f"Error: {normalize_for_display(summary.error_message)}"
             )
 
         for bullet in summary.bullet_lines:
@@ -834,10 +829,8 @@ class MessageSegmentPanel(wx.Panel):
         for key, state in list(self._deferred_payloads.items()):
             pane = state.pane
             if isinstance(pane, wx.CollapsiblePane):
-                try:
+                with suppress(RuntimeError):
                     self._collapsed_state[key] = pane.IsCollapsed()
-                except RuntimeError:
-                    pass
                 handler = state.handler
                 if handler is not None:
                     with suppress(RuntimeError):
@@ -848,10 +841,8 @@ class MessageSegmentPanel(wx.Panel):
         self._deferred_payloads.clear()
         for key, pane in list(self._collapsible.items()):
             if isinstance(pane, wx.CollapsiblePane):
-                try:
+                with suppress(RuntimeError):
                     self._collapsed_state[key] = pane.IsCollapsed()
-                except RuntimeError:
-                    continue
 
     # ------------------------------------------------------------------
     def _register_collapsible(self, key: str, pane: wx.CollapsiblePane) -> None:
@@ -866,8 +857,10 @@ class MessageSegmentPanel(wx.Panel):
         text_ctrl: wx.TextCtrl,
         raw_payload: Any,
     ) -> None:
-        loader = lambda: self._ensure_deferred_payload_loaded(key)
-        setattr(pane, "_cookareq_on_expand", loader)
+        def loader() -> None:
+            self._ensure_deferred_payload_loaded(key)
+
+        pane._cookareq_on_expand = loader  # type: ignore[attr-defined]
         self._deferred_payloads[key] = _DeferredPayloadState(
             pane=pane,
             text_ctrl=text_ctrl,
@@ -890,10 +883,8 @@ class MessageSegmentPanel(wx.Panel):
     def _apply_deferred_text(
         self, state: _DeferredPayloadState, text: str
     ) -> None:
-        try:
+        with suppress(RuntimeError):
             state.text_ctrl.ChangeValue(text)
-        except RuntimeError:
-            pass
         for mirror in list(state.mirrors):
             with suppress(RuntimeError):
                 mirror.ChangeValue(text)
@@ -933,10 +924,8 @@ class MessageSegmentPanel(wx.Panel):
             state.cached_text = text
             state.loading = False
             self._apply_deferred_text(state, text)
-            try:
+            with suppress(RuntimeError):
                 state.text_ctrl.ShowPosition(0)
-            except RuntimeError:
-                pass
 
             handler_ref = state.handler
             if handler_ref is not None:
@@ -985,10 +974,8 @@ class MessageSegmentPanel(wx.Panel):
         self._layout_hints[key] = width
         if self._on_layout_hint is None:
             return
-        try:
+        with suppress(Exception):
             self._on_layout_hint(key, width)
-        except Exception:
-            pass
 
     # ------------------------------------------------------------------
     @staticmethod
@@ -1008,10 +995,8 @@ class MessageSegmentPanel(wx.Panel):
         handler = self._regenerate_handler
         if handler is None:
             return
-        try:
+        with suppress(Exception):
             handler()
-        except Exception:
-            pass
 class TurnCard(wx.Panel):
     """Container combining message and diagnostic segments for an entry."""
 
@@ -1023,6 +1008,7 @@ class TurnCard(wx.Panel):
         entry_index: int,
         on_layout_hint: Callable[[str, int], None] | None,
     ) -> None:
+        """Prepare sub-panels used to render a conversation entry."""
         super().__init__(parent)
         self.SetBackgroundColour(parent.GetBackgroundColour())
         self.SetForegroundColour(parent.GetForegroundColour())
@@ -1055,16 +1041,15 @@ class TurnCard(wx.Panel):
         on_regenerate: Callable[[], None] | None,
         regenerate_enabled: bool,
     ) -> None:
+        """Render transcript ``segments`` and capture regenerated state."""
         self._capture_system_state()
         previous_notice = self._regenerated_notice
         sizer = self.GetSizer()
         sizer.Clear(delete_windows=False)
         self._regenerated_notice = None
         if previous_notice is not None:
-            try:
+            with suppress(RuntimeError):
                 previous_notice.Destroy()
-            except RuntimeError:
-                pass
 
         prompt_segment = next(
             (segment for segment in segments if segment.kind == "user"),
@@ -1137,10 +1122,8 @@ class TurnCard(wx.Panel):
         for key, pane in list(self._system_sections.items()):
             if isinstance(pane, wx.CollapsiblePane):
                 self._collapsed_state[key] = pane.IsCollapsed()
-                try:
+                with suppress(RuntimeError):
                     pane.Destroy()
-                except RuntimeError:
-                    pass
         self._system_sections.clear()
 
     # ------------------------------------------------------------------

--- a/app/ui/agent_chat_panel/components/view.py
+++ b/app/ui/agent_chat_panel/components/view.py
@@ -1,4 +1,4 @@
-"""View layer for the agent chat panel widgets."""
+"""Helpers for constructing and updating the agent chat panel view."""
 
 from __future__ import annotations
 
@@ -43,6 +43,7 @@ class AgentChatView:
         layout_builder: AgentChatLayoutBuilder,
         status_help_text: str,
     ) -> None:
+        """Capture collaborators used to build and refresh the view."""
         self._panel = panel
         self._layout_builder = layout_builder
         self._status_help_text = status_help_text
@@ -52,7 +53,6 @@ class AgentChatView:
     @property
     def state(self) -> AgentChatViewState:
         """Return the current view state."""
-
         if self._state is None:
             raise RuntimeError("AgentChatView is not initialized")
         return self._state
@@ -60,7 +60,6 @@ class AgentChatView:
     # ------------------------------------------------------------------
     def build(self) -> AgentChatViewState:
         """Construct widgets and store the resulting handles."""
-
         layout = self._layout_builder.build(status_help_text=self._status_help_text)
         self._state = AgentChatViewState(layout=layout)
         return self._state
@@ -75,7 +74,6 @@ class AgentChatView:
         callbacks: WaitStateCallbacks,
     ) -> None:
         """Reflect busy state in the view."""
-
         state = self.state
         primary_btn = state.layout.primary_action_button
         idle_label_text = state.layout.primary_action_idle_label
@@ -132,7 +130,6 @@ class AgentChatView:
     # ------------------------------------------------------------------
     def update_status_label(self, label: str) -> None:
         """Update the text shown in the status area."""
-
         self.state.layout.status_label.SetLabel(label)
 
     # ------------------------------------------------------------------
@@ -143,7 +140,6 @@ class AgentChatView:
         context_limit: int | None,
     ) -> None:
         """Show running timer alongside prompt token summary."""
-
         minutes, seconds = divmod(int(elapsed), 60)
         base = _("Waiting for agent… {time}").format(
             time=f"{minutes:02d}:{seconds:02d}",
@@ -165,7 +161,6 @@ class AgentChatView:
         context_limit: int | None,
     ) -> str:
         """Return label for the ready state."""
-
         base = _("Ready")
         if tokens is None:
             return base
@@ -182,7 +177,6 @@ class AgentChatView:
         disabled_bitmap: wx.Bitmap | None,
     ) -> None:
         """Attach the idle-state bitmaps to the primary action button."""
-
         if not bitmap or not bitmap.IsOk():
             return
 
@@ -209,7 +203,6 @@ class AgentChatView:
     # ------------------------------------------------------------------
     def _clear_primary_action_bitmaps(self, button: wx.Button) -> None:
         """Remove bitmaps from the primary action button."""
-
         null_bitmap = wx.NullBitmap
         for attr in (
             "SetBitmap",
@@ -234,7 +227,6 @@ class AgentChatView:
         disabled_bitmap: wx.Bitmap | None,
     ) -> None:
         """Apply the requested primary action presentation."""
-
         if uses_bitmap and bitmap is not None:
             self._set_primary_action_bitmaps(button, bitmap, disabled_bitmap)
         else:
@@ -252,7 +244,6 @@ class AgentChatView:
         context_limit: int | None,
     ) -> str:
         """Return label for the initial running state."""
-
         if tokens is None:
             return _("Waiting for agent… {time}").format(time="00:00")
         details = summarize_token_usage(tokens, context_limit)

--- a/app/ui/agent_chat_panel/confirm_preferences.py
+++ b/app/ui/agent_chat_panel/confirm_preferences.py
@@ -43,7 +43,6 @@ class ConfirmPreferencesMixin:
         value: RequirementConfirmPreference | str | None,
     ) -> RequirementConfirmPreference:
         """Convert *value* into a recognised confirmation preference."""
-
         if isinstance(value, RequirementConfirmPreference):
             return value
         if isinstance(value, str):
@@ -162,7 +161,6 @@ class ConfirmPreferencesMixin:
     @property
     def confirmation_preference(self) -> str:
         """Return current confirmation policy as a string key."""
-
         return self._confirm_preference.value
 
 

--- a/app/ui/agent_chat_panel/controller.py
+++ b/app/ui/agent_chat_panel/controller.py
@@ -25,7 +25,6 @@ logger = logging.getLogger(__name__)
 
 def _call_supports_keyword(func: Any, name: str) -> bool:
     """Return True when *func* accepts the keyword argument ``name``."""
-
     try:
         signature = inspect.signature(func)
     except (TypeError, ValueError):  # pragma: no cover - fallback for builtins

--- a/app/ui/agent_chat_panel/coordinator.py
+++ b/app/ui/agent_chat_panel/coordinator.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Mapping, Sequence
+from collections.abc import Mapping, Sequence
 
 from .controller import AgentRunController
 from .execution import AgentCommandExecutor, _AgentRunHandle
@@ -32,7 +32,6 @@ class AgentChatCoordinator:
     # ------------------------------------------------------------------
     def submit_prompt(self, prompt: str, *, prompt_at: str | None = None) -> None:
         """Send a prompt to the agent pipeline."""
-
         self._run_controller.submit_prompt(prompt, prompt_at=prompt_at)
 
     # ------------------------------------------------------------------
@@ -45,7 +44,6 @@ class AgentChatCoordinator:
         prompt_at: str | None,
     ) -> None:
         """Send a prompt that carries additional context information."""
-
         self._run_controller.submit_prompt_with_context(
             prompt,
             conversation_id=conversation_id,
@@ -56,32 +54,27 @@ class AgentChatCoordinator:
     # ------------------------------------------------------------------
     def cancel_active_run(self) -> _AgentRunHandle | None:
         """Abort the current agent run when possible."""
-
         return self._run_controller.stop()
 
     # ------------------------------------------------------------------
     def stop(self) -> None:
         """Stop the underlying controller and cancel the executor."""
-
         self._run_controller.stop()
 
     # ------------------------------------------------------------------
     @property
     def active_handle(self) -> _AgentRunHandle | None:
         """Expose the controller's active handle for inspection."""
-
         return self._run_controller.active_handle
 
     # ------------------------------------------------------------------
     def reset_active_handle(self, handle: _AgentRunHandle) -> None:
         """Clear the active handle if it matches *handle*."""
-
         self._run_controller.reset_active_handle(handle)
 
     # ------------------------------------------------------------------
     def regenerate_entry(self, conversation_id: str, entry: ChatEntry) -> None:
         """Trigger regeneration of the last entry in a conversation."""
-
         self._run_controller.regenerate_entry(conversation_id, entry)
 
 

--- a/app/ui/agent_chat_panel/execution.py
+++ b/app/ui/agent_chat_panel/execution.py
@@ -34,7 +34,6 @@ class ThreadedAgentCommandExecutor:
     @property
     def pool(self) -> ThreadPoolExecutor:
         """Expose the underlying thread pool."""
-
         return self._pool
 
     def submit(self, func: Callable[[], Any]) -> Future[Any]:
@@ -74,7 +73,6 @@ class _AgentRunHandle:
         self,
     ) -> tuple[dict[str, Any], ...] | None:
         """Return an immutable snapshot of collected tool payloads."""
-
         if not self.streamed_tool_results:
             return None
         return clone_streamed_tool_results(self.streamed_tool_results)

--- a/app/ui/agent_chat_panel/history.py
+++ b/app/ui/agent_chat_panel/history.py
@@ -33,13 +33,11 @@ class AgentChatHistory:
     @property
     def conversations(self) -> list[ChatConversation]:
         """Return the in-memory conversations."""
-
         return self._conversations
 
     # ------------------------------------------------------------------
     def get_conversation(self, conversation_id: str) -> ChatConversation | None:
         """Return conversation matching *conversation_id* when present."""
-
         for conversation in self._conversations:
             if conversation.conversation_id == conversation_id:
                 return conversation
@@ -49,26 +47,22 @@ class AgentChatHistory:
     @property
     def active_id(self) -> str | None:
         """Return identifier of the currently selected conversation."""
-
         return self._active_id
 
     # ------------------------------------------------------------------
     @property
     def path(self) -> Path:
         """Expose backing store path so callers can surface it in the UI."""
-
         return self._store.path
 
     # ------------------------------------------------------------------
     def set_conversations(self, conversations: Sequence[ChatConversation]) -> None:
         """Replace the in-memory conversation list."""
-
         self._conversations = list(conversations)
 
     # ------------------------------------------------------------------
     def set_active_id(self, conversation_id: str | None) -> None:
         """Set active conversation id notifying listeners on change."""
-
         previous = self._active_id
         self._active_id = conversation_id
         if conversation_id is not None:
@@ -84,7 +78,6 @@ class AgentChatHistory:
     # ------------------------------------------------------------------
     def persist_active_selection(self) -> None:
         """Persist the currently selected conversation id."""
-
         try:
             self._store.save_active_id(self._active_id)
         except Exception:  # pragma: no cover - defensive logging
@@ -96,7 +89,6 @@ class AgentChatHistory:
     # ------------------------------------------------------------------
     def load(self) -> tuple[list[ChatConversation], str | None]:
         """Populate memory state from disk and report the loaded payload."""
-
         previous = self._active_id
         conversations, active_id = self._store.load()
         self._conversations = list(conversations)
@@ -112,7 +104,6 @@ class AgentChatHistory:
     # ------------------------------------------------------------------
     def save(self) -> None:
         """Persist current state to disk logging failures defensively."""
-
         try:
             self._store.save(self._conversations, self._active_id)
         except Exception:  # pragma: no cover - defensive logging
@@ -128,7 +119,6 @@ class AgentChatHistory:
         persist_existing: bool = False,
     ) -> bool:
         """Switch history store to *path* returning ``True`` on change."""
-
         conversations: Iterable[ChatConversation] | None = (
             self._conversations if persist_existing else None
         )
@@ -142,7 +132,6 @@ class AgentChatHistory:
     # ------------------------------------------------------------------
     def ensure_conversation_entries(self, conversation: ChatConversation) -> None:
         """Ensure entries for *conversation* are available in memory."""
-
         if conversation.entries_loaded:
             return
         try:

--- a/app/ui/agent_chat_panel/history_utils.py
+++ b/app/ui/agent_chat_panel/history_utils.py
@@ -13,7 +13,6 @@ from .time_formatting import parse_iso_timestamp
 
 def history_json_safe(value: Any) -> Any:
     """Convert values for history storage using permissive coercions."""
-
     return make_json_safe(
         value,
         stringify_keys=True,
@@ -25,7 +24,6 @@ def history_json_safe(value: Any) -> Any:
 
 def stringify_payload(payload: Any) -> str:
     """Return textual representation suitable for transcript storage."""
-
     if payload is None:
         return ""
     if isinstance(payload, str):
@@ -90,7 +88,6 @@ def clone_streamed_tool_results(
     tool_results: Sequence[Mapping[str, Any]] | None,
 ) -> tuple[dict[str, Any], ...]:
     """Return a defensive copy of streamed tool payloads."""
-
     if not tool_results:
         return ()
     clones: list[dict[str, Any]] = []
@@ -104,7 +101,6 @@ def sort_tool_payloads(
     payloads: Sequence[Any] | None,
 ) -> list[Any]:
     """Return payloads ordered by their earliest recorded timestamp."""
-
     if not payloads:
         return []
 
@@ -134,7 +130,6 @@ def sort_tool_payloads(
 
 def normalise_tool_payloads(tool_results: Any) -> list[Any] | None:
     """Return sorted tool payloads from *tool_results* or ``None``."""
-
     if not tool_results:
         return None
 
@@ -163,7 +158,6 @@ def normalise_tool_payloads(tool_results: Any) -> list[Any] | None:
 
 def extract_tool_results(raw_result: Any) -> list[Any] | None:
     """Pull tool payloads from *raw_result* if present."""
-
     if not isinstance(raw_result, Mapping):
         return None
     return normalise_tool_payloads(raw_result.get("tool_results"))
@@ -173,7 +167,6 @@ def update_tool_results(
     raw_result: Any | None, tool_results: Sequence[Any] | None
 ) -> Any | None:
     """Return ``raw_result`` with the provided ``tool_results`` merged in."""
-
     normalised = normalise_tool_payloads(tool_results)
 
     if normalised is None:
@@ -191,7 +184,6 @@ def update_tool_results(
 
 def format_value_snippet(value: Any) -> str:
     """Produce a human-friendly snippet for diagnostic payloads."""
-
     from .tool_summaries import format_value_snippet as _format_value_snippet
 
     return _format_value_snippet(value)

--- a/app/ui/agent_chat_panel/history_utils.py
+++ b/app/ui/agent_chat_panel/history_utils.py
@@ -8,7 +8,6 @@ from typing import Any
 import json
 
 from ...util.json import make_json_safe
-from ..text import normalize_for_display
 from .time_formatting import parse_iso_timestamp
 
 
@@ -184,10 +183,7 @@ def update_tool_results(
             return updated
         return raw_result
 
-    if isinstance(raw_result, Mapping):
-        updated = dict(raw_result)
-    else:
-        updated = {}
+    updated = dict(raw_result) if isinstance(raw_result, Mapping) else {}
 
     updated["tool_results"] = normalised
     return updated
@@ -203,7 +199,6 @@ def format_value_snippet(value: Any) -> str:
 
 def shorten_text(text: str, *, limit: int = 120) -> str:
     """Truncate ``text`` to ``limit`` characters preserving ellipsis."""
-
     from .tool_summaries import shorten_text as _shorten_text
 
     return _shorten_text(text, limit=limit)

--- a/app/ui/agent_chat_panel/history_view.py
+++ b/app/ui/agent_chat_panel/history_view.py
@@ -61,7 +61,6 @@ class HistoryView:
     # ------------------------------------------------------------------
     def refresh(self) -> None:
         """Repopulate the history list from the callbacks."""
-
         conversations = self._get_conversations()
         self._list.Freeze()
         self._suppress_selection = True

--- a/app/ui/agent_chat_panel/layout.py
+++ b/app/ui/agent_chat_panel/layout.py
@@ -442,7 +442,6 @@ class AgentChatLayoutBuilder:
         stop_visual: _PrimaryActionVisual,
     ) -> None:
         """Keep the primary button size stable across idle and running states."""
-
         idle_size = self._measure_primary_action_visual(button, idle_visual)
         stop_size = self._measure_primary_action_visual(button, stop_visual)
 
@@ -462,7 +461,6 @@ class AgentChatLayoutBuilder:
         self, button: wx.Button, visual: _PrimaryActionVisual
     ) -> wx.Size:
         """Return the best size for the provided primary action visual."""
-
         self._apply_primary_action_visual(button, visual)
         button.InvalidateBestSize()
         size = button.GetBestSize()
@@ -475,7 +473,6 @@ class AgentChatLayoutBuilder:
         self, button: wx.Button, visual: _PrimaryActionVisual
     ) -> None:
         """Apply the provided visual state to the primary action button."""
-
         if visual.uses_bitmap and visual.bitmap is not None:
             self._apply_button_bitmaps(
                 button, visual.bitmap, visual.disabled_bitmap
@@ -491,7 +488,6 @@ class AgentChatLayoutBuilder:
         self, parent: wx.Window
     ) -> tuple[wx.Button, _PrimaryActionVisual, _PrimaryActionVisual]:
         """Construct the send/stop button together with its visuals."""
-
         idle_visual = self._build_primary_action_idle_visual(parent)
         stop_visual = self._build_primary_action_stop_visual(parent)
         button = wx.Button(parent, label="", style=wx.BU_AUTODRAW | wx.BU_EXACTFIT)
@@ -504,7 +500,6 @@ class AgentChatLayoutBuilder:
         self, parent: wx.Window
     ) -> _PrimaryActionVisual:
         """Return the idle visual description for the primary action button."""
-
         return self._build_primary_action_visual(
             parent,
             svg_builder=self._build_primary_action_arrow_svg,
@@ -516,7 +511,6 @@ class AgentChatLayoutBuilder:
         self, parent: wx.Window
     ) -> _PrimaryActionVisual:
         """Return the running visual description for the primary action button."""
-
         return self._build_primary_action_visual(
             parent,
             svg_builder=self._build_primary_action_stop_svg,
@@ -532,7 +526,6 @@ class AgentChatLayoutBuilder:
         fallback_label: str,
     ) -> _PrimaryActionVisual:
         """Return a visual description for the primary action button."""
-
         icon_edge = dip(self._panel, PRIMARY_ACTION_ICON_EDGE)
         icon_size = wx.Size(icon_edge, icon_edge)
         bitmaps = self._render_primary_action_bitmaps(parent, icon_size, svg_builder)
@@ -561,7 +554,6 @@ class AgentChatLayoutBuilder:
         svg_builder: Callable[[wx.Colour], str],
     ) -> tuple[wx.Bitmap, wx.Bitmap] | None:
         """Render the idle-state bitmaps for the primary action button."""
-
         colours = self._resolve_primary_action_colours(parent)
         if colours is None:
             return None
@@ -581,7 +573,6 @@ class AgentChatLayoutBuilder:
         self, parent: wx.Window
     ) -> tuple[wx.Colour, wx.Colour] | None:
         """Pick colours for the active and disabled arrow."""
-
         accent = parent.GetForegroundColour()
         if not isinstance(accent, wx.Colour) or not accent.IsOk():
             accent = wx.SystemSettings.GetColour(wx.SYS_COLOUR_BTNTEXT)
@@ -602,7 +593,6 @@ class AgentChatLayoutBuilder:
         self, first: wx.Colour, second: wx.Colour, first_weight: float
     ) -> wx.Colour:
         """Blend two colours using the provided weight for the first colour."""
-
         ratio = max(0.0, min(1.0, first_weight))
         other = 1.0 - ratio
 
@@ -621,7 +611,6 @@ class AgentChatLayoutBuilder:
     # ------------------------------------------------------------------
     def _colour_alpha(self, colour: wx.Colour) -> int:
         """Return the alpha component of a colour, defaulting to fully opaque."""
-
         alpha_getter = getattr(colour, "Alpha", None)
         if callable(alpha_getter):
             return int(alpha_getter())
@@ -634,7 +623,6 @@ class AgentChatLayoutBuilder:
         self, button: wx.Button, bitmap: wx.Bitmap, disabled_bitmap: wx.Bitmap | None
     ) -> None:
         """Attach the provided bitmaps to a button."""
-
         if not bitmap or not bitmap.IsOk():
             return
 
@@ -661,7 +649,6 @@ class AgentChatLayoutBuilder:
     # ------------------------------------------------------------------
     def _clear_button_bitmaps(self, button: wx.Button) -> None:
         """Remove any bitmaps associated with a button."""
-
         null_bitmap = wx.NullBitmap
         for attr in (
             "SetBitmap",
@@ -680,7 +667,6 @@ class AgentChatLayoutBuilder:
         self, primary_button: wx.Button, buttons: Sequence[wx.Button]
     ) -> None:
         """Align auxiliary icon buttons with the primary button footprint."""
-
         if not buttons:
             return
 
@@ -704,7 +690,6 @@ class AgentChatLayoutBuilder:
         self, parent: wx.Window
     ) -> tuple[wx.Button, bool]:
         """Create an icon-first button used to pick an attachment."""
-
         panel = self._panel
         icon_edge = dip(panel, PRIMARY_ACTION_ICON_EDGE)
         icon_size = wx.Size(icon_edge, icon_edge)
@@ -727,7 +712,6 @@ class AgentChatLayoutBuilder:
         self, parent: wx.Window
     ) -> tuple[wx.Button, bool]:
         """Create a compact icon button that opens agent instructions."""
-
         panel = self._panel
         icon_edge = dip(panel, PRIMARY_ACTION_ICON_EDGE)
         icon_size = wx.Size(icon_edge, icon_edge)
@@ -750,7 +734,6 @@ class AgentChatLayoutBuilder:
         self, parent: wx.Window
     ) -> tuple[wx.Button, bool]:
         """Create a compact button for clearing the chat input."""
-
         panel = self._panel
         icon_edge = dip(panel, PRIMARY_ACTION_ICON_EDGE)
         icon_size = wx.Size(icon_edge, icon_edge)
@@ -773,7 +756,6 @@ class AgentChatLayoutBuilder:
         self, parent: wx.Window, icon_size: wx.Size
     ) -> tuple[wx.Bitmap, wx.Bitmap] | None:
         """Return bitmaps for the clear-input button or ``None`` if unavailable."""
-
         colour = self._resolve_control_icon_colour(parent)
 
         stroke = self._colour_to_hex(colour)
@@ -796,7 +778,6 @@ class AgentChatLayoutBuilder:
         self, parent: wx.Window, icon_size: wx.Size
     ) -> tuple[wx.Bitmap, wx.Bitmap] | None:
         """Return bitmaps for the attachment button or ``None`` if unavailable."""
-
         colour = self._resolve_control_icon_colour(parent)
         stroke = self._colour_to_hex(colour)
         opacity = max(0.0, min(self._colour_alpha(colour) / 255.0, 1.0))
@@ -818,7 +799,6 @@ class AgentChatLayoutBuilder:
         self, parent: wx.Window, icon_size: wx.Size
     ) -> tuple[wx.Bitmap, wx.Bitmap] | None:
         """Return bitmaps for the agent instructions button."""
-
         highlight = wx.SystemSettings.GetColour(wx.SYS_COLOUR_HIGHLIGHT)
         if not isinstance(highlight, wx.Colour) or not highlight.IsOk():
             highlight = wx.Colour(33, 114, 229)
@@ -842,7 +822,6 @@ class AgentChatLayoutBuilder:
     # ------------------------------------------------------------------
     def _resolve_control_icon_colour(self, parent: wx.Window) -> wx.Colour:
         """Return a foreground colour suitable for monochrome control icons."""
-
         colour = parent.GetForegroundColour()
         if not isinstance(colour, wx.Colour) or not colour.IsOk():
             colour = wx.SystemSettings.GetColour(wx.SYS_COLOUR_BTNTEXT)
@@ -853,7 +832,6 @@ class AgentChatLayoutBuilder:
     # ------------------------------------------------------------------
     def _render_svg_bitmap(self, svg_markup: str, icon_size: wx.Size) -> wx.Bitmap | None:
         """Render SVG markup into a bitmap using available wx backends."""
-
         bitmap = self._render_svg_with_bitmap_bundle(svg_markup, icon_size)
         if bitmap is None:
             bitmap = self._render_svg_with_wxsvg(svg_markup, icon_size)
@@ -864,7 +842,6 @@ class AgentChatLayoutBuilder:
         self, svg_markup: str, icon_size: wx.Size
     ) -> wx.Bitmap | None:
         """Render SVG markup through :mod:`wx.BitmapBundle` if supported."""
-
         if not hasattr(wx, "BitmapBundle"):
             return None
         from_svg = getattr(wx.BitmapBundle, "FromSVG", None)
@@ -888,7 +865,6 @@ class AgentChatLayoutBuilder:
         self, svg_markup: str, icon_size: wx.Size
     ) -> wx.Bitmap | None:
         """Render SVG markup via :mod:`wx.svg` as a compatibility fallback."""
-
         try:
             import wx.svg as wxsvg
         except Exception:  # pragma: no cover - defensive against missing module
@@ -912,7 +888,6 @@ class AgentChatLayoutBuilder:
     # ------------------------------------------------------------------
     def _build_primary_action_arrow_svg(self, colour: wx.Colour) -> str:
         """Return SVG markup for the idle-state upward arrow."""
-
         fill = self._colour_to_hex(colour)
         opacity = max(0.0, min(self._colour_alpha(colour) / 255.0, 1.0))
         return _PRIMARY_ACTION_ARROW_ICON_SVG_TEMPLATE.format(
@@ -923,7 +898,6 @@ class AgentChatLayoutBuilder:
     # ------------------------------------------------------------------
     def _build_primary_action_stop_svg(self, colour: wx.Colour) -> str:
         """Return SVG markup for the running-state stop icon."""
-
         fill = self._colour_to_hex(colour)
         opacity = max(0.0, min(self._colour_alpha(colour) / 255.0, 1.0))
         return _PRIMARY_ACTION_STOP_ICON_SVG_TEMPLATE.format(
@@ -934,7 +908,6 @@ class AgentChatLayoutBuilder:
     # ------------------------------------------------------------------
     def _colour_to_hex(self, colour: wx.Colour) -> str:
         """Convert a colour to a ``#RRGGBB`` hex string."""
-
         red = max(0, min(int(colour.Red()), 255))
         green = max(0, min(int(colour.Green()), 255))
         blue = max(0, min(int(colour.Blue()), 255))

--- a/app/ui/agent_chat_panel/layout.py
+++ b/app/ui/agent_chat_panel/layout.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from textwrap import dedent
-from typing import TYPE_CHECKING, Callable, Sequence
+from collections.abc import Callable, Sequence
+from typing import TYPE_CHECKING
 
 import wx
 import wx.dataview as dv
@@ -934,11 +935,10 @@ class AgentChatLayoutBuilder:
     def _colour_to_hex(self, colour: wx.Colour) -> str:
         """Convert a colour to a ``#RRGGBB`` hex string."""
 
-        return "#{:02X}{:02X}{:02X}".format(
-            max(0, min(int(colour.Red()), 255)),
-            max(0, min(int(colour.Green()), 255)),
-            max(0, min(int(colour.Blue()), 255)),
-        )
+        red = max(0, min(int(colour.Red()), 255))
+        green = max(0, min(int(colour.Green()), 255))
+        blue = max(0, min(int(colour.Blue()), 255))
+        return f"#{red:02X}{green:02X}{blue:02X}"
 
 
 _PRIMARY_ACTION_ARROW_ICON_SVG_TEMPLATE = dedent(

--- a/app/ui/agent_chat_panel/log_export.py
+++ b/app/ui/agent_chat_panel/log_export.py
@@ -35,7 +35,6 @@ class _PlainEvent:
 
 def _format_timestamp_label(info: TimestampInfo | None) -> str:
     """Return display label for *info* consistent with the transcript UI."""
-
     if info is None:
         return _("not recorded")
     if info.formatted:
@@ -49,7 +48,6 @@ def _format_timestamp_label(info: TimestampInfo | None) -> str:
 
 def _format_iso_timestamp(value: str | None, fallback: TimestampInfo | None) -> str:
     """Return formatted timestamp derived from ISO *value* or *fallback*."""
-
     if value:
         formatted = format_entry_timestamp(value)
         if formatted:
@@ -62,7 +60,6 @@ def _format_tool_timestamp(
     summary: Any, fallback: TimestampInfo | None
 ) -> str:
     """Return formatted timestamp for a tool call *summary*."""
-
     for candidate in (
         getattr(summary, "completed_at", None),
         getattr(summary, "last_observed_at", None),
@@ -75,7 +72,6 @@ def _format_tool_timestamp(
 
 def _collect_agent_plain_events(entry: TranscriptEntry) -> list[_PlainEvent]:
     """Return ordered plain-text events describing the agent turn."""
-
     turn = entry.agent_turn
     events: list[_PlainEvent] = []
     last_text: str | None = None
@@ -211,7 +207,6 @@ def compose_transcript_text(
     timeline: ConversationTimeline | None = None,
 ) -> str:
     """Return the plain conversation transcript for *conversation*."""
-
     if conversation is None:
         return _("Start chatting with the agent to see responses here.")
     if not conversation.entries:
@@ -333,7 +328,6 @@ def compose_transcript_log_text(
     timeline: ConversationTimeline | None = None,
 ) -> str:
     """Return the detailed diagnostic log for *conversation*."""
-
     if conversation is None:
         return _("Start chatting with the agent to see responses here.")
     if not conversation.entries:

--- a/app/ui/agent_chat_panel/paths.py
+++ b/app/ui/agent_chat_panel/paths.py
@@ -7,19 +7,16 @@ from pathlib import Path
 
 def _default_history_path() -> Path:
     """Return default location for persisted chat history."""
-
     return Path.home() / ".cookareq" / "agent_chats.sqlite"
 
 
 def _normalize_history_path(path: Path | str) -> Path:
     """Expand user references and coerce *path* into :class:`Path`."""
-
     return Path(path).expanduser()
 
 
 def history_path_for_documents(base_directory: Path | str | None) -> Path:
     """Return history file path colocated with a requirements directory."""
-
     if base_directory is None:
         return _default_history_path()
     base_path = _normalize_history_path(base_directory)
@@ -28,13 +25,11 @@ def history_path_for_documents(base_directory: Path | str | None) -> Path:
 
 def _default_settings_path() -> Path:
     """Return default location for persisted project agent settings."""
-
     return Path.home() / ".cookareq" / "agent_settings.json"
 
 
 def settings_path_for_documents(base_directory: Path | str | None) -> Path:
     """Return project settings path colocated with a requirements directory."""
-
     if base_directory is None:
         return _default_settings_path()
     base_path = _normalize_history_path(base_directory)

--- a/app/ui/agent_chat_panel/project_settings.py
+++ b/app/ui/agent_chat_panel/project_settings.py
@@ -22,9 +22,8 @@ class AgentProjectSettings:
     custom_system_prompt: str = ""
     documents_path: str = ""
 
-    def normalized(self) -> "AgentProjectSettings":
+    def normalized(self) -> AgentProjectSettings:
         """Return settings with whitespace-normalised fields."""
-
         return AgentProjectSettings(
             custom_system_prompt=self.custom_system_prompt.strip(),
             documents_path=normalize_documents_path(self.documents_path),
@@ -32,7 +31,6 @@ class AgentProjectSettings:
 
     def to_dict(self) -> dict[str, Any]:
         """Serialise settings into a JSON-compatible mapping."""
-
         normalized = self.normalized()
         return {
             "version": 4,
@@ -43,7 +41,6 @@ class AgentProjectSettings:
     @classmethod
     def from_dict(cls, payload: Mapping[str, Any]) -> AgentProjectSettings:
         """Create :class:`AgentProjectSettings` from *payload* data."""
-
         prompt = payload.get("custom_system_prompt", "")
         if not isinstance(prompt, str):
             prompt = ""
@@ -58,7 +55,6 @@ class AgentProjectSettings:
 
 def load_agent_project_settings(path: Path) -> AgentProjectSettings:
     """Load project settings from *path* returning defaults on failure."""
-
     try:
         raw = json.loads(path.read_text(encoding="utf-8"))
     except FileNotFoundError:
@@ -75,11 +71,11 @@ def load_agent_project_settings(path: Path) -> AgentProjectSettings:
 
 def save_agent_project_settings(path: Path, settings: AgentProjectSettings) -> None:
     """Persist *settings* to *path* using a temporary file."""
-
     payload = settings.to_dict()
     path.parent.mkdir(parents=True, exist_ok=True)
     tmp_path = path.with_suffix(path.suffix + ".tmp")
-    tmp_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+    payload_text = json.dumps(payload, ensure_ascii=False, indent=2)
+    tmp_path.write_text(payload_text, encoding="utf-8")
     tmp_path.replace(path)
 
 

--- a/app/ui/agent_chat_panel/session.py
+++ b/app/ui/agent_chat_panel/session.py
@@ -87,7 +87,6 @@ class AgentChatSession:
     # ------------------------------------------------------------------
     def begin_run(self, *, tokens: TokenCountResult | None = None) -> None:
         """Mark the agent run as active."""
-
         self._is_running = True
         self._tokens = tokens if tokens is not None else TokenCountResult.exact(0)
         self._start_time = time.monotonic()
@@ -100,7 +99,6 @@ class AgentChatSession:
     # ------------------------------------------------------------------
     def finalize_run(self, *, tokens: TokenCountResult | None = None) -> None:
         """Mark the agent run as completed."""
-
         if self._start_time is not None:
             try:
                 self._elapsed = max(0.0, time.monotonic() - self._start_time)
@@ -120,7 +118,6 @@ class AgentChatSession:
     # ------------------------------------------------------------------
     def update_tokens(self, tokens: TokenCountResult) -> None:
         """Persist the latest token usage."""
-
         self._tokens = tokens
         self.events.tokens_changed.emit(tokens)
 
@@ -128,26 +125,22 @@ class AgentChatSession:
     @property
     def elapsed(self) -> float:
         """Return the latest elapsed value in seconds."""
-
         return self._elapsed
 
     # ------------------------------------------------------------------
     def notify_history_changed(self) -> None:
         """Emit a change event for the underlying history."""
-
         self.events.history_changed.emit(self._history)
 
     # ------------------------------------------------------------------
     def load_history(self) -> None:
         """Refresh the in-memory history from disk."""
-
         self._history.load()
         self.notify_history_changed()
 
     # ------------------------------------------------------------------
     def save_history(self) -> None:
         """Persist the in-memory history to disk."""
-
         self._history.save()
 
     # ------------------------------------------------------------------
@@ -158,7 +151,6 @@ class AgentChatSession:
         persist_existing: bool = False,
     ) -> bool:
         """Update the history storage location."""
-
         changed = self._history.set_path(path, persist_existing=persist_existing)
         if changed:
             self.notify_history_changed()
@@ -167,7 +159,6 @@ class AgentChatSession:
     # ------------------------------------------------------------------
     def shutdown(self) -> None:
         """Tear down resources owned by the session."""
-
         if self._timer.IsRunning():
             self._timer.Stop()
         self._timer_owner.Unbind(wx.EVT_TIMER, handler=self._on_timer, source=self._timer)

--- a/app/ui/agent_chat_panel/session.py
+++ b/app/ui/agent_chat_panel/session.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Callable, Generic, TypeVar
+from collections.abc import Callable
+from contextlib import suppress
+from typing import Any
 import time
 
 import wx
@@ -13,27 +15,22 @@ from .history import AgentChatHistory
 from .token_usage import TokenCountResult
 
 
-T = TypeVar("T")
-
-
-class SessionEvent(Generic[T]):
+class SessionEvent:
     """Simple signal implementation for the session model."""
 
     __slots__ = ("_listeners",)
 
     def __init__(self) -> None:
-        self._listeners: list[Callable[[T], None]] = []
+        self._listeners: list[Callable[[Any], None]] = []
 
-    def connect(self, callback: Callable[[T], None]) -> None:
+    def connect(self, callback: Callable[[Any], None]) -> None:
         self._listeners.append(callback)
 
-    def disconnect(self, callback: Callable[[T], None]) -> None:
-        try:
+    def disconnect(self, callback: Callable[[Any], None]) -> None:
+        with suppress(ValueError):
             self._listeners.remove(callback)
-        except ValueError:  # pragma: no cover - defensive cleanup
-            pass
 
-    def emit(self, payload: T) -> None:
+    def emit(self, payload: Any) -> None:
         for listener in list(self._listeners):
             listener(payload)
 

--- a/app/ui/agent_chat_panel/settings_dialog.py
+++ b/app/ui/agent_chat_panel/settings_dialog.py
@@ -79,12 +79,10 @@ class AgentProjectSettingsDialog(wx.Dialog):
 
     def get_custom_system_prompt(self) -> str:
         """Return the configured custom system prompt."""
-
         return self._prompt.GetValue().strip()
 
     def get_documents_path(self) -> str:
         """Return the configured documentation directory path."""
-
         return self._documents_path.GetValue().strip()
 
     def _on_browse_documents_path(self, _event: wx.Event) -> None:

--- a/app/ui/agent_chat_panel/time_formatting.py
+++ b/app/ui/agent_chat_panel/time_formatting.py
@@ -10,7 +10,6 @@ from ...i18n import _
 
 def _coerce_datetime(value: Any) -> datetime.datetime | None:
     """Return timezone-aware ``datetime`` extracted from *value*."""
-
     if isinstance(value, datetime.datetime):
         moment = value
     elif isinstance(value, str):
@@ -33,7 +32,6 @@ def _coerce_datetime(value: Any) -> datetime.datetime | None:
 
 def format_last_activity(timestamp: str | None) -> str:
     """Return human readable description of last activity time."""
-
     if not timestamp:
         return _("No activity yet")
     moment = _coerce_datetime(timestamp)
@@ -54,7 +52,6 @@ def format_last_activity(timestamp: str | None) -> str:
 
 def format_entry_timestamp(timestamp: str | None) -> str:
     """Return timestamp for transcript entries in local time."""
-
     if not timestamp:
         return ""
     moment = _coerce_datetime(timestamp)
@@ -66,7 +63,6 @@ def format_entry_timestamp(timestamp: str | None) -> str:
 
 def parse_iso_timestamp(value: Any) -> datetime.datetime | None:
     """Return timezone-aware ``datetime`` derived from ISO timestamp."""
-
     return _coerce_datetime(value)
 
 

--- a/app/ui/agent_chat_panel/token_usage.py
+++ b/app/ui/agent_chat_panel/token_usage.py
@@ -23,7 +23,6 @@ class ContextTokenBreakdown:
     @property
     def total(self) -> TokenCountResult:
         """Return combined token usage across all components."""
-
         return combine_token_counts(
             [self.system, self.history, self.context, self.prompt]
         )
@@ -31,7 +30,6 @@ class ContextTokenBreakdown:
 
 def format_token_quantity(tokens: TokenCountResult) -> str:
     """Return human readable representation for ``tokens``."""
-
     if tokens.tokens is None:
         return TOKEN_UNAVAILABLE_LABEL
     quantity = tokens.tokens / 1000 if tokens.tokens else 0.0
@@ -43,7 +41,6 @@ def summarize_token_usage(
     tokens: TokenCountResult, limit: int | None
 ) -> str:
     """Return formatted usage string with optional context *limit*."""
-
     used = format_token_quantity(tokens)
     if limit is None:
         return used

--- a/app/ui/agent_chat_panel/tool_summaries.py
+++ b/app/ui/agent_chat_panel/tool_summaries.py
@@ -35,7 +35,6 @@ def summarize_tool_results(
     tool_results: Sequence[Any] | None,
 ) -> tuple[ToolCallSummary, ...]:
     """Generate summaries for tool payloads returned by the agent."""
-
     from .history_utils import history_json_safe, sort_tool_payloads
 
     summaries: list[ToolCallSummary] = []

--- a/app/ui/chat_entry.py
+++ b/app/ui/chat_entry.py
@@ -77,7 +77,6 @@ def _deserialize_token_cache(
     payload: Any,
 ) -> dict[str, dict[str, EntryTokenCacheRecord]]:
     """Return sanitised cache mapping from serialized representation."""
-
     if not isinstance(payload, Mapping):
         return {}
     cache: dict[str, dict[str, EntryTokenCacheRecord]] = {}
@@ -104,7 +103,6 @@ def count_context_message_tokens(
     model: str | None,
 ) -> TokenCountResult:
     """Return token usage for a single contextual message."""
-
     if not isinstance(message, Mapping):
         return TokenCountResult.exact(0, model=model)
 
@@ -142,7 +140,6 @@ def count_context_message_tokens(
 
 def _recalculate_pair_token_info(prompt: str, response: str) -> TokenCountResult:
     """Return combined token statistics for *prompt* and *response*."""
-
     prompt_tokens = count_text_tokens(prompt, model=_DEFAULT_TOKEN_MODEL)
     response_tokens = count_text_tokens(response, model=_DEFAULT_TOKEN_MODEL)
     combined = combine_token_counts((prompt_tokens, response_tokens))
@@ -257,7 +254,6 @@ class ChatEntry:
     @property
     def tool_results(self) -> list[Any] | None:
         """Return MCP tool payloads associated with this entry."""
-
         results = extract_tool_results(self.raw_result)
         if not results:
             return None
@@ -311,7 +307,6 @@ class ChatEntry:
 
     def ensure_token_info(self, *, force: bool = False) -> TokenCountResult | None:
         """Ensure ``token_info`` reflects the current prompt/response text."""
-
         if force or self.token_info is None:
             self.token_info = _recalculate_pair_token_info(self.prompt, self.response)
         info = self.token_info
@@ -323,7 +318,6 @@ class ChatEntry:
 
     def ensure_prompt_token_usage(self, model: str | None) -> TokenCountResult:
         """Return token count for the prompt, caching the result."""
-
         text = self.prompt or ""
         digest = _hash_text(text)
         cached = self._cache_lookup("prompt", model=model, digest=digest)
@@ -335,7 +329,6 @@ class ChatEntry:
 
     def ensure_response_token_usage(self, model: str | None) -> TokenCountResult:
         """Return token count for the response, caching the result."""
-
         text = self.response or ""
         digest = _hash_text(text)
         cached = self._cache_lookup("response", model=model, digest=digest)
@@ -352,7 +345,6 @@ class ChatEntry:
         messages: tuple[dict[str, Any], ...] | None = None,
     ) -> TokenCountResult:
         """Return token count for contextual messages, caching the result."""
-
         if messages is None:
             messages = self.context_messages
         if not messages:
@@ -373,7 +365,6 @@ class ChatEntry:
     @classmethod
     def from_dict(cls, payload: Mapping[str, Any]) -> ChatEntry:
         """Create :class:`ChatEntry` instance from stored mapping."""
-
         prompt = str(payload.get("prompt", ""))
         response = str(payload.get("response", ""))
         display_response = payload.get("display_response")
@@ -469,7 +460,6 @@ class ChatEntry:
 
     def to_dict(self) -> dict[str, Any]:
         """Return representation suitable for JSON storage."""
-
         payload = {
             "prompt": self.prompt,
             "response": self.response,
@@ -525,7 +515,6 @@ class ChatConversation:
     @classmethod
     def new(cls) -> ChatConversation:
         """Return empty conversation with generated identifiers."""
-
         now = utc_now_iso()
         return cls(
             conversation_id=str(uuid4()),
@@ -539,7 +528,6 @@ class ChatConversation:
     @classmethod
     def from_dict(cls, payload: Mapping[str, Any]) -> ChatConversation:
         """Create :class:`ChatConversation` from stored mapping."""
-
         conversation_id_raw = payload.get("id") or payload.get("conversation_id")
         conversation_id = (
             conversation_id_raw if isinstance(conversation_id_raw, str) else str(uuid4())
@@ -642,7 +630,6 @@ class ChatConversation:
 
     def ensure_title(self) -> None:
         """Populate title from first prompt when unset."""
-
         if self.title:
             return
         derived = self.derive_title()
@@ -651,7 +638,6 @@ class ChatConversation:
 
     def derive_title(self) -> str:
         """Generate human-friendly title from entries."""
-
         self.ensure_entries_loaded()
         for entry in self._entries:
             candidate = entry.prompt.strip()
@@ -662,7 +648,6 @@ class ChatConversation:
 
     def append_entry(self, entry: ChatEntry) -> None:
         """Add ``entry`` to the conversation and refresh metadata."""
-
         if not self._entries_loaded:
             self._entries = []
             self._entries_loaded = True
@@ -684,7 +669,6 @@ class ChatConversation:
 
     def total_token_info(self) -> TokenCountResult:
         """Return aggregated token statistics for the conversation."""
-
         self.ensure_entries_loaded()
         results: list[TokenCountResult] = []
         for item in self._entries:
@@ -695,12 +679,10 @@ class ChatConversation:
 
     def total_tokens(self) -> int:
         """Return total token count across all entries."""
-
         return self.total_token_info().tokens or 0
 
     def to_dict(self) -> dict[str, Any]:
         """Return representation suitable for JSON storage."""
-
         self.ensure_entries_loaded()
         return {
             "id": self.conversation_id,

--- a/app/ui/chat_entry.py
+++ b/app/ui/chat_entry.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 import hashlib
 import json
 from dataclasses import dataclass, field
-from typing import Any, Callable
-from collections.abc import Iterable, Mapping, Sequence
+from typing import Any
+from collections.abc import Callable, Iterable, Mapping, Sequence
 from uuid import uuid4
 
 from ..llm.tokenizer import (

--- a/app/ui/controllers/documents.py
+++ b/app/ui/controllers/documents.py
@@ -36,7 +36,6 @@ class DocumentsController:
     # ------------------------------------------------------------------
     def load_documents(self) -> dict[str, Document]:
         """Populate ``documents`` from the service and return them."""
-
         self.documents = self.service.load_documents(refresh=True)
         return self.documents
 
@@ -61,12 +60,10 @@ class DocumentsController:
 
     def collect_labels(self, prefix: str) -> tuple[list[LabelDef], bool]:
         """Return labels and free-form flag for document ``prefix``."""
-
         return self.service.collect_label_defs(prefix)
 
     def build_trace_matrix(self, config: TraceMatrixConfig) -> TraceMatrix:
         """Construct traceability matrix for ``config`` using cached documents."""
-
         if not self.documents:
             self.load_documents()
         return build_trace_matrix(self.service.root, config, docs=self.documents)
@@ -133,13 +130,11 @@ class DocumentsController:
     # requirement operations -----------------------------------------
     def next_item_id(self, prefix: str) -> int:
         """Return next available requirement id for document ``prefix``."""
-
         self._get_document(prefix)
         return self.service.next_item_id(prefix)
 
     def add_requirement(self, prefix: str, req: Requirement) -> None:
         """Add ``req`` to the in-memory model for document ``prefix``."""
-
         doc = self._get_document(prefix)
         self._ensure_unique_id(prefix, doc, req)
         req.doc_prefix = prefix
@@ -148,7 +143,6 @@ class DocumentsController:
 
     def save_requirement(self, prefix: str, req: Requirement) -> Path:
         """Persist ``req`` within document ``prefix`` and return file path."""
-
         doc = self._get_document(prefix)
         original_rid = getattr(req, "rid", "")
         original_id = self._parse_original_id(doc, original_rid)
@@ -166,7 +160,6 @@ class DocumentsController:
 
     def delete_requirement(self, prefix: str, req_id: int) -> str:
         """Remove requirement ``req_id`` from document ``prefix``."""
-
         try:
             doc = self._get_document(prefix)
         except ValueError as exc:
@@ -182,7 +175,6 @@ class DocumentsController:
 
     def delete_document(self, prefix: str) -> bool:
         """Remove document ``prefix`` and its descendants."""
-
         removed = self.service.delete_document(prefix)
         if removed:
             self.load_documents()
@@ -197,7 +189,6 @@ class DocumentsController:
         parent: str | None = None,
     ) -> Document:
         """Create a new document and persist it to disk."""
-
         prefix = prefix.strip()
         if not prefix:
             raise ValueError("prefix cannot be empty")
@@ -226,7 +217,6 @@ class DocumentsController:
         title: str | None = None,
     ) -> Document:
         """Update metadata of document ``prefix``."""
-
         doc = self.documents.get(prefix)
         if doc is None:
             try:
@@ -247,11 +237,9 @@ class DocumentsController:
     # ------------------------------------------------------------------
     def iter_links(self) -> Iterable[tuple[str, str]]:
         """Yield ``(child_rid, parent_rid)`` pairs for requirements."""
-
         return iter_links(self.service.root)
 
     @property
     def root(self) -> Path:
         """Return the filesystem root backing the requirements service."""
-
         return self.service.root

--- a/app/ui/controllers/documents.py
+++ b/app/ui/controllers/documents.py
@@ -134,7 +134,7 @@ class DocumentsController:
     def next_item_id(self, prefix: str) -> int:
         """Return next available requirement id for document ``prefix``."""
 
-        doc = self._get_document(prefix)
+        self._get_document(prefix)
         return self.service.next_item_id(prefix)
 
     def add_requirement(self, prefix: str, req: Requirement) -> None:
@@ -211,7 +211,7 @@ class DocumentsController:
                 raise ValueError("document cannot be its own parent")
             if parent not in self.documents:
                 raise ValueError(f"unknown parent document: {parent}")
-        doc = self.service.create_document(
+        self.service.create_document(
             prefix=prefix,
             title=title or prefix,
             parent=parent or None,

--- a/app/ui/detached_editor.py
+++ b/app/ui/detached_editor.py
@@ -30,7 +30,6 @@ class DetachedEditorFrame(wx.Frame):
         on_close: Callable[[DetachedEditorFrame], None] | None = None,
     ) -> None:
         """Create frame initialized with ``requirement`` contents."""
-
         title = self._format_title(requirement, doc_prefix)
         super().__init__(parent, title=title)
         background_source = self._resolve_background_source(parent)
@@ -72,7 +71,6 @@ class DetachedEditorFrame(wx.Frame):
     # ------------------------------------------------------------------
     def _resolve_background_source(self, parent: wx.Window | None) -> wx.Window | None:
         """Return a widget whose colours should be mirrored by this frame."""
-
         if parent is None:
             return None
         try:
@@ -89,7 +87,6 @@ class DetachedEditorFrame(wx.Frame):
         self, target: wx.Window, source: wx.Window | None
     ) -> None:
         """Copy background colour to ``target`` falling back to system defaults."""
-
         if source is not None:
             inherit_background(target, source)
             return
@@ -108,7 +105,6 @@ class DetachedEditorFrame(wx.Frame):
     @property
     def key(self) -> tuple[str, int]:
         """Return dictionary key representing this editor instance."""
-
         return self.doc_prefix, self.requirement_id
 
     def reload(
@@ -119,7 +115,6 @@ class DetachedEditorFrame(wx.Frame):
         allow_freeform: bool,
     ) -> None:
         """Load ``requirement`` replacing current contents."""
-
         self.doc_prefix = requirement.doc_prefix or doc_prefix or self.doc_prefix
         self.requirement_id = requirement.id
         self._labels = list(labels)
@@ -133,14 +128,12 @@ class DetachedEditorFrame(wx.Frame):
     # ------------------------------------------------------------------
     def _handle_save(self) -> None:
         """Delegate saving to owning frame and keep focus on success."""
-
         if self._on_save(self):
             # Reload handled by callback; nothing else to do on success.
             return
 
     def _handle_cancel(self) -> bool:
         """Close the frame when the editor requests to discard changes."""
-
         self._closing_via_cancel = True
         closed = self.Close()
         if not closed:
@@ -150,7 +143,6 @@ class DetachedEditorFrame(wx.Frame):
 
     def _on_close_window(self, event: wx.CloseEvent) -> None:
         """Confirm closing when editor has unsaved changes."""
-
         if self._closing_via_cancel:
             self._closing_via_cancel = False
             if self._on_close:
@@ -167,13 +159,11 @@ class DetachedEditorFrame(wx.Frame):
 
     def _update_title(self, requirement: Requirement) -> None:
         """Refresh window title based on ``requirement`` metadata."""
-
         self.SetTitle(self._format_title(requirement, self.doc_prefix))
 
     @staticmethod
     def _format_title(requirement: Requirement, doc_prefix: str) -> str:
         """Return localized title string for ``requirement``."""
-
         rid = getattr(requirement, "rid", "") or f"{doc_prefix}-{requirement.id:04d}".strip("-")
         base = requirement.title.strip() if getattr(requirement, "title", "") else ""
         if base:

--- a/app/ui/document_dialog.py
+++ b/app/ui/document_dialog.py
@@ -134,5 +134,4 @@ class DocumentPropertiesDialog(wx.Dialog):
 
     def get_properties(self) -> DocumentProperties | None:
         """Return document properties when dialog was accepted."""
-
         return self._result

--- a/app/ui/document_tree.py
+++ b/app/ui/document_tree.py
@@ -67,7 +67,6 @@ class DocumentTree(wx.Panel):
 
     def select(self, prefix: str) -> None:
         """Select tree item corresponding to ``prefix`` if present."""
-
         node = self._node_for_prefix.get(prefix)
         if node:
             self.tree.SelectItem(node)
@@ -75,7 +74,6 @@ class DocumentTree(wx.Panel):
 
     def get_selected_prefix(self) -> str | None:
         """Return prefix associated with the currently selected node."""
-
         item = self.tree.GetSelection()
         if not item.IsOk():
             return None

--- a/app/ui/editor_panel.py
+++ b/app/ui/editor_panel.py
@@ -262,21 +262,18 @@ class EditorPanel(wx.Panel):
 
     def FitInside(self) -> None:  # noqa: N802 - wxWidgets API casing
         """Recalculate the scrollable area of the editor form."""
-
         self._content_panel.FitInside()
         self._content_panel.Layout()
         super().Layout()
 
     def Layout(self) -> bool:  # noqa: N802 - wxWidgets API casing
         """Layout both the scrollable content and the outer panel."""
-
         self._content_panel.Layout()
         return super().Layout()
 
     # helpers -------------------------------------------------------------
     def set_service(self, service: RequirementsService | None) -> None:
         """Configure requirements service used by the editor."""
-
         self._service = service
         self._document = None
         self._known_ids = None
@@ -286,7 +283,6 @@ class EditorPanel(wx.Panel):
 
     def set_document(self, prefix: str | None) -> None:
         """Select active document ``prefix`` for ID validation."""
-
         self._doc_prefix = prefix
         self.extra["doc_prefix"] = prefix or ""
         self._document = None
@@ -459,7 +455,6 @@ class EditorPanel(wx.Panel):
 
     def _lookup_link_metadata(self, rid: str) -> dict[str, Any] | None:
         """Return cached metadata for ``rid`` or load it from storage."""
-
         rid = rid.strip()
         if not rid:
             return None
@@ -495,7 +490,6 @@ class EditorPanel(wx.Panel):
         self, links: list[dict[str, Any]]
     ) -> list[dict[str, Any]]:
         """Enrich serialized ``links`` with cached metadata when available."""
-
         enriched: list[dict[str, Any]] = []
         for entry in links:
             rid = str(entry.get("rid", "")).strip()
@@ -516,7 +510,6 @@ class EditorPanel(wx.Panel):
 
     def _format_link_note(self, link: dict[str, Any]) -> str:
         """Return human-readable text for ``link`` entry."""
-
         rid = str(link.get("rid", "")).strip()
         title = str(link.get("title", "")).strip()
         doc_title = str(link.get("doc_title", "")).strip()
@@ -631,7 +624,6 @@ class EditorPanel(wx.Panel):
     # basic operations -------------------------------------------------
     def new_requirement(self) -> None:
         """Reset UI fields to create a new requirement."""
-
         with self._bulk_update():
             for ctrl in self.fields.values():
                 ctrl.ChangeValue("")
@@ -682,7 +674,6 @@ class EditorPanel(wx.Panel):
         mtime: float | None = None,
     ) -> None:
         """Populate editor fields from ``data``."""
-
         if isinstance(data, Requirement):
             self.extra["doc_prefix"] = data.doc_prefix
             self.extra["rid"] = data.rid
@@ -756,7 +747,6 @@ class EditorPanel(wx.Panel):
 
     def clone(self, new_id: int) -> None:
         """Copy current requirement into a new one with ``new_id``."""
-
         with self._bulk_update():
             self.fields["id"].ChangeValue(str(new_id))
             self.fields["modified_at"].ChangeValue("")
@@ -775,7 +765,6 @@ class EditorPanel(wx.Panel):
     # data helpers -----------------------------------------------------
     def get_data(self) -> Requirement:
         """Collect form data into a :class:`Requirement`."""
-
         id_value = self.fields["id"].GetValue().strip()
         if not id_value:
             raise ValueError(_("ID is required"))
@@ -1093,7 +1082,6 @@ class EditorPanel(wx.Panel):
 
     def save(self, prefix: str) -> Path:
         """Persist editor contents within document ``prefix`` and return path."""
-
         service = self._require_service()
         try:
             doc = service.get_document(prefix)
@@ -1135,7 +1123,6 @@ class EditorPanel(wx.Panel):
 
     def _snapshot_state(self) -> dict[str, Any]:
         """Return immutable snapshot of current editor contents."""
-
         fields_state = {
             name: ctrl.GetValue()
             for name, ctrl in self.fields.items()
@@ -1161,19 +1148,16 @@ class EditorPanel(wx.Panel):
 
     def mark_clean(self) -> None:
         """Store current state as the latest saved baseline."""
-
         self._saved_state = self._snapshot_state()
 
     def is_dirty(self) -> bool:
         """Return True when editor content differs from saved baseline."""
-
         if self._saved_state is None:
             return False
         return self._snapshot_state() != self._saved_state
 
     def discard_changes(self) -> None:
         """Revert editor fields to the latest stored version."""
-
         handled = False
         if self._on_discard_callback:
             handled = bool(self._on_discard_callback())
@@ -1241,7 +1225,6 @@ class EditorPanel(wx.Panel):
 
     def add_attachment(self, path: str, note: str = "") -> None:
         """Append attachment with ``path`` and optional ``note``."""
-
         self.attachments.append({"path": path, "note": note})
         if hasattr(self, "attachments_list"):
             idx = self.attachments_list.InsertItem(

--- a/app/ui/error_dialog.py
+++ b/app/ui/error_dialog.py
@@ -12,6 +12,7 @@ class ErrorDialog(wx.Dialog):
     """Dialog showing a copyable error message."""
 
     def __init__(self, parent: wx.Window | None, message: str, *, title: str) -> None:
+        """Initialise the dialog and populate it with controls."""
         super().__init__(
             parent,
             title=title,
@@ -47,7 +48,6 @@ class ErrorDialog(wx.Dialog):
 
     def _on_copy(self, event: wx.CommandEvent | None) -> None:
         """Copy error text to clipboard."""
-
         clipboard = wx.TheClipboard
         opened = False
         try:
@@ -65,7 +65,6 @@ class ErrorDialog(wx.Dialog):
 
     def _on_close(self, event: wx.CommandEvent | None) -> None:
         """Close dialog."""
-
         self.EndModal(wx.ID_OK)
         if event is not None:
             event.Skip(False)
@@ -78,7 +77,6 @@ def show_error_dialog(
     title: str | None = None,
 ) -> None:
     """Display an :class:`ErrorDialog` with ``message``."""
-
     dlg = ErrorDialog(parent, message, title=title or _("Error"))
     try:
         dlg.ShowModal()

--- a/app/ui/helpers.py
+++ b/app/ui/helpers.py
@@ -11,7 +11,6 @@ from ..i18n import _
 
 def inherit_background(target: wx.Window, source: wx.Window | None) -> None:
     """Copy background colour from ``source`` to ``target`` when available."""
-
     if source is None:
         return
     setter = getattr(target, "SetBackgroundColour", None)
@@ -46,7 +45,6 @@ def inherit_background(target: wx.Window, source: wx.Window | None) -> None:
 
 def dip(window: wx.Window, value: int) -> int:
     """Convert a device-independent pixel ``value`` for ``window`` if possible."""
-
     converter = getattr(window, "FromDIP", None)
     if callable(converter):
         try:
@@ -69,7 +67,6 @@ def create_copy_button(
     size: int = 16,
 ) -> wx.Window:
     """Create a copy button reusing themed bitmaps when available."""
-
     icon_size = wx.Size(dip(parent, size), dip(parent, size))
     bitmap = wx.ArtProvider.GetBitmap(wx.ART_COPY, wx.ART_BUTTON, icon_size)
     if bitmap.IsOk():
@@ -134,7 +131,6 @@ class HelpStaticBox(wx.StaticBoxSizer):
 
     def _handle_help(self, _evt: wx.CommandEvent) -> None:
         """Invoke the configured help callback for this static box."""
-
         self._on_help(self._btn, self._help_text)
 
     def Add(
@@ -254,7 +250,6 @@ class AutoHeightListCtrl(wx.ListCtrl):
 
 def _client_display_rect_for(window: wx.Window | None) -> wx.Rect:
     """Return the usable display area for the monitor containing ``window``."""
-
     if window is not None:
         index = wx.Display.GetFromWindow(window)
         if index != wx.NOT_FOUND:
@@ -270,7 +265,6 @@ def _calculate_popup_position(
     pad: int = 8,
 ) -> tuple[int, int]:
     """Compute where to place a popup so it stays close to ``anchor_rect``."""
-
     width = popup_size.width
     height = popup_size.height
 
@@ -317,7 +311,6 @@ def _calculate_popup_position(
 
 def _position_window_near_anchor(window: wx.Window, anchor: wx.Window | None) -> None:
     """Place ``window`` close to ``anchor`` while keeping it on-screen."""
-
     if anchor is None or not anchor.IsShownOnScreen():
         window.CenterOnParent()
         return
@@ -340,7 +333,6 @@ def show_help(
     anchor: wx.Window | None = None,
 ) -> None:
     """Display a modal dialog with ``message`` near the triggering control."""
-
     top_level = parent.GetTopLevelParent() if parent else None
     dialog_parent = top_level or parent
 
@@ -390,7 +382,6 @@ def make_help_button(
         widgets (e.g. notebook pages) and guarantees the popup stays near the
         triggering button.
     """
-
     btn = wx.Button(parent, label="?", style=wx.BU_EXACTFIT)
 
     def _on_click(_evt: wx.CommandEvent) -> None:
@@ -408,7 +399,6 @@ def format_error_message(error: object, *, fallback: str | None = None) -> str:
     ``"code: message"`` pairs when possible.  If all attempts fail, returns the
     provided ``fallback`` or a localized "Unknown error" string.
     """
-
     if isinstance(error, dict):
         code = error.get("code") or error.get("type")
         message = error.get("message")

--- a/app/ui/import_dialog.py
+++ b/app/ui/import_dialog.py
@@ -56,6 +56,7 @@ class RequirementImportDialog(wx.Dialog):
         next_id: int,
         document_label: str | None = None,
     ) -> None:
+        """Initialise dialog state and construct interactive controls."""
         title = _("Import Requirements")
         super().__init__(parent, title=title, style=wx.DEFAULT_DIALOG_STYLE | wx.RESIZE_BORDER)
         self._base_allocator = SequentialIDAllocator(start=next_id, existing=existing_ids)
@@ -533,6 +534,7 @@ class RequirementImportDialog(wx.Dialog):
 
     # ------------------------------------------------------------------
     def get_plan(self) -> RequirementImportPlan | None:
+        """Return configured import plan or ``None`` when selection incomplete."""
         if not (self._dataset and self._current_config and self._selected_path and self._format):
             return None
         return RequirementImportPlan(

--- a/app/ui/labels_dialog.py
+++ b/app/ui/labels_dialog.py
@@ -261,6 +261,5 @@ class LabelsDialog(wx.Dialog):
 
     def Destroy(self) -> bool:  # pragma: no cover - GUI side effect
         """Save window geometry before closing dialog."""
-
         self._save_layout()
         return super().Destroy()

--- a/app/ui/list_panel.py
+++ b/app/ui/list_panel.py
@@ -980,14 +980,13 @@ class ListPanel(wx.Panel, ColumnSorterMixin):
             menu.AppendSubMenu(status_menu, label)
         field = self._field_from_column(column)
         edit_item = None
-        if field and field != "title":
-            if field != "status":
-                edit_item = menu.Append(wx.ID_ANY, _("Edit {field}").format(field=field))
-                menu.Bind(
-                    wx.EVT_MENU,
-                    lambda _evt, c=column: self._on_edit_field(c),
-                    edit_item,
-                )
+        if field and field not in {"title", "status"}:
+            edit_item = menu.Append(wx.ID_ANY, _("Edit {field}").format(field=field))
+            menu.Bind(
+                wx.EVT_MENU,
+                lambda _evt, c=column: self._on_edit_field(c),
+                edit_item,
+            )
         if clone_item and self._on_clone and req_id is not None:
             menu.Bind(wx.EVT_MENU, lambda _evt, i=req_id: self._on_clone(i), clone_item)
         if len(selected_ids) > 1:

--- a/app/ui/list_panel.py
+++ b/app/ui/list_panel.py
@@ -26,7 +26,6 @@ from .requirement_model import RequirementModel
 
 def _apply_item_selection(list_ctrl: wx.ListCtrl, index: int, selected: bool) -> None:
     """Set ``index`` selection on ``list_ctrl`` while swallowing backend quirks."""
-
     select_flag = getattr(wx, "LIST_STATE_SELECTED", 0x0002)
     focus_flag = getattr(wx, "LIST_STATE_FOCUSED", 0x0001)
     mask = select_flag | focus_flag
@@ -295,12 +294,10 @@ class ListPanel(wx.Panel, ColumnSorterMixin):
     # ColumnSorterMixin requirement
     def GetListCtrl(self):  # pragma: no cover - simple forwarding
         """Return internal ``wx.ListCtrl`` for sorting mixin."""
-
         return self.list
 
     def GetSortImages(self):  # pragma: no cover - default arrows
         """Return image ids for sort arrows (unused)."""
-
         return (-1, -1)
 
     def set_handlers(
@@ -325,7 +322,6 @@ class ListPanel(wx.Panel, ColumnSorterMixin):
         self, controller: DocumentsController | None
     ) -> None:
         """Set documents controller used for persistence."""
-
         self._docs_controller = controller
         self._doc_titles = {}
         self._link_display_cache.clear()
@@ -337,7 +333,6 @@ class ListPanel(wx.Panel, ColumnSorterMixin):
 
     def set_active_document(self, prefix: str | None) -> None:
         """Record currently active document prefix for persistence."""
-
         self._current_doc_prefix = prefix
 
     def _label_color(self, name: str) -> str:
@@ -592,7 +587,6 @@ class ListPanel(wx.Panel, ColumnSorterMixin):
 
     def _default_column_width(self, field: str) -> int:
         """Return sensible default width for a given column field."""
-
         return columns.default_column_width(field)
 
     def load_column_order(self, config: ConfigManager) -> None:
@@ -677,12 +671,10 @@ class ListPanel(wx.Panel, ColumnSorterMixin):
 
     def set_label_filter(self, labels: list[str]) -> None:
         """Apply label filter to the model."""
-
         self.apply_filters({"labels": labels})
 
     def set_search_query(self, query: str, fields: Sequence[str] | None = None) -> None:
         """Apply text ``query`` with optional field restriction."""
-
         filters = {"query": query}
         if fields is not None:
             filters["fields"] = list(fields)
@@ -822,14 +814,12 @@ class ListPanel(wx.Panel, ColumnSorterMixin):
         When ``select_id`` is provided, the list selects the matching
         requirement and scrolls to it after reloading the contents.
         """
-
         self._refresh()
         if select_id is not None:
             self.focus_requirement(select_id)
 
     def focus_requirement(self, req_id: int) -> None:
         """Select and ensure visibility of requirement ``req_id``."""
-
         target_index: int | None = None
         try:
             count = self.list.GetItemCount()
@@ -858,17 +848,14 @@ class ListPanel(wx.Panel, ColumnSorterMixin):
 
     def _set_item_selected(self, index: int, selected: bool) -> None:
         """Apply selection state without propagating backend errors."""
-
         _apply_item_selection(self.list, index, selected)
 
     def record_link(self, parent_rid: str, child_id: int) -> None:
         """Record that ``child_id`` links to ``parent_rid``."""
-
         self.derived_map.setdefault(parent_rid, []).append(child_id)
 
     def recalc_derived_map(self, requirements: list[Requirement]) -> None:
         """Rebuild derived requirements map from ``requirements``."""
-
         derived_map: dict[str, list[int]] = {}
         for req in requirements:
             for parent in getattr(req, "links", []):
@@ -949,7 +936,6 @@ class ListPanel(wx.Panel, ColumnSorterMixin):
 
     def _reset_context_menu_flag(self) -> None:
         """Allow opening the context menu again after the current popup closes."""
-
         self._context_menu_open = False
 
     def _create_context_menu(self, index: int, column: int | None):
@@ -1041,7 +1027,6 @@ class ListPanel(wx.Panel, ColumnSorterMixin):
 
     def get_selected_ids(self) -> list[int]:
         """Return identifiers of currently selected requirements."""
-
         ordered: list[int] = []
         seen: set[int] = set()
         for req_id in self._indices_to_ids(self._get_selected_indices()):
@@ -1134,7 +1119,6 @@ class ListPanel(wx.Panel, ColumnSorterMixin):
 
     def _ordered_unique_ids(self, req_ids: Sequence[int]) -> list[int]:
         """Return ``req_ids`` without duplicates preserving order."""
-
         unique: list[int] = []
         seen: set[int] = set()
         for req_id in req_ids:
@@ -1169,7 +1153,6 @@ class ListPanel(wx.Panel, ColumnSorterMixin):
 
     def _show_labels_dialog(self, req_ids: Sequence[int]) -> None:
         """Open dialog to adjust labels for ``req_ids``."""
-
         unique_order = self._ordered_unique_ids(req_ids)
         if not unique_order:
             return
@@ -1220,7 +1203,6 @@ class ListPanel(wx.Panel, ColumnSorterMixin):
 
     def _set_labels(self, req_ids: Sequence[int], labels: Sequence[str]) -> None:
         """Apply ``labels`` to requirements identified by ``req_ids``."""
-
         unique_order = self._ordered_unique_ids(req_ids)
         if not unique_order:
             return
@@ -1290,7 +1272,6 @@ class ListPanel(wx.Panel, ColumnSorterMixin):
 
     def _persist_requirement(self, req: Requirement) -> None:
         """Persist edited ``req`` if controller and document are available."""
-
         if not self._docs_controller or not self._current_doc_prefix:
             return
         try:

--- a/app/ui/main_frame/agent.py
+++ b/app/ui/main_frame/agent.py
@@ -32,7 +32,6 @@ logger = logging.getLogger("cookareq.ui.main_frame.agent")
 
 def _short_repr(value: Any, *, limit: int = 200) -> str:
     """Return shortened ``repr`` for logging purposes."""
-
     try:
         text = repr(value)
     except Exception:  # pragma: no cover - extremely defensive
@@ -58,7 +57,6 @@ class MainFrameAgentMixin:
         | None = None,
     ):
         """Construct ``LocalAgent`` using current settings."""
-
         from . import confirm
 
         factory = getattr(self, "local_agent_factory", None)
@@ -77,7 +75,6 @@ class MainFrameAgentMixin:
 
     def _init_mcp_tool_listener(self: MainFrame) -> None:
         """Subscribe to MCP tool result notifications."""
-
         if getattr(self, "_mcp_tool_listener_remove", None):
             return
 
@@ -93,7 +90,6 @@ class MainFrameAgentMixin:
 
     def _teardown_mcp_tool_listener(self: MainFrame) -> None:
         """Detach from MCP tool result notifications."""
-
         remover = getattr(self, "_mcp_tool_listener_remove", None)
         if remover is not None:
             try:
@@ -121,7 +117,6 @@ class MainFrameAgentMixin:
         self: MainFrame, event: ToolResultEvent
     ) -> None:
         """Apply requirement changes described by *event*."""
-
         if not event.payloads:
             return
         if getattr(self, "_shutdown_in_progress", False):
@@ -439,7 +434,6 @@ class MainFrameAgentMixin:
         self: MainFrame, tool_results: Sequence[Mapping[str, Any]]
     ) -> None:
         """Apply requirement updates returned by the agent."""
-
         if not tool_results:
             return
         current_prefix = getattr(self, "current_doc_prefix", None)
@@ -595,7 +589,6 @@ class MainFrameAgentMixin:
 
     def on_run_command(self: MainFrame, _event: wx.Event) -> None:
         """Ensure agent chat panel is visible and focused."""
-
         if not self.agent_chat_menu_item:
             return
         if not self.agent_chat_menu_item.IsChecked():
@@ -606,7 +599,6 @@ class MainFrameAgentMixin:
 
     def on_toggle_agent_chat(self: MainFrame, _event: wx.CommandEvent | None) -> None:
         """Toggle agent chat panel visibility."""
-
         if not self.agent_chat_menu_item:
             return
         self._apply_agent_chat_visibility(persist=True)

--- a/app/ui/main_frame/agent.py
+++ b/app/ui/main_frame/agent.py
@@ -353,10 +353,7 @@ class MainFrameAgentMixin:
         if read_kib is None:
             read_kib = read_limit // 1024
         lines.append(
-            "Read chunk limit: {bytes} bytes (~{kib} KiB)".format(
-                bytes=read_limit,
-                kib=read_kib,
-            )
+            f"Read chunk limit: {read_limit} bytes (~{read_kib} KiB)"
         )
         tree_model = snapshot.get("token_model")
         if tree_model:

--- a/app/ui/main_frame/documents.py
+++ b/app/ui/main_frame/documents.py
@@ -36,12 +36,10 @@ class MainFrameDocumentsMixin:
     @property
     def recent_dirs(self: MainFrame) -> list[str]:
         """Return directories recently opened by the user."""
-
         return self.config.get_recent_dirs()
 
     def _current_document_summary(self: MainFrame) -> str | None:
         """Return prefix and title of the active document for the header."""
-
         prefix = self.current_doc_prefix
         if not prefix:
             return None
@@ -63,7 +61,6 @@ class MainFrameDocumentsMixin:
 
     def _update_requirements_label(self: MainFrame) -> None:
         """Adjust requirements pane title to reflect active document."""
-
         label_ctrl = getattr(self, "list_label", None)
         if not label_ctrl:
             return
@@ -82,7 +79,6 @@ class MainFrameDocumentsMixin:
 
     def on_open_folder(self: MainFrame, _event: wx.Event) -> None:
         """Handle "Open Folder" menu action."""
-
         dlg = wx.DirDialog(self, _("Select requirements folder"))
         if dlg.ShowModal() == wx.ID_OK:
             if not self._confirm_discard_changes():
@@ -93,14 +89,12 @@ class MainFrameDocumentsMixin:
 
     def on_open_recent(self: MainFrame, event: wx.CommandEvent) -> None:
         """Open a directory selected from the "recent" menu."""
-
         path = self.navigation.get_recent_path(event.GetId())
         if path and self._confirm_discard_changes():
             self._load_directory(path)
 
     def _normalise_directory_path(self, path: Path) -> str:
         """Return canonical string representation for ``path``."""
-
         try:
             return str(path.resolve())
         except OSError:
@@ -108,7 +102,6 @@ class MainFrameDocumentsMixin:
 
     def _sync_mcp_base_path(self: MainFrame, path: Path) -> None:
         """Persist MCP base path and keep the running server in sync."""
-
         new_base_path = self._normalise_directory_path(path)
         if self.mcp_settings.base_path == new_base_path:
             return
@@ -148,7 +141,6 @@ class MainFrameDocumentsMixin:
 
     def _load_directory(self: MainFrame, path: Path) -> None:
         """Load requirements from ``path`` and update recent list."""
-
         factory = getattr(self, "requirements_service_factory", None)
         if factory is None:
             raise RuntimeError("Requirements service factory not configured")
@@ -202,7 +194,6 @@ class MainFrameDocumentsMixin:
 
     def _show_directory_error(self: MainFrame, path: Path, error: Exception) -> None:
         """Display error message for a failed directory load."""
-
         message = _(
             "Failed to load requirements folder \"{path}\": {error}"
         ).format(path=path, error=error)
@@ -215,7 +206,6 @@ class MainFrameDocumentsMixin:
         force_reload: bool = False,
     ) -> None:
         """Reload document tree and optionally change selection."""
-
         if not self.docs_controller:
             return
         docs = self.docs_controller.load_documents()
@@ -245,7 +235,6 @@ class MainFrameDocumentsMixin:
 
     def _load_document_contents(self: MainFrame, prefix: str) -> bool:
         """Load items and labels for ``prefix`` and update the views."""
-
         if not self.docs_controller:
             return False
         self._update_requirements_label()
@@ -337,7 +326,6 @@ class MainFrameDocumentsMixin:
 
     def on_new_document(self: MainFrame, parent_prefix: str | None) -> None:
         """Create a new document under ``parent_prefix``."""
-
         if not (self.docs_controller and self.current_dir):
             wx.MessageBox(_("Select requirements folder first"), _("No Data"))
             return
@@ -371,7 +359,6 @@ class MainFrameDocumentsMixin:
 
     def on_rename_document(self: MainFrame, prefix: str) -> None:
         """Rename or retitle document ``prefix``."""
-
         if not self.docs_controller:
             return
         doc = self.docs_controller.documents.get(prefix)
@@ -407,7 +394,6 @@ class MainFrameDocumentsMixin:
 
     def on_delete_document(self: MainFrame, prefix: str) -> None:
         """Delete document ``prefix`` after confirmation."""
-
         if not self.docs_controller:
             return
         doc = self.docs_controller.documents.get(prefix)
@@ -429,7 +415,6 @@ class MainFrameDocumentsMixin:
 
     def _on_doc_changing(self: MainFrame, event: wx.TreeEvent) -> None:
         """Request confirmation before switching documents."""
-
         if event.GetItem() == event.GetOldItem():
             event.Skip()
             return
@@ -441,7 +426,6 @@ class MainFrameDocumentsMixin:
 
     def on_document_selected(self: MainFrame, prefix: str) -> None:
         """Load items and labels for selected document ``prefix``."""
-
         if prefix == self.current_doc_prefix:
             return
         if not self.docs_controller:
@@ -453,7 +437,6 @@ class MainFrameDocumentsMixin:
 
     def on_import_requirements(self: MainFrame, _event: wx.Event) -> None:
         """Open the import dialog and persist selected requirements."""
-
         if not (self.docs_controller and self.current_doc_prefix and self.current_dir):
             wx.MessageBox(_("Select requirements folder first"), _("No Data"))
             return
@@ -558,7 +541,6 @@ class MainFrameDocumentsMixin:
 
     def on_manage_labels(self: MainFrame, _event: wx.Event) -> None:
         """Open dialog to manage defined labels."""
-
         if not (self.docs_controller and self.current_doc_prefix and self.current_dir):
             return
         doc = self.docs_controller.documents[self.current_doc_prefix]
@@ -576,7 +558,6 @@ class MainFrameDocumentsMixin:
 
     def on_show_derivation_graph(self: MainFrame, _event: wx.Event) -> None:
         """Open window displaying requirement derivation graph."""
-
         if not (self.current_dir and self.docs_controller):
             wx.MessageBox(_("Select requirements folder first"), _("No Data"))
             return
@@ -595,7 +576,6 @@ class MainFrameDocumentsMixin:
 
     def on_show_trace_matrix(self: MainFrame, _event: wx.Event) -> None:
         """Open window displaying requirement trace links."""
-
         if not (self.current_dir and self.docs_controller):
             wx.MessageBox(_("Select requirements folder first"), _("No Data"))
             return

--- a/app/ui/main_frame/editor.py
+++ b/app/ui/main_frame/editor.py
@@ -23,7 +23,6 @@ class MainFrameEditorMixin:
 
     def on_requirement_selected(self: MainFrame, event: wx.ListEvent) -> None:
         """Load requirement into editor when selected in list."""
-
         index = event.GetIndex()
         if index == wx.NOT_FOUND:
             return
@@ -46,7 +45,6 @@ class MainFrameEditorMixin:
 
     def on_requirement_activated(self: MainFrame, event: wx.ListEvent) -> None:
         """Open requirement in a detached editor when activated."""
-
         if self._is_editor_visible():
             event.Skip()
             return
@@ -111,7 +109,6 @@ class MainFrameEditorMixin:
 
     def _handle_editor_discard(self: MainFrame) -> bool:
         """Reload currently selected requirement into the editor."""
-
         if self._selected_requirement_id is None:
             return False
         requirement = self.model.get_by_id(self._selected_requirement_id)

--- a/app/ui/main_frame/frame.py
+++ b/app/ui/main_frame/frame.py
@@ -61,7 +61,6 @@ class MainFrame(
         mcp_factory: MCPControllerFactory | None = None,
     ) -> None:
         """Set up main application window and controllers."""
-
         self._base_title = "CookaReq"
         if context is None:
             raise ValueError("MainFrame requires an ApplicationContext instance")
@@ -143,7 +142,6 @@ class MainFrame(
     # initialization helpers
     def _init_icons(self) -> None:
         """Load platform icons into the frame."""
-
         with resources.as_file(
             resources.files("app.resources") / "app.ico",
         ) as icon_path:
@@ -152,7 +150,6 @@ class MainFrame(
 
     def _create_navigation(self) -> Navigation:
         """Build the navigation menus and toolbars."""
-
         return Navigation(
             self,
             self.config,
@@ -177,7 +174,6 @@ class MainFrame(
 
     def _assign_navigation_references(self) -> None:
         """Expose frequently used menu items as attributes."""
-
         self._recent_menu = self.navigation.recent_menu
         self.log_menu_item = self.navigation.log_menu_item
         self.hierarchy_menu_item = self.navigation.hierarchy_menu_item
@@ -187,7 +183,6 @@ class MainFrame(
 
     def _init_sections(self) -> None:
         """Construct hierarchy, list, editor and agent panels."""
-
         (
             self.doc_tree_container,
             self.doc_tree_label,

--- a/app/ui/main_frame/logging.py
+++ b/app/ui/main_frame/logging.py
@@ -43,7 +43,6 @@ class WxLogHandler(logging.Handler):
 
     def emit(self, record: logging.LogRecord) -> None:  # pragma: no cover - GUI side effect
         """Append formatted ``record`` text to the log console."""
-
         if not wx.GetApp():
             return
         msg = self.format(record)
@@ -51,7 +50,6 @@ class WxLogHandler(logging.Handler):
 
     def _append_message(self, message: str) -> None:
         """Render ``message`` in the target control respecting the size limit."""
-
         target = self._target
         if not target or target.IsBeingDeleted():
             return
@@ -77,7 +75,6 @@ class MainFrameLoggingMixin:
 
     def _init_log_console(self: MainFrame) -> None:
         """Create the log console panel and attach handler."""
-
         self.log_panel = SectionContainer(self.main_splitter)
         inner_panel = wx.Panel(self.log_panel)
         inherit_background(inner_panel, self.log_panel)
@@ -136,7 +133,6 @@ class MainFrameLoggingMixin:
     # log level handling
     def _log_level_options(self) -> list[tuple[str, int]]:
         """Return ordered pairs of localized labels and log levels."""
-
         return [
             (_("Debug"), logging.DEBUG),
             (_("Info"), logging.INFO),
@@ -146,7 +142,6 @@ class MainFrameLoggingMixin:
 
     def _populate_log_level_choice(self, selected_level: int | None = None) -> None:
         """Fill the level selector preserving the current ``selected_level``."""
-
         if not getattr(self, "log_level_choice", None):
             return
 
@@ -171,7 +166,6 @@ class MainFrameLoggingMixin:
 
     def _find_choice_index_for_level(self, level: int) -> int:
         """Return the closest matching index for ``level`` in the selector."""
-
         if not self._log_level_values:
             return -1
         if level in self._log_level_values:
@@ -183,7 +177,6 @@ class MainFrameLoggingMixin:
 
     def on_change_log_level(self, event: wx.CommandEvent) -> None:
         """Adjust the wx log handler level according to user selection."""
-
         if not getattr(self, "log_handler", None):
             return
         selection = event.GetSelection()
@@ -197,7 +190,6 @@ class MainFrameLoggingMixin:
     # visibility & labelling helpers
     def on_toggle_log_console(self, _event: wx.CommandEvent) -> None:
         """Toggle visibility of log console panel."""
-
         if self.navigation.log_menu_item.IsChecked():
             sash = self.config.get_log_sash(self.GetClientSize().height - 150)
             self.log_panel.Show()
@@ -211,7 +203,6 @@ class MainFrameLoggingMixin:
 
     def update_log_console_labels(self) -> None:
         """Refresh captions for logging controls according to locale."""
-
         if not getattr(self, "log_label", None):
             return
         self.log_label.SetLabel(_("Log Console"))
@@ -229,7 +220,6 @@ class MainFrameLoggingMixin:
     # clipboard interaction
     def on_copy_logs(self, event: wx.CommandEvent | None) -> None:
         """Copy current log console text to the clipboard."""
-
         console = getattr(self, "log_console", None)
         if console is None or console.IsBeingDeleted():
             return
@@ -254,7 +244,6 @@ class MainFrameLoggingMixin:
     # file system interaction
     def on_open_logs(self, _event: wx.CommandEvent) -> None:
         """Show the log directory in the system file browser."""
-
         from ...telemetry import log_event
 
         directory = get_log_directory()
@@ -271,6 +260,5 @@ class MainFrameLoggingMixin:
 
     def _detach_log_handler(self) -> None:
         """Remove the custom wx handler from the global logger."""
-
         if getattr(self, "log_handler", None) and self.log_handler in logger.handlers:
             logger.removeHandler(self.log_handler)

--- a/app/ui/main_frame/requirements.py
+++ b/app/ui/main_frame/requirements.py
@@ -26,7 +26,6 @@ class MainFrameRequirementsMixin:
 
     def on_toggle_column(self: MainFrame, event: wx.CommandEvent) -> None:
         """Show or hide column associated with menu item."""
-
         field = self.navigation.get_field_for_id(event.GetId())
         if not field:
             return
@@ -41,7 +40,6 @@ class MainFrameRequirementsMixin:
 
     def on_new_requirement(self: MainFrame, _event: wx.Event) -> None:
         """Create and persist a new requirement."""
-
         if not (self.docs_controller and self.current_doc_prefix):
             return
         new_id = self.docs_controller.next_item_id(self.current_doc_prefix)
@@ -60,7 +58,6 @@ class MainFrameRequirementsMixin:
 
     def on_clone_requirement(self: MainFrame, req_id: int) -> None:
         """Clone requirement ``req_id`` and open in editor."""
-
         if not (self.docs_controller and self.current_doc_prefix):
             return
         source = self.model.get_by_id(req_id)
@@ -131,7 +128,6 @@ class MainFrameRequirementsMixin:
 
     def on_derive_requirement(self: MainFrame, req_id: int) -> None:
         """Create a requirement derived from ``req_id`` and open it."""
-
         if not (self.docs_controller and self.current_doc_prefix):
             return
         source = self.model.get_by_id(req_id)
@@ -166,7 +162,6 @@ class MainFrameRequirementsMixin:
 
     def on_delete_requirements(self: MainFrame, req_ids: Sequence[int]) -> None:
         """Delete multiple requirements referenced by ``req_ids``."""
-
         if not req_ids:
             return
         if not (self.docs_controller and self.current_doc_prefix):
@@ -266,7 +261,6 @@ class MainFrameRequirementsMixin:
 
     def on_delete_requirement(self: MainFrame, req_id: int) -> None:
         """Delete requirement ``req_id`` and refresh views."""
-
         self.on_delete_requirements([req_id])
 
     def _on_sort_changed(self: MainFrame, column: int, ascending: bool) -> None:

--- a/app/ui/main_frame/sections.py
+++ b/app/ui/main_frame/sections.py
@@ -24,7 +24,6 @@ class MainFrameSectionsMixin:
 
     def _create_splitter(self, parent: wx.Window) -> wx.SplitterWindow:
         """Create a splitter with consistent styling and behaviour."""
-
         splitter = wx.SplitterWindow(parent)
         style_splitter(splitter)
         self._disable_splitter_unsplit(splitter)
@@ -41,7 +40,6 @@ class MainFrameSectionsMixin:
         padding: int = 0,
     ) -> tuple[wx.Panel, wx.StaticText, wx.Window]:
         """Build a titled container holding the widget returned by ``factory``."""
-
         container = SectionContainer(parent)
         background = container.GetBackgroundColour()
         sizer = wx.BoxSizer(wx.VERTICAL)
@@ -78,7 +76,6 @@ class MainFrameSectionsMixin:
     # visibility and localisation helpers
     def _apply_doc_tree_visibility(self: MainFrame, *, persist: bool) -> None:
         """Update hierarchy pane visibility based on the menu state."""
-
         if not getattr(self, "doc_splitter", None) or not getattr(self, "doc_tree_container", None):
             return
         if not self.hierarchy_menu_item:
@@ -115,19 +112,16 @@ class MainFrameSectionsMixin:
 
     def _is_doc_tree_visible(self: MainFrame) -> bool:
         """Return whether the hierarchy pane is currently shown."""
-
         return bool(self.hierarchy_menu_item and self.hierarchy_menu_item.IsChecked())
 
     def on_toggle_hierarchy(self: MainFrame, _event: wx.CommandEvent | None) -> None:
         """Handle hierarchy visibility toggles from the menu."""
-
         if not self.hierarchy_menu_item:
             return
         self._apply_doc_tree_visibility(persist=True)
 
     def _apply_agent_chat_visibility(self: MainFrame, *, persist: bool) -> None:
         """Update agent chat pane visibility based on the menu state."""
-
         if not self.agent_chat_menu_item:
             return
         shown = self.agent_chat_menu_item.IsChecked()
@@ -164,12 +158,10 @@ class MainFrameSectionsMixin:
 
     def _is_agent_chat_visible(self: MainFrame) -> bool:
         """Return whether the agent chat pane is currently shown."""
-
         return bool(self.agent_chat_menu_item and self.agent_chat_menu_item.IsChecked())
 
     def _show_editor_panel(self: MainFrame) -> None:
         """Display the editor section alongside its container."""
-
         if not self.splitter.IsSplit():
             sash = self.config.get_editor_sash(self._default_editor_sash())
             self.splitter.SplitVertically(
@@ -185,14 +177,12 @@ class MainFrameSectionsMixin:
 
     def _hide_editor_panel(self: MainFrame) -> None:
         """Hide the editor section and its container."""
-
         self.editor.Hide()
         self.editor_container.Hide()
         refresh_splitter_highlight(self.splitter)
 
     def _clear_editor_panel(self: MainFrame) -> None:
         """Reset editor contents and reflect current visibility setting."""
-
         if not getattr(self, "editor", None):
             return
         self.editor.new_requirement()
@@ -203,12 +193,10 @@ class MainFrameSectionsMixin:
 
     def _is_editor_visible(self: MainFrame) -> bool:
         """Return ``True`` when the main editor pane is enabled."""
-
         return bool(self.editor_menu_item and self.editor_menu_item.IsChecked())
 
     def _show_agent_section(self: MainFrame) -> None:
         """Display the agent chat section and ensure layout refresh."""
-
         self.agent_container.Show()
         self.agent_panel.Show()
         self.agent_container.Layout()
@@ -217,14 +205,12 @@ class MainFrameSectionsMixin:
 
     def _hide_agent_section(self: MainFrame) -> None:
         """Hide the agent chat widgets to free screen space."""
-
         self.agent_panel.Hide()
         self.agent_container.Hide()
         refresh_splitter_highlight(self.agent_splitter)
 
     def _update_section_labels(self: MainFrame) -> None:
         """Refresh captions for titled sections according to current locale."""
-
         self.doc_tree_label.SetLabel(_("Hierarchy"))
         self.editor_label.SetLabel(_("Editor"))
         self.agent_label.SetLabel(_("Agent Chat"))
@@ -236,7 +222,6 @@ class MainFrameSectionsMixin:
 
     def _confirm_discard_changes(self: MainFrame) -> bool:
         """Ask user to discard unsaved edits if editor has pending changes."""
-
         from . import confirm
 
         if not getattr(self, "editor", None):
@@ -309,7 +294,6 @@ class MainFrameSectionsMixin:
 
     def on_toggle_requirement_editor(self: MainFrame, _event: wx.CommandEvent) -> None:
         """Toggle visibility of the requirement editor pane."""
-
         if not self.editor_menu_item:
             return
         if (
@@ -324,7 +308,6 @@ class MainFrameSectionsMixin:
     # persistence helpers
     def _load_layout(self: MainFrame) -> None:
         """Restore window geometry, splitter, console, and column widths."""
-
         self.config.restore_layout(
             self,
             self.doc_splitter,
@@ -356,7 +339,6 @@ class MainFrameSectionsMixin:
 
     def _save_layout(self: MainFrame) -> None:
         """Persist window geometry, splitter, console, and column widths."""
-
         doc_tree_sash = (
             self.doc_splitter.GetSashPosition()
             if self.doc_splitter.IsSplit()
@@ -385,11 +367,9 @@ class MainFrameSectionsMixin:
     # splitter behaviour
     def _disable_splitter_unsplit(self: MainFrame, splitter: wx.SplitterWindow) -> None:
         """Attach handlers preventing ``splitter`` from unsplitting on double click."""
-
         splitter.Bind(wx.EVT_SPLITTER_DOUBLECLICKED, self._prevent_splitter_unsplit)
         splitter.Bind(wx.EVT_SPLITTER_DCLICK, self._prevent_splitter_unsplit)
 
     def _prevent_splitter_unsplit(self: MainFrame, event: wx.SplitterEvent) -> None:
         """Block attempts to unsplit panes initiated by double clicks."""
-
         event.Veto()

--- a/app/ui/main_frame/settings.py
+++ b/app/ui/main_frame/settings.py
@@ -20,7 +20,6 @@ class MainFrameSettingsMixin:
         _event: wx.Event,
     ) -> None:  # pragma: no cover - GUI event
         """Display settings dialog and apply changes."""
-
         from . import SettingsDialog
 
         dlg = SettingsDialog(

--- a/app/ui/main_frame/shutdown.py
+++ b/app/ui/main_frame/shutdown.py
@@ -20,7 +20,6 @@ class MainFrameShutdownMixin:
 
     def register_auxiliary_frame(self: MainFrame, frame: wx.Frame) -> None:
         """Ensure ``frame`` is configured to follow the main window lifecycle."""
-
         if frame is None:
             return
         def _ensure_destroy(event: wx.CloseEvent) -> None:  # pragma: no cover - GUI event
@@ -34,7 +33,6 @@ class MainFrameShutdownMixin:
 
     def _request_exit_main_loop(self: MainFrame) -> None:
         """Ask wx to terminate the main loop if it is still running."""
-
         app = wx.GetApp()
         if not app:
             return

--- a/app/ui/navigation.py
+++ b/app/ui/navigation.py
@@ -171,15 +171,12 @@ class Navigation:
 
     def update_recent_menu(self) -> None:
         """Refresh menu showing recently opened directories."""
-
         self._rebuild_recent_menu()
 
     def get_field_for_id(self, item_id: int) -> str | None:
         """Return field name associated with menu ``item_id``."""
-
         return self._column_items.get(item_id)
 
     def get_recent_path(self, item_id: int) -> Path | None:
         """Return path associated with recent-menu ``item_id``."""
-
         return self._recent_items.get(item_id)

--- a/app/ui/requirement_model.py
+++ b/app/ui/requirement_model.py
@@ -36,13 +36,11 @@ class RequirementModel:
 
     def add(self, requirement: Requirement) -> None:
         """Append ``requirement`` to the model."""
-
         self._all.append(requirement)
         self._refresh()
 
     def update(self, requirement: Requirement) -> None:
         """Replace existing requirement with same id or append new."""
-
         rid = requirement.id
         for i, req in enumerate(self._all):
             if req.id == rid:
@@ -54,7 +52,6 @@ class RequirementModel:
 
     def update_many(self, requirements: Sequence[Requirement]) -> None:
         """Replace or append multiple ``requirements`` in one refresh."""
-
         if not requirements:
             return
 
@@ -74,13 +71,11 @@ class RequirementModel:
 
     def delete(self, req_id: int) -> None:
         """Remove requirement with ``req_id``."""
-
         self._all = [r for r in self._all if r.id != req_id]
         self._refresh()
 
     def get_by_id(self, req_id: int) -> Requirement | None:
         """Return requirement with ``req_id`` or ``None``."""
-
         for req in self._all:
             if req.id == req_id:
                 return req
@@ -89,39 +84,33 @@ class RequirementModel:
     # filtering -------------------------------------------------------
     def set_label_filter(self, labels: list[str]) -> None:
         """Filter visible requirements by ``labels``."""
-
         self._labels = labels
         self._refresh()
 
     def set_label_match_all(self, match_all: bool) -> None:
         """Require all selected labels when ``match_all`` is ``True``."""
-
         self._labels_match_all = match_all
         self._refresh()
 
     def set_search_query(self, query: str, fields: Sequence[str] | None = None) -> None:
         """Set free-text ``query`` and optional fields to search."""
-
         self._query = query
         self._fields = fields
         self._refresh()
 
     def set_is_derived(self, value: bool) -> None:
         """Filter to requirements that are themselves derived."""
-
         self._is_derived = value
         self._refresh()
 
     def set_has_derived(self, value: bool) -> None:
         """Filter to requirements that have derived children."""
-
         self._has_derived = value
         self._refresh()
 
 
     def set_status(self, status: str | None) -> None:
         """Filter requirements by status code."""
-
         self._status = status
         self._refresh()
 
@@ -133,7 +122,6 @@ class RequirementModel:
     # sorting ---------------------------------------------------------
     def sort(self, field: str, ascending: bool = True) -> None:
         """Sort visible requirements by ``field``."""
-
         self._sort_field = field
         self._sort_ascending = ascending
         self._apply_sort()
@@ -179,10 +167,8 @@ class RequirementModel:
     # access ----------------------------------------------------------
     def get_visible(self) -> list[Requirement]:
         """Return currently visible requirements."""
-
         return list(self._visible)
 
     def get_all(self) -> list[Requirement]:
         """Return all requirements managed by the model."""
-
         return list(self._all)

--- a/app/ui/settings_dialog.py
+++ b/app/ui/settings_dialog.py
@@ -819,7 +819,6 @@ class SettingsDialog(wx.Dialog):
 
     def _on_browse_documents_path(self, _event: wx.Event) -> None:
         """Prompt the user to select a documentation directory."""
-
         current = self._documents_path.GetValue().strip()
         start_path = current or ""
         style = getattr(wx, "DD_DEFAULT_STYLE", 0) | getattr(
@@ -841,17 +840,14 @@ class SettingsDialog(wx.Dialog):
 
     def _on_documents_path_edited(self, _event: wx.Event) -> None:
         """Refresh documentation hint when related paths change."""
-
         self._refresh_documents_hint()
 
     def _on_documents_read_limit_changed(self, _event: wx.Event) -> None:
         """Keep the documentation hint in sync with the read limit spinner."""
-
         self._refresh_documents_hint()
 
     def _refresh_documents_hint(self) -> None:
         """Update the absolute documentation path preview and validation colour."""
-
         base_text = self._base_path.GetValue().strip()
         documents_text = self._documents_path.GetValue().strip()
         description = describe_documents_root(base_text, documents_text)

--- a/app/ui/settings_dialog.py
+++ b/app/ui/settings_dialog.py
@@ -16,7 +16,7 @@ from ..llm.constants import (
 )
 from ..mcp.client import MCPClient
 from ..mcp.controller import MCPController, MCPStatus
-from ..mcp.paths import describe_documents_root, resolve_documents_root
+from ..mcp.paths import describe_documents_root
 from ..settings import (
     LLMSettings,
     MCPSettings,

--- a/app/ui/splitter_utils.py
+++ b/app/ui/splitter_utils.py
@@ -17,7 +17,6 @@ class SplitterEventBlocker:
     @contextmanager
     def pause(self) -> Iterator[None]:
         """Temporarily increment the guard depth while yielding control."""
-
         self._depth += 1
         try:
             yield
@@ -27,7 +26,6 @@ class SplitterEventBlocker:
     @property
     def active(self) -> bool:
         """Return ``True`` when callbacks should be ignored."""
-
         return self._depth > 0
 
 _DEFAULT_SASH_THICKNESS_DIP = 6
@@ -42,7 +40,6 @@ def style_splitter(
     thickness: int | None = None,
 ) -> None:
     """Highlight ``splitter`` so the draggable sash is easy to find."""
-
     if not splitter:
         return
     accent = _resolve_colour(splitter, sash_colour)
@@ -58,7 +55,6 @@ def style_splitter(
 
 def refresh_splitter_highlight(splitter: wx.SplitterWindow) -> None:
     """Force ``splitter`` to repaint its sash highlight if configured."""
-
     helper = getattr(splitter, "_cooka_splitter_highlight", None)
     if helper is not None:
         helper.refresh()

--- a/app/ui/text.py
+++ b/app/ui/text.py
@@ -23,7 +23,6 @@ _DIRECT_TRANSLATIONS: dict[str, str] = {
 
 def normalize_for_display(value: str) -> str:
     """Return *value* with punctuation normalised for safer rendering."""
-
     if not value:
         return value
 

--- a/app/ui/trace_matrix.py
+++ b/app/ui/trace_matrix.py
@@ -459,7 +459,6 @@ class TraceMatrixFrame(wx.Frame):
     # sizing ----------------------------------------------------------
     def _configure_grid_dimensions(self, table: TraceMatrixTable) -> None:
         """Adapt grid label and cell sizes to the current dataset."""
-
         row_label_min = self.FromDIP(220)
         row_label_max = self.FromDIP(420)
         column_min = self.FromDIP(90)

--- a/app/ui/widgets/markdown_view.py
+++ b/app/ui/widgets/markdown_view.py
@@ -106,7 +106,6 @@ class MarkdownView(html.HtmlWindow):
 
     def SetMarkdown(self, markdown_text: str) -> None:
         """Update control contents with *markdown_text*."""
-
         self._markdown = markdown_text
         html_markup = self._wrap_html(_render_markdown(markdown_text))
         html_markup = normalize_for_display(html_markup)
@@ -282,7 +281,6 @@ class MarkdownContent(wx.Panel):
 
     def SetMarkdown(self, markdown: str) -> None:
         """Forward updated markdown to the underlying view."""
-
         self._view.SetMarkdown(markdown)
 
     def SelectAll(self) -> None:  # noqa: N802 - wx naming convention

--- a/app/ui/widgets/section_container.py
+++ b/app/ui/widgets/section_container.py
@@ -33,7 +33,6 @@ class SectionContainer(wx.Panel):
 
     def SetBackgroundColour(self, colour: wx.Colour | wx.ColourBase) -> bool:  # type: ignore[override]
         """Ensure chrome colours follow the panel background."""
-
         changed = super().SetBackgroundColour(colour)
         if changed and self._chrome:
             self._chrome.refresh_palette()

--- a/app/util/cancellation.py
+++ b/app/util/cancellation.py
@@ -22,38 +22,31 @@ class CancellationEvent:
     @property
     def cancelled(self) -> bool:
         """Return ``True`` when cancellation has been requested."""
-
         return self._event.is_set()
 
     def is_set(self) -> bool:
         """Expose :meth:`threading.Event.is_set`."""
-
         return self._event.is_set()
 
     def set(self) -> None:
         """Signal cancellation."""
-
         self._event.set()
 
     def wait(self, timeout: float | None = None) -> bool:
         """Block until cancellation occurs or *timeout* elapses."""
-
         return self._event.wait(timeout)
 
     def clear(self) -> None:
         """Reset the event; used in tests to simulate reuse."""
-
         self._event.clear()
 
     def raise_if_cancelled(self) -> None:
         """Raise :class:`OperationCancelledError` if cancellation occurred."""
-
         if self._event.is_set():
             raise OperationCancelledError()
 
 
 def raise_if_cancelled(cancellation: CancellationEvent | None) -> None:
     """Convenience helper raising when *cancellation* has been signalled."""
-
     if cancellation is not None:
         cancellation.raise_if_cancelled()

--- a/app/util/json.py
+++ b/app/util/json.py
@@ -34,7 +34,6 @@ def make_json_safe(
         Fallback callable used for unsupported objects. Defaults to
         :func:`repr` to match :mod:`json` behaviour.
     """
-
     if default is None:
         default = repr
 

--- a/app/util/time.py
+++ b/app/util/time.py
@@ -24,7 +24,6 @@ def normalize_timestamp(value: str | None) -> str:
     while datetime strings are converted to ``YYYY-MM-DD HH:MM:SS`` format with
     microseconds discarded. Invalid values raise :class:`ValueError`.
     """
-
     if not value:
         return ""
 

--- a/tests/gui/test_agent_chat_performance.py
+++ b/tests/gui/test_agent_chat_performance.py
@@ -155,7 +155,7 @@ def test_transcript_panels_reused_between_switches(tmp_path, wx_app):
             cache_after.panels_by_entry[key] for key in cache_after.order
         ]
         assert len(second_panels) == len(first_panels)
-        for original, restored in zip(first_panels, second_panels):
+        for original, restored in zip(first_panels, second_panels, strict=False):
             assert restored is original
     finally:
         destroy_panel(frame, panel)

--- a/tests/gui/test_editor_duplicate_id.py
+++ b/tests/gui/test_editor_duplicate_id.py
@@ -37,6 +37,7 @@ def test_editor_save_rejects_duplicate_id(monkeypatch, wx_app, tmp_path: Path) -
     doc_dir = tmp_path / "SYS"
     service = RequirementsService(tmp_path)
     service.save_document(doc)
+    assert doc_dir.exists()
     service.save_requirement_payload("SYS", requirement_to_dict(_make_requirement(1)))
 
     frame = wx.Frame(None)

--- a/tests/integration/test_llm_openrouter_transcript_logs.py
+++ b/tests/integration/test_llm_openrouter_transcript_logs.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 import os
 from pathlib import Path
-from typing import Sequence
+from collections.abc import Sequence
 
 import pytest
 
@@ -95,7 +95,7 @@ def test_openrouter_transcript_logs(tmp_path, target_language):
     normalized_reasoning = normalise_reasoning_segments(response.reasoning)
     assert normalized_reasoning, "model did not return reasoning segments"
     types = [segment["type"] for segment in normalized_reasoning]
-    assert all(prev != curr for prev, curr in zip(types, types[1:]))
+    assert all(prev != curr for prev, curr in zip(types, types[1:], strict=False))
 
     conversation_history = ChatConversation.new()
     timestamp = utc_now_iso()

--- a/tests/integration/test_mcp_client.py
+++ b/tests/integration/test_mcp_client.py
@@ -4,10 +4,6 @@ import json
 import logging
 from pathlib import Path
 
-import json
-import logging
-from pathlib import Path
-
 import pytest
 
 from app.log import logger

--- a/tests/integration/test_mcp_server.py
+++ b/tests/integration/test_mcp_server.py
@@ -2,8 +2,6 @@
 
 import json
 import logging
-import json
-import logging
 from pathlib import Path
 
 import pytest

--- a/tests/unit/llm/factories.py
+++ b/tests/unit/llm/factories.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from types import SimpleNamespace
-from typing import Any, Mapping, Sequence
+from typing import Any
 
 from app.llm.request_builder import PreparedChatRequest
 from app.llm.types import LLMResponse

--- a/tests/unit/llm/test_llm_client_arguments.py
+++ b/tests/unit/llm/test_llm_client_arguments.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from collections.abc import Iterable, Mapping
+from collections.abc import Mapping
 from typing import Any
 
 from openai.types.responses.response_function_tool_call import (

--- a/tests/unit/test_agent_chat_log_export.py
+++ b/tests/unit/test_agent_chat_log_export.py
@@ -1,5 +1,5 @@
 import json
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 from app.llm.spec import SYSTEM_PROMPT
 from app.ui.agent_chat_panel.log_export import (
@@ -16,7 +16,7 @@ _SYSTEM_PROMPT_TEXT = str(SYSTEM_PROMPT).strip()
 def _iso(ts: str) -> str:
     """Return ISO8601 timestamp for tests."""
 
-    return datetime.fromisoformat(ts).astimezone(timezone.utc).isoformat()
+    return datetime.fromisoformat(ts).astimezone(UTC).isoformat()
 
 
 def _build_tool_payloads() -> list[dict[str, object]]:

--- a/tests/unit/test_agent_debug_logging.py
+++ b/tests/unit/test_agent_debug_logging.py
@@ -1,5 +1,6 @@
 import asyncio
-from typing import Any, Mapping, Sequence
+from collections.abc import Mapping, Sequence
+from typing import Any
 
 import pytest
 
@@ -107,7 +108,7 @@ def test_execute_tool_calls_logs_full_exchange(
         agent._execute_tool_calls_core((tool_call,))
     )
 
-    assert not messages[0]["content"] == ""
+    assert messages[0]["content"] != ""
     assert error_payload is None
     assert successful and successful[0]["ok"] is True
 


### PR DESCRIPTION
## Summary
- add comprehensive docstrings across LLM response parsing helpers and remove post-docstring padding
- document MCP client/controller utilities and normalize docstring spacing throughout tools and telemetry helpers
- tidy agent chat utilities and tests by removing unused imports, adding targeted docstrings, and replacing ad-hoc try/except blocks with contextlib.suppress

## Testing
- pytest --suite service -q *(fails: repository still contains widespread legacy pydocstyle/ruff violations under app/ui and related modules)*

------
https://chatgpt.com/codex/tasks/task_e_68e61ed56d0483208bada430e120706b