### PR TITLE
Убрать дублирующиеся суффиксы _rev в имени ZIP-экспорта проекта

### DIFF
--- a/app/core/project_archive.py
+++ b/app/core/project_archive.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from collections.abc import Mapping
 from datetime import date
 from pathlib import Path
+import re
 from zipfile import ZIP_DEFLATED, ZipFile
 
 from .document_store import Document, get_document_revision
@@ -14,6 +15,8 @@ __all__ = [
     "create_project_archive",
     "resolve_root_document_prefix",
 ]
+
+_ARCHIVE_SUFFIX_RE = re.compile(r"(?:_rev\d+_\d{8})+$")
 
 
 def resolve_root_document_prefix(
@@ -53,7 +56,8 @@ def build_project_archive_name(
         root_doc = docs.get(root_prefix)
         if root_doc is not None:
             revision = get_document_revision(root_doc)
-    safe_name = project_dir.name.strip() or "requirements"
+    raw_name = project_dir.name.strip() or "requirements"
+    safe_name = _ARCHIVE_SUFFIX_RE.sub("", raw_name).strip() or "requirements"
     return f"{safe_name}_rev{revision}_{archive_date:%Y%m%d}.zip"
 
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -158,7 +158,10 @@ pipeline, fallback cleanup, and regression coverage strategy), see
   such as `.cookareq` and every document subtree) into a user-selected archive.
   The suggested archive file name is generated from the opened project
   directory name, the top-level document revision (`doc_revision`) and current
-  date to keep snapshots traceable.
+  date to keep snapshots traceable. If the opened directory already looks like
+  a previous archive export (`*_revNNN_YYYYMMDD`), the suffix is stripped before
+  composing a new name so repeated exports do not accumulate duplicated
+  revision/date tails.
 
 ## Application services and configuration context
 

--- a/tests/unit/test_project_archive.py
+++ b/tests/unit/test_project_archive.py
@@ -41,6 +41,20 @@ def test_build_project_archive_name_uses_root_revision_and_date() -> None:
     assert name == "MyProject_rev7_20260331.zip"
 
 
+def test_build_project_archive_name_strips_previous_archive_suffixes() -> None:
+    docs = {
+        "SYS": Document(prefix="SYS", title="System", attributes={"doc_revision": 237}),
+    }
+    name = build_project_archive_name(
+        project_dir=Path("/tmp/Требования CookaReq Проект_rev237_20260407"),
+        docs=docs,
+        current_prefix="SYS",
+        today=date(2026, 4, 14),
+    )
+
+    assert name == "Требования CookaReq Проект_rev237_20260414.zip"
+
+
 def test_create_project_archive_includes_documents_and_hidden_internal_folder(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
### Motivation
- При повторном экспорте из уже экспортированной папки имя архива копилось с хвостами вида `_rev<число>_<YYYYMMDD>` и получалось длинное повторяющееся окончание (например `..._rev237_20260407_rev237_20260414`).
- Цель — нормализовать базовое имя проекта перед добавлением нового суффикса, чтобы повторные экспорты не накапливали хвосты.
- Поиск места генерации имени потребовал дополнительного времени, так как код экспорта разбросан по проекту и нужно было точно найти функцию `build_project_archive_name`.

### Description
- Добавлен регулярный паттерн `_ARCHIVE_SUFFIX_RE = re.compile(r"(?:_rev\d+_\d{8})+$")` и логика, которая перед формированием финального имени удаляет уже существующие хвосты в имени каталога и использует результат как `safe_name` (файл `app/core/project_archive.py`).
- Сохранён fallback на `"requirements"`, если после очистки имя получится пустым; исходная логика ревизии/даты не изменилась и итоговый формат остаётся `..._rev{revision}_{YYYYMMDD}.zip`.
- Добавлен unit-тест `test_build_project_archive_name_strips_previous_archive_suffixes` в `tests/unit/test_project_archive.py`, покрывающий сценарий с кириллическим именем каталога, который ранее приводил к накоплению хвостов.
- Обновлена документация в `docs/ARCHITECTURE.md` с описанием новой нормализации имени при повторных экспортных циклах.

### Testing
- Запущен таргетный набор тестов: `python3 -m pytest --suite core tests/unit/test_project_archive.py -q` и все тесты прошли успешно (4 passed).
- Модификации покрыты добавленным unit-тестом, который проверяет удаление предыдущего суффикса и формирование нового имени.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ddf0e6b8c08320b2844cc90046b3e2)