### PR TITLE
Adjust tool bubble accent palette

### DIFF
--- a/app/ui/widgets/chat_message.py
+++ b/app/ui/widgets/chat_message.py
@@ -108,9 +108,9 @@ _TOOL_ACCENT_COLOURS: tuple[wx.Colour, ...] = (
     wx.Colour(196, 221, 255),
     wx.Colour(202, 242, 255),
     wx.Colour(210, 245, 221),
-    wx.Colour(255, 232, 206),
-    wx.Colour(244, 224, 255),
-    wx.Colour(255, 226, 235),
+    wx.Colour(235, 244, 215),
+    wx.Colour(229, 241, 255),
+    wx.Colour(224, 239, 246),
 )
 
 


### PR DESCRIPTION
## Summary
- replace the red/pink entries in the tool call bubble palette with calmer blue and green accents

## Testing
- pytest --suite core -q -m "not gui"

------
https://chatgpt.com/codex/tasks/task_e_68e67bba79188320872fa4f3eb8b2ae1