### PR TITLE
Add multi-document export scope and manual document selection to export dialog

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -75,6 +75,8 @@ class ExportDialogState:
     card_sort_mode: str | None
     card_label_group_mode: str | None = None
     export_scope: str | None = None
+    document_scope: str | None = None
+    selected_document_prefixes: list[str] | None = None
     colorize_label_backgrounds: bool = False
     docx_include_requirement_heading: bool = True
     generate_context_docs_preface: bool = False
@@ -506,6 +508,16 @@ class ConfigManager:
         export_scope = payload.get("export_scope")
         if not isinstance(export_scope, str):
             export_scope = None
+        document_scope = payload.get("document_scope")
+        if not isinstance(document_scope, str):
+            document_scope = None
+        selected_document_prefixes_raw = payload.get("selected_document_prefixes")
+        if not isinstance(selected_document_prefixes_raw, list):
+            selected_document_prefixes: list[str] = []
+        else:
+            selected_document_prefixes = [
+                str(item) for item in selected_document_prefixes_raw if item
+            ]
         colorize_label_backgrounds = payload.get("colorize_label_backgrounds")
         if not isinstance(colorize_label_backgrounds, bool):
             colorize_label_backgrounds = False
@@ -528,6 +540,8 @@ class ConfigManager:
             card_sort_mode=card_sort_mode,
             card_label_group_mode=card_label_group_mode,
             export_scope=export_scope,
+            document_scope=document_scope,
+            selected_document_prefixes=selected_document_prefixes,
             colorize_label_backgrounds=colorize_label_backgrounds,
             docx_include_requirement_heading=docx_include_requirement_heading,
             generate_context_docs_preface=generate_context_docs_preface,
@@ -549,6 +563,8 @@ class ConfigManager:
             "card_sort_mode": state.card_sort_mode,
             "card_label_group_mode": state.card_label_group_mode,
             "export_scope": state.export_scope,
+            "document_scope": state.document_scope,
+            "selected_document_prefixes": list(state.selected_document_prefixes or []),
             "colorize_label_backgrounds": state.colorize_label_backgrounds,
             "docx_include_requirement_heading": state.docx_include_requirement_heading,
             "generate_context_docs_preface": state.generate_context_docs_preface,

--- a/app/core/requirement_export.py
+++ b/app/core/requirement_export.py
@@ -493,6 +493,11 @@ def render_requirements_markdown(
 ) -> str:
     """Render export data as Markdown."""
     selected_fields = _normalize_export_fields(fields)
+    rendered_rids = {
+        view.requirement.rid
+        for doc in export.documents
+        for view in doc.requirements
+    }
     heading = title or _('Requirements export')
     parts: list[str] = [f"# {heading}", ""]
     parts.append(
@@ -580,13 +585,15 @@ def render_requirements_markdown(
                     parts.append(f"**{_('Related requirements')}**")
                     for link in view.links:
                         label = link.rid
-                        if link.exists:
+                        if link.exists and link.rid in rendered_rids:
                             label = f"[{link.rid}](#{link.rid})"
                         suffix: list[str] = []
                         if link.title:
                             suffix.append(link.title)
                         if not link.exists:
                             suffix.append(_('missing'))
+                        elif link.rid not in rendered_rids:
+                            suffix.append(_('outside exported scope'))
                         if link.suspect:
                             suffix.append(_('suspect'))
                         if suffix:

--- a/app/locale/en/LC_MESSAGES/CookaReq.po
+++ b/app/locale/en/LC_MESSAGES/CookaReq.po
@@ -3404,3 +3404,33 @@ msgstr "Edit RID: {prefix}"
 
 msgid "(no prefix)"
 msgstr "(no prefix)"
+
+msgid "Document scope"
+msgstr "Document scope"
+
+msgid "Current document"
+msgstr "Current document"
+
+msgid "Current document subtree"
+msgstr "Current document subtree"
+
+msgid "All project documents"
+msgstr "All project documents"
+
+msgid "Selected documents"
+msgstr "Selected documents"
+
+msgid "Documents for manual selection"
+msgstr "Documents for manual selection"
+
+msgid "Choose at least one document to export."
+msgstr "Choose at least one document to export."
+
+msgid "No documents selected for export."
+msgstr "No documents selected for export."
+
+msgid "Requirements export — multiple documents"
+msgstr "Requirements export — multiple documents"
+
+msgid "Document {prefix} revision: {value}"
+msgstr "Document {prefix} revision: {value}"

--- a/app/locale/ru/LC_MESSAGES/CookaReq.po
+++ b/app/locale/ru/LC_MESSAGES/CookaReq.po
@@ -3424,3 +3424,33 @@ msgstr "Изменение RID: {prefix}"
 
 msgid "(no prefix)"
 msgstr "(без префикса)"
+
+msgid "Document scope"
+msgstr "Охват документов"
+
+msgid "Current document"
+msgstr "Текущий документ"
+
+msgid "Current document subtree"
+msgstr "Поддерево текущего документа"
+
+msgid "All project documents"
+msgstr "Все документы проекта"
+
+msgid "Selected documents"
+msgstr "Выбранные документы"
+
+msgid "Documents for manual selection"
+msgstr "Документы для ручного выбора"
+
+msgid "Choose at least one document to export."
+msgstr "Выберите хотя бы один документ для экспорта."
+
+msgid "No documents selected for export."
+msgstr "Не выбраны документы для экспорта."
+
+msgid "Requirements export — multiple documents"
+msgstr "Экспорт требований — несколько документов"
+
+msgid "Document {prefix} revision: {value}"
+msgstr "Ревизия документа {prefix}: {value}"

--- a/app/ui/export_dialog.py
+++ b/app/ui/export_dialog.py
@@ -37,6 +37,8 @@ class RequirementExportPlan:
     card_sort_mode: str
     card_label_group_mode: str
     export_scope: Literal["all", "visible", "selected"]
+    document_scope: Literal["current", "subtree", "all", "manual"]
+    selected_document_prefixes: list[str]
     colorize_label_backgrounds: bool
     docx_include_requirement_heading: bool
     generate_context_docs_preface: bool
@@ -106,6 +108,9 @@ class RequirementExportDialog(wx.Dialog):
         default_path: Path | None = None,
         saved_state: ExportDialogState | None = None,
         default_export_scope: Literal["all", "visible", "selected"] = "all",
+        available_documents: list[tuple[str, str]] | None = None,
+        default_document_scope: Literal["current", "subtree", "all", "manual"] = "all",
+        current_document_prefix: str | None = None,
     ) -> None:
         title = _("Export Requirements")
         super().__init__(parent, title=title, style=wx.DEFAULT_DIALOG_STYLE | wx.RESIZE_BORDER)
@@ -154,6 +159,23 @@ class RequirementExportDialog(wx.Dialog):
         self._export_scope = self._coerce_export_scope(
             saved_state.export_scope if saved_state else self._default_export_scope
         )
+        self._documents = self._normalize_documents(available_documents or [])
+        self._current_document_prefix = (
+            current_document_prefix
+            if current_document_prefix in {prefix for prefix, _ in self._documents}
+            else None
+        )
+        self._default_document_scope: Literal["current", "subtree", "all", "manual"] = (
+            default_document_scope
+            if default_document_scope in {"current", "subtree", "all", "manual"}
+            else "all"
+        )
+        self._document_scope = self._coerce_document_scope(
+            saved_state.document_scope if saved_state else self._default_document_scope
+        )
+        self._saved_document_prefixes = self._normalize_selected_document_prefixes(
+            saved_state.selected_document_prefixes if saved_state else None
+        )
         self._txt_placeholder_label = _("(not set)")
         self._drag_start_index: int | None = None
 
@@ -191,6 +213,35 @@ class RequirementExportDialog(wx.Dialog):
                 continue
             seen.add(field)
             ordered.append(field)
+        return ordered
+
+    def _normalize_documents(self, documents: list[tuple[str, str]]) -> list[tuple[str, str]]:
+        normalized: list[tuple[str, str]] = []
+        seen: set[str] = set()
+        for prefix, label in documents:
+            prefix_value = str(prefix).strip()
+            if not prefix_value or prefix_value in seen:
+                continue
+            seen.add(prefix_value)
+            title_value = str(label).strip() if label is not None else ""
+            normalized.append((prefix_value, title_value or prefix_value))
+        return normalized
+
+    def _normalize_selected_document_prefixes(
+        self,
+        values: list[str] | None,
+    ) -> list[str]:
+        if not values:
+            return []
+        available = {prefix for prefix, _ in self._documents}
+        ordered: list[str] = []
+        seen: set[str] = set()
+        for value in values:
+            prefix = str(value).strip()
+            if not prefix or prefix in seen or prefix not in available:
+                continue
+            seen.add(prefix)
+            ordered.append(prefix)
         return ordered
 
     def _build_default_selected(
@@ -287,6 +338,29 @@ class RequirementExportDialog(wx.Dialog):
         )
         self._apply_export_scope_choice()
 
+        self.document_scope_choice = wx.RadioBox(
+            self,
+            label=_("Document scope"),
+            choices=[
+                _("Current document"),
+                _("Current document subtree"),
+                _("All project documents"),
+                _("Selected documents"),
+            ],
+            majorDimension=1,
+            style=wx.RA_SPECIFY_ROWS,
+        )
+        self._apply_document_scope_choice()
+        self.document_list_label = wx.StaticText(
+            self,
+            label=_("Documents for manual selection"),
+        )
+        self.document_list = wx.CheckListBox(
+            self,
+            choices=[label for _, label in self._documents],
+        )
+        self._apply_selected_documents()
+
         self.columns_box = wx.StaticBox(self, label=_("Columns"))
         self.column_list = wx.CheckListBox(self.columns_box)
 
@@ -378,6 +452,8 @@ class RequirementExportDialog(wx.Dialog):
         self.file_picker.Bind(wx.EVT_FILEPICKER_CHANGED, self._on_path_changed)
         self.format_choice.Bind(wx.EVT_RADIOBOX, self._on_format_changed)
         self.scope_choice.Bind(wx.EVT_RADIOBOX, self._on_scope_changed)
+        self.document_scope_choice.Bind(wx.EVT_RADIOBOX, self._on_document_scope_changed)
+        self.document_list.Bind(wx.EVT_CHECKLISTBOX, self._on_document_selection_changed)
         self.column_list.Bind(wx.EVT_CHECKLISTBOX, self._on_columns_changed)
         self.card_sort_choice.Bind(wx.EVT_CHOICE, self._on_card_sort_changed)
         self.column_list.Bind(wx.EVT_LEFT_DOWN, self._on_column_left_down)
@@ -408,6 +484,9 @@ class RequirementExportDialog(wx.Dialog):
         path_sizer.Add(self.path_display, 1, wx.EXPAND)
         main_sizer.Add(path_sizer, 0, wx.EXPAND | wx.LEFT | wx.RIGHT | wx.BOTTOM, 10)
         main_sizer.Add(self.format_choice, 0, wx.EXPAND | wx.LEFT | wx.RIGHT, 10)
+        main_sizer.Add(self.document_scope_choice, 0, wx.EXPAND | wx.LEFT | wx.RIGHT | wx.TOP, 10)
+        main_sizer.Add(self.document_list_label, 0, wx.LEFT | wx.RIGHT | wx.TOP, 10)
+        main_sizer.Add(self.document_list, 0, wx.EXPAND | wx.LEFT | wx.RIGHT | wx.TOP, 6)
         main_sizer.Add(self.scope_choice, 0, wx.EXPAND | wx.LEFT | wx.RIGHT | wx.TOP, 10)
 
         txt_options_sizer = wx.StaticBoxSizer(self.txt_options_box, wx.VERTICAL)
@@ -473,6 +552,8 @@ class RequirementExportDialog(wx.Dialog):
         self._txt_options_sizer = txt_options_sizer
         self._columns_sizer = columns_sizer
         self._docx_options_sizer = docx_options_sizer
+        self._update_document_selection_state()
+        self._update_requirement_scope_state()
 
     # ------------------------------------------------------------------
     def _refresh_checklist(self, *, keep_selection: int | None = None) -> None:
@@ -507,9 +588,12 @@ class RequirementExportDialog(wx.Dialog):
             return
         path = self.file_picker.GetPath()
         has_path = bool(path)
+        has_documents = True
+        if self._selected_document_scope() == "manual":
+            has_documents = bool(self._selected_document_prefixes())
         require_columns = not self._can_export_without_columns()
         has_columns = bool(self._checked_fields()) if require_columns else True
-        self.ok_button.Enable(has_path and has_columns)
+        self.ok_button.Enable(has_path and has_columns and has_documents)
 
     def _can_export_without_columns(self) -> bool:
         return (
@@ -539,6 +623,67 @@ class RequirementExportDialog(wx.Dialog):
         self._main_sizer.Show(self._docx_options_sizer, is_docx, recursive=True)
         self._main_sizer.Layout()
 
+    def _coerce_document_scope(
+        self,
+        value: str | None,
+    ) -> Literal["current", "subtree", "all", "manual"]:
+        if value in {"current", "subtree", "all", "manual"}:
+            return value
+        return self._default_document_scope
+
+    def _apply_document_scope_choice(self) -> None:
+        selection_map = {
+            "current": 0,
+            "subtree": 1,
+            "all": 2,
+            "manual": 3,
+        }
+        self.document_scope_choice.SetSelection(selection_map.get(self._document_scope, 2))
+
+    def _selected_document_scope(self) -> Literal["current", "subtree", "all", "manual"]:
+        selection = self.document_scope_choice.GetSelection()
+        if selection == 0:
+            return "current"
+        if selection == 1:
+            return "subtree"
+        if selection == 3:
+            return "manual"
+        return "all"
+
+    def _apply_selected_documents(self) -> None:
+        selected = set(self._saved_document_prefixes)
+        if not selected and self._current_document_prefix:
+            selected.add(self._current_document_prefix)
+        for index, (prefix, _label) in enumerate(self._documents):
+            self.document_list.Check(index, prefix in selected)
+
+    def _selected_document_prefixes(self) -> list[str]:
+        checked_indexes = set(self.document_list.GetCheckedItems())
+        return [
+            prefix
+            for index, (prefix, _label) in enumerate(self._documents)
+            if index in checked_indexes
+        ]
+
+    def _update_document_selection_state(self) -> None:
+        manual = self._selected_document_scope() == "manual"
+        has_docs = bool(self._documents)
+        self.document_list_label.Show(manual and has_docs)
+        self.document_list.Show(manual and has_docs)
+        self.document_list.Enable(manual and has_docs)
+        if manual and has_docs and not self._selected_document_prefixes():
+            self.document_list.Check(0, True)
+        self._main_sizer.Layout()
+
+    def _update_requirement_scope_state(self) -> None:
+        if not self._documents:
+            self.scope_choice.Enable(True)
+            return
+        single_document_scope = self._selected_document_scope() == "current"
+        self.scope_choice.Enable(single_document_scope)
+        if not single_document_scope:
+            self.scope_choice.SetSelection(0)
+
     def _coerce_export_scope(self, value: str | None) -> Literal["all", "visible", "selected"]:
         if value in {"all", "visible", "selected"}:
             return value
@@ -553,6 +698,8 @@ class RequirementExportDialog(wx.Dialog):
         self.scope_choice.SetSelection(selection_map.get(self._export_scope, 0))
 
     def _selected_export_scope(self) -> Literal["all", "visible", "selected"]:
+        if self._documents and self._selected_document_scope() != "current":
+            return "all"
         selection = self.scope_choice.GetSelection()
         if selection == 1:
             return "visible"
@@ -685,6 +832,14 @@ class RequirementExportDialog(wx.Dialog):
     def _on_scope_changed(self, _event: wx.CommandEvent) -> None:
         self._update_ok_state()
 
+    def _on_document_scope_changed(self, _event: wx.CommandEvent) -> None:
+        self._update_document_selection_state()
+        self._update_requirement_scope_state()
+        self._update_ok_state()
+
+    def _on_document_selection_changed(self, _event: wx.CommandEvent) -> None:
+        self._update_ok_state()
+
     def _on_card_sort_changed(self, _event: wx.CommandEvent) -> None:
         self._update_label_grouping_state()
         self._update_context_docs_preface_state()
@@ -746,6 +901,9 @@ class RequirementExportDialog(wx.Dialog):
         if not self.file_picker.GetPath():
             wx.MessageBox(_("Select export file first."), _("Export blocked"))
             return
+        if self._selected_document_scope() == "manual" and not self._selected_document_prefixes():
+            wx.MessageBox(_("Choose at least one document to export."), _("Export blocked"))
+            return
         if not self._checked_fields() and not self._can_export_without_columns():
             wx.MessageBox(_("Choose at least one column to export."), _("Export blocked"))
             return
@@ -755,6 +913,8 @@ class RequirementExportDialog(wx.Dialog):
     def get_plan(self) -> RequirementExportPlan | None:
         path = self.file_picker.GetPath()
         if not path:
+            return None
+        if self._selected_document_scope() == "manual" and not self._selected_document_prefixes():
             return None
         columns = self._checked_fields()
         if not columns and not self._can_export_without_columns():
@@ -777,6 +937,8 @@ class RequirementExportDialog(wx.Dialog):
             card_sort_mode=self._selected_card_sort_mode(),
             card_label_group_mode=self._selected_card_label_group_mode(),
             export_scope=self._selected_export_scope(),
+            document_scope=self._selected_document_scope(),
+            selected_document_prefixes=self._selected_document_prefixes(),
             colorize_label_backgrounds=self.colorize_label_backgrounds_checkbox.GetValue(),
             docx_include_requirement_heading=self.docx_include_requirement_heading_checkbox.GetValue(),
             generate_context_docs_preface=self.context_docs_preface_checkbox.GetValue(),
@@ -804,6 +966,8 @@ class RequirementExportDialog(wx.Dialog):
             card_sort_mode=self._selected_card_sort_mode(),
             card_label_group_mode=self._selected_card_label_group_mode(),
             export_scope=self._selected_export_scope(),
+            document_scope=self._selected_document_scope(),
+            selected_document_prefixes=self._selected_document_prefixes(),
             colorize_label_backgrounds=self.colorize_label_backgrounds_checkbox.GetValue(),
             docx_include_requirement_heading=self.docx_include_requirement_heading_checkbox.GetValue(),
             generate_context_docs_preface=self.context_docs_preface_checkbox.GetValue(),

--- a/app/ui/main_frame/documents.py
+++ b/app/ui/main_frame/documents.py
@@ -121,6 +121,28 @@ class MainFrameDocumentsMixin:
             lines.append(_("Document revision: {value}").format(value=revision_label))
         return lines
 
+    def _export_header_lines_for_documents(
+        self: MainFrame,
+        documents: Sequence[object],
+        *,
+        requirement_count: int,
+    ) -> list[str]:
+        """Build metadata lines for exports covering multiple documents."""
+        lines: list[str] = [_("Requirements count: {count}").format(count=requirement_count)]
+        for document in documents:
+            prefix = str(getattr(document, "prefix", "")).strip()
+            if not prefix:
+                continue
+            revision_label = self._format_document_revision(document)
+            if revision_label:
+                lines.append(
+                    _("Document {prefix} revision: {value}").format(
+                        prefix=prefix,
+                        value=revision_label,
+                    )
+                )
+        return lines
+
     def _collect_context_preface(
         self: MainFrame,
         requirements: Sequence[object],
@@ -901,6 +923,79 @@ class MainFrameDocumentsMixin:
             return "visible"
         return "all"
 
+    def _default_document_export_scope(self: MainFrame) -> str:
+        """Return default document scope for export."""
+        return "current"
+
+    def _ordered_document_prefixes(
+        self: MainFrame,
+        docs: Mapping[str, object],
+        *,
+        selected_prefixes: Sequence[str],
+    ) -> list[str]:
+        """Return selected prefixes ordered by document hierarchy (parent first)."""
+        selected_set = set(selected_prefixes)
+        children: dict[str | None, list[str]] = {}
+        for prefix in selected_set:
+            document = docs.get(prefix)
+            parent = getattr(document, "parent", None) if document is not None else None
+            if parent not in selected_set:
+                parent = None
+            children.setdefault(parent, []).append(prefix)
+        for entries in children.values():
+            entries.sort()
+
+        ordered: list[str] = []
+
+        def _visit(parent_prefix: str | None) -> None:
+            for child in children.get(parent_prefix, []):
+                ordered.append(child)
+                _visit(child)
+
+        _visit(None)
+        return ordered
+
+    def _descendant_document_prefixes(
+        self: MainFrame,
+        docs: Mapping[str, object],
+        *,
+        root_prefix: str,
+    ) -> list[str]:
+        """Return ``root_prefix`` and descendants ordered by hierarchy."""
+        selected: list[str] = []
+        for prefix, document in docs.items():
+            if prefix == root_prefix:
+                selected.append(prefix)
+                continue
+            current = document
+            while current is not None:
+                parent_prefix = getattr(current, "parent", None)
+                if not parent_prefix:
+                    break
+                if parent_prefix == root_prefix:
+                    selected.append(prefix)
+                    break
+                current = docs.get(parent_prefix)
+        return self._ordered_document_prefixes(docs, selected_prefixes=selected)
+
+    def _resolve_export_document_prefixes(
+        self: MainFrame,
+        *,
+        docs: Mapping[str, object],
+        current_prefix: str,
+        document_scope: str,
+        manual_prefixes: Sequence[str],
+    ) -> list[str]:
+        """Resolve export prefixes using selected dialog scope."""
+        if document_scope == "current":
+            return [current_prefix] if current_prefix in docs else []
+        if document_scope == "subtree":
+            return self._descendant_document_prefixes(docs, root_prefix=current_prefix)
+        if document_scope == "manual":
+            selected = [prefix for prefix in manual_prefixes if prefix in docs]
+            return self._ordered_document_prefixes(docs, selected_prefixes=selected)
+        return self._ordered_document_prefixes(docs, selected_prefixes=list(docs))
+
     def _recommended_export_directory(self: MainFrame) -> Path | None:
         """Return non-workspace directory recommended for exports."""
         if not self.current_dir:
@@ -955,15 +1050,11 @@ class MainFrameDocumentsMixin:
             wx.MessageBox(_("Document not found"), _("Error"), wx.ICON_ERROR)
             return
 
+        docs = self.docs_controller.documents
         all_requirements = self.model.get_all()
         visible_requirements = self.model.get_visible()
         selected_ids = self.panel.get_selected_ids()
-        selected_requirements: list = []
         selected_lookup: set[int] = set(selected_ids)
-        if selected_lookup:
-            selected_requirements = [
-                req for req in all_requirements if int(getattr(req, "id", -1)) in selected_lookup
-            ]
 
         if not all_requirements:
             wx.MessageBox(_("No requirements to export."), _("Export"))
@@ -988,6 +1079,12 @@ class MainFrameDocumentsMixin:
                 default_path=default_path,
                 saved_state=saved_state,
                 default_export_scope=self._default_export_scope(),
+                available_documents=[
+                    (prefix, self._format_document_choice(document))
+                    for prefix, document in sorted(docs.items())
+                ],
+                default_document_scope=self._default_document_export_scope(),
+                current_document_prefix=self.current_doc_prefix,
             )
             try:
                 if dlg.ShowModal() != wx.ID_OK:
@@ -1009,12 +1106,41 @@ class MainFrameDocumentsMixin:
             saved_state = dialog_state
         self.config.set_export_dialog_state(self.current_dir, dialog_state)
 
-        scope_sources = {
-            "all": all_requirements,
-            "visible": visible_requirements,
-            "selected": selected_requirements,
+        selected_doc_prefixes = self._resolve_export_document_prefixes(
+            docs=docs,
+            current_prefix=doc.prefix,
+            document_scope=plan.document_scope,
+            manual_prefixes=plan.selected_document_prefixes,
+        )
+        if not selected_doc_prefixes:
+            wx.MessageBox(_("No documents selected for export."), _("Export"))
+            return
+
+        loaded_requirements = self.docs_controller.service.load_requirements(
+            prefixes=selected_doc_prefixes
+        )
+        visible_lookup = {
+            (str(getattr(req, "doc_prefix", "")), int(getattr(req, "id", -1)))
+            for req in visible_requirements
         }
-        requirements = list(scope_sources.get(plan.export_scope, all_requirements))
+        selected_lookup_pairs = {(doc.prefix, item_id) for item_id in selected_lookup}
+
+        scope_sources = {
+            "all": loaded_requirements,
+            "visible": [
+                req
+                for req in loaded_requirements
+                if (str(getattr(req, "doc_prefix", "")), int(getattr(req, "id", -1)))
+                in visible_lookup
+            ],
+            "selected": [
+                req
+                for req in loaded_requirements
+                if (str(getattr(req, "doc_prefix", "")), int(getattr(req, "id", -1)))
+                in selected_lookup_pairs
+            ],
+        }
+        requirements = list(scope_sources.get(plan.export_scope, loaded_requirements))
         if not requirements:
             wx.MessageBox(_("No requirements to export."), _("Export"))
             return
@@ -1025,27 +1151,67 @@ class MainFrameDocumentsMixin:
         )
         context_preface: list[tuple[str, str]] = []
         context_missing: list[str] = []
-        doc_root = self.current_dir / doc.prefix
-        if plan.include_shared_artifacts:
-            shared_preface, shared_missing = self._collect_shared_artifacts_preface(
-                doc,
-                doc_root=doc_root,
-            )
-            context_preface.extend(shared_preface)
-            context_missing.extend(shared_missing)
-        if should_generate_context_preface:
-            docs_preface, docs_missing = self._collect_context_preface(
-                requirements,
-                doc_root=doc_root,
-            )
-            context_preface.extend(docs_preface)
-            context_missing.extend(docs_missing)
+        for selected_prefix in selected_doc_prefixes:
+            selected_doc = docs.get(selected_prefix)
+            if selected_doc is None:
+                continue
+            doc_root = self.current_dir / selected_prefix
+            if plan.include_shared_artifacts:
+                shared_preface, shared_missing = self._collect_shared_artifacts_preface(
+                    selected_doc,
+                    doc_root=doc_root,
+                )
+                context_preface.extend(
+                    [
+                        (f"{selected_prefix}: {title}", text)
+                        for title, text in shared_preface
+                    ]
+                )
+                context_missing.extend(
+                    [f"{selected_prefix}: {line}" for line in shared_missing]
+                )
+            if should_generate_context_preface:
+                document_requirements = [
+                    req
+                    for req in requirements
+                    if str(getattr(req, "doc_prefix", "")) == selected_prefix
+                ]
+                docs_preface, docs_missing = self._collect_context_preface(
+                    document_requirements,
+                    doc_root=doc_root,
+                )
+                context_preface.extend(
+                    [(f"{selected_prefix}/{title}", text) for title, text in docs_preface]
+                )
+                context_missing.extend(docs_missing)
 
         labels_grouped = plan.card_sort_mode == "labels"
         label_group_mode = plan.card_label_group_mode
-        card_export_requirements = sort_requirements_for_cards(
-            requirements,
-            sort_mode=plan.card_sort_mode,
+        if len(selected_doc_prefixes) <= 1:
+            card_export_requirements = sort_requirements_for_cards(
+                requirements,
+                sort_mode=plan.card_sort_mode,
+            )
+        else:
+            card_export_requirements = []
+            for selected_prefix in selected_doc_prefixes:
+                document_requirements = [
+                    req
+                    for req in requirements
+                    if str(getattr(req, "doc_prefix", "")) == selected_prefix
+                ]
+                card_export_requirements.extend(
+                    sort_requirements_for_cards(
+                        document_requirements,
+                        sort_mode=plan.card_sort_mode,
+                    )
+                )
+
+        link_lookup = self.docs_controller.service.load_requirements()
+        title = (
+            _("Requirements export — {label}").format(label=document_label)
+            if len(selected_doc_prefixes) == 1
+            else _("Requirements export — multiple documents")
         )
 
         if plan.format == ExportFormat.DOCX:
@@ -1053,10 +1219,9 @@ class MainFrameDocumentsMixin:
                 card_export_requirements,
                 self.docs_controller.documents,
                 base_path=self.current_dir,
-                prefixes=(doc.prefix,),
-                link_lookup=self.model.get_all(),
+                prefixes=tuple(selected_doc_prefixes),
+                link_lookup=link_lookup,
             )
-            title = _("Requirements export — {label}").format(label=document_label)
             placeholder_label = _("(not set)")
             empty_placeholder = (
                 placeholder_label if plan.empty_fields_placeholder else None
@@ -1079,10 +1244,9 @@ class MainFrameDocumentsMixin:
                     card_export_requirements,
                     self.docs_controller.documents,
                     base_path=self.current_dir,
-                    prefixes=(doc.prefix,),
-                    link_lookup=self.model.get_all(),
+                    prefixes=tuple(selected_doc_prefixes),
+                    link_lookup=link_lookup,
                 )
-                title = _("Requirements export — {label}").format(label=document_label)
                 placeholder_label = _("(not set)")
                 empty_placeholder = (
                     placeholder_label if plan.empty_fields_placeholder else None
@@ -1116,10 +1280,37 @@ class MainFrameDocumentsMixin:
                     header_style=header_style,
                     value_style=value_style,
                 )
-                header_lines = self._export_header_lines(
-                    doc,
-                    requirement_count=len(export_rows_source),
-                )
+                if plan.format in {ExportFormat.CSV, ExportFormat.TSV} and len(selected_doc_prefixes) > 1:
+                    required_fields = ("doc_prefix", "rid")
+                    missing_fields = [
+                        field for field in required_fields if field not in headers
+                    ]
+                    if missing_fields:
+                        extra_headers, extra_rows = build_tabular_export(
+                            export_rows_source,
+                            list(missing_fields),
+                            derived_map=derived_map,
+                            header_style=header_style,
+                            value_style=value_style,
+                        )
+                        headers = [*extra_headers, *headers]
+                        rows = [
+                            [*extra_row, *row]
+                            for extra_row, row in zip(extra_rows, rows)
+                        ]
+                selected_documents = [
+                    docs[prefix] for prefix in selected_doc_prefixes if prefix in docs
+                ]
+                if len(selected_documents) == 1:
+                    header_lines = self._export_header_lines(
+                        selected_documents[0],
+                        requirement_count=len(export_rows_source),
+                    )
+                else:
+                    header_lines = self._export_header_lines_for_documents(
+                        selected_documents,
+                        requirement_count=len(export_rows_source),
+                    )
                 if context_preface and plan.format in {ExportFormat.CSV, ExportFormat.TSV}:
                     header_lines.extend(self._render_preface_header_lines(context_preface))
                 if plan.format == ExportFormat.CSV:

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -384,13 +384,17 @@ pipeline, fallback cleanup, and regression coverage strategy), see
   state. `LabelsDialog` coordinates label edits by capturing rename propagation
   choices and deletion clean-up flags before the controller forwards the plan to
   `RequirementsService.update_document_labels()`. The export dialog
-  (`app/ui/export_dialog.py`) lets users choose export scope (all requirements,
-  only currently visible after filters, or only selected rows), columns and
-  format before rendering output, including a text-only option for omitting or
-  labelling empty fields, plus DOCX toggles that control whether each
-  requirement card gets its own heading line (enabled by default). When users
-  clear all export columns but keep heading rendering enabled for DOCX, export
-  switches to a compact one-line list (`RID - title`) without card tables.
+  (`app/ui/export_dialog.py`) lets users configure both document coverage
+  (current document, current subtree, all project documents, or manual selection)
+  and requirement scope (all/visible/selected; visible/selected remain available
+  for current-document exports), then choose columns and output format before
+  rendering. Card exports keep document hierarchy order when multiple documents
+  are selected, so parent/child modules are not interleaved in a single card
+  stream. The same dialog also exposes text options for omitting/labelling empty
+  fields and DOCX toggles that control whether each requirement card gets its own
+  heading line (enabled by default). When users clear all export columns but keep
+  heading rendering enabled for DOCX, export switches to a compact one-line list
+  (`RID - title`) without card tables.
   `EditorPanel` keeps the requirement form in an explicit two-stage sequence: a
   primary block (ID/title/statement/context/rationale/notes/source/status/labels,
   attachments and a context-docs picker that stores relative Markdown paths under

--- a/tests/gui/test_export_dialog.py
+++ b/tests/gui/test_export_dialog.py
@@ -18,6 +18,8 @@ def test_export_dialog_text_options_visibility(wx_app):
         available_fields=["id", "statement"],
         selected_fields=["statement"],
         document_label="DOC",
+        available_documents=[("DOC", "DOC — Document"), ("SYS", "SYS — System")],
+        current_document_prefix="DOC",
     )
     try:
         wx_app.Yield()
@@ -28,6 +30,8 @@ def test_export_dialog_text_options_visibility(wx_app):
         assert not dialog.context_docs_preface_checkbox.IsShown()
         assert dialog.include_shared_artifacts_checkbox.GetValue() is True
         assert dialog._selected_export_scope() == "all"
+        assert dialog._selected_document_scope() == "all"
+        assert not dialog.scope_choice.IsEnabled()
 
         dialog.format_choice.SetSelection(1)
         dialog._update_text_options_visibility()
@@ -40,6 +44,7 @@ def test_export_dialog_text_options_visibility(wx_app):
         assert dialog.colorize_label_backgrounds_checkbox.IsEnabled()
         assert not dialog.context_docs_preface_checkbox.IsShown()
         assert dialog._selected_export_scope() == "all"
+        assert not dialog.scope_choice.IsEnabled()
 
         dialog.format_choice.SetSelection(2)
         dialog._update_text_options_visibility()
@@ -89,13 +94,19 @@ def test_export_dialog_card_sort_defaults_and_plan(wx_app):
             card_sort_mode="source",
             card_label_group_mode="per_label",
             export_scope="visible",
+            document_scope="manual",
+            selected_document_prefixes=["SYS"],
             include_shared_artifacts=False,
         ),
+        available_documents=[("DOC", "DOC — Document"), ("SYS", "SYS — System")],
+        current_document_prefix="DOC",
     )
     try:
         wx_app.Yield()
         assert dialog._selected_card_sort_mode() == "source"
-        assert dialog._selected_export_scope() == "visible"
+        assert dialog._selected_export_scope() == "all"
+        assert dialog._selected_document_scope() == "manual"
+        assert dialog._selected_document_prefixes() == ["SYS"]
         assert dialog.include_shared_artifacts_checkbox.GetValue() is False
         assert dialog._selected_card_label_group_mode() == "per_label"
         assert not dialog.card_label_group_choice.IsEnabled()
@@ -117,6 +128,8 @@ def test_export_dialog_card_sort_defaults_and_plan(wx_app):
         state = dialog.get_state()
         assert state.card_sort_mode == "labels"
         assert state.card_label_group_mode == "label_set"
+        assert state.document_scope == "manual"
+        assert state.selected_document_prefixes == ["SYS"]
 
         dialog.card_sort_choice.SetSelection(4)
         dialog._on_card_sort_changed(_wx.CommandEvent())
@@ -144,10 +157,14 @@ def test_export_dialog_default_scope_from_context(wx_app):
         available_fields=["id", "statement"],
         selected_fields=["statement"],
         default_export_scope="selected",
+        default_document_scope="current",
+        available_documents=[("DOC", "DOC — Document"), ("SYS", "SYS — System")],
+        current_document_prefix="DOC",
     )
     try:
         wx_app.Yield()
         assert dialog._selected_export_scope() == "selected"
+        assert dialog.scope_choice.IsEnabled()
 
         dialog.scope_choice.SetSelection(0)
         dialog._on_scope_changed(_wx.CommandEvent())
@@ -167,6 +184,38 @@ def test_export_dialog_default_scope_from_context(wx_app):
         assert state.export_scope == "all"
         assert state.colorize_label_backgrounds is True
         assert state.docx_include_requirement_heading is True
+    finally:
+        dialog.Destroy()
+        wx_app.Yield()
+
+
+@pytest.mark.gui_smoke
+def test_export_dialog_manual_document_selection_requires_document(wx_app):
+    _wx = pytest.importorskip("wx")
+    from app.ui.export_dialog import RequirementExportDialog
+
+    dialog = RequirementExportDialog(
+        None,
+        available_fields=["id", "statement"],
+        selected_fields=["statement"],
+        available_documents=[("DOC", "DOC — Document"), ("SYS", "SYS — System")],
+        current_document_prefix="DOC",
+        default_document_scope="manual",
+    )
+    try:
+        wx_app.Yield()
+        dialog.file_picker.SetPath("/tmp/export.txt")
+        dialog.document_list.Check(0, False)
+        dialog.document_list.Check(1, False)
+        dialog._on_document_selection_changed(_wx.CommandEvent())
+        assert dialog.get_plan() is None
+
+        dialog.document_list.Check(1, True)
+        dialog._on_document_selection_changed(_wx.CommandEvent())
+        plan = dialog.get_plan()
+        assert plan is not None
+        assert plan.document_scope == "manual"
+        assert plan.selected_document_prefixes == ["SYS"]
     finally:
         dialog.Destroy()
         wx_app.Yield()

--- a/tests/unit/test_main_frame_documents.py
+++ b/tests/unit/test_main_frame_documents.py
@@ -119,6 +119,12 @@ def test_default_export_scope_falls_back_to_all() -> None:
     assert frame._default_export_scope() == "all"
 
 
+def test_default_document_export_scope_is_current() -> None:
+    frame = _ScopeFrame(selected_ids=[], has_filters=False)
+
+    assert frame._default_document_export_scope() == "current"
+
+
 class _SummaryFrame(MainFrameDocumentsMixin):
     def __init__(self) -> None:
         self.current_doc_prefix = "SYS"
@@ -137,6 +143,43 @@ def test_current_document_summary_includes_revision() -> None:
     frame = _SummaryFrame()
 
     assert frame._current_document_summary() == "SYS: System (rev 5)"
+
+
+def test_resolve_export_document_prefixes_orders_subtree() -> None:
+    frame = _SummaryFrame()
+    docs = {
+        "SYS": Document(prefix="SYS", title="System"),
+        "TVU": Document(prefix="TVU", title="Top", parent="SYS"),
+        "HLR": Document(prefix="HLR", title="High"),
+        "TNU": Document(prefix="TNU", title="Low", parent="TVU"),
+    }
+
+    prefixes = frame._resolve_export_document_prefixes(
+        docs=docs,
+        current_prefix="SYS",
+        document_scope="subtree",
+        manual_prefixes=[],
+    )
+
+    assert prefixes == ["SYS", "TVU", "TNU"]
+
+
+def test_resolve_export_document_prefixes_orders_manual_selection() -> None:
+    frame = _SummaryFrame()
+    docs = {
+        "SYS": Document(prefix="SYS", title="System"),
+        "TVU": Document(prefix="TVU", title="Top", parent="SYS"),
+        "HLR": Document(prefix="HLR", title="High"),
+    }
+
+    prefixes = frame._resolve_export_document_prefixes(
+        docs=docs,
+        current_prefix="SYS",
+        document_scope="manual",
+        manual_prefixes=["TVU", "SYS"],
+    )
+
+    assert prefixes == ["SYS", "TVU"]
 
 
 class _ExportFrame(MainFrameDocumentsMixin):

--- a/tests/unit/test_requirement_export_markdown.py
+++ b/tests/unit/test_requirement_export_markdown.py
@@ -6,8 +6,12 @@ import pytest
 
 from app.core.document_store import Document, save_document, save_item
 from app.i18n import install
-from app.core.model import Priority, Requirement, RequirementType, Status, Verification
-from app.core.requirement_export import build_requirement_export, render_requirements_markdown
+from app.core.model import Link, Priority, Requirement, RequirementType, Status, Verification
+from app.core.requirement_export import (
+    build_requirement_export,
+    build_requirement_export_from_requirements,
+    render_requirements_markdown,
+)
 
 pytestmark = pytest.mark.unit
 
@@ -263,3 +267,52 @@ def test_render_requirements_markdown_renders_all_verification_methods(tmp_path:
     markdown = render_requirements_markdown(export)
 
     assert "- **Verification method:** ``Analysis, Test, Inspection``" in markdown
+
+
+def test_render_requirements_markdown_marks_links_outside_export_scope(tmp_path: Path) -> None:
+    sys_doc = Document(prefix="SYS", title="System")
+    tvu_doc = Document(prefix="TVU", title="Top", parent="SYS")
+    save_document(tmp_path / "SYS", sys_doc)
+    save_document(tmp_path / "TVU", tvu_doc)
+
+    sys_req = Requirement(
+        id=1,
+        title="SYS root",
+        statement="Root statement",
+        type=RequirementType.REQUIREMENT,
+        status=Status.APPROVED,
+        owner="",
+        priority=Priority.MEDIUM,
+        source="",
+        verification=Verification.ANALYSIS,
+        attachments=[],
+        doc_prefix="SYS",
+        rid="SYS1",
+    )
+    tvu_req = Requirement(
+        id=1,
+        title="TVU child",
+        statement="Child statement",
+        type=RequirementType.REQUIREMENT,
+        status=Status.DRAFT,
+        owner="",
+        priority=Priority.MEDIUM,
+        source="",
+        verification=Verification.ANALYSIS,
+        links=[Link(rid="SYS1")],
+        attachments=[],
+        doc_prefix="TVU",
+        rid="TVU1",
+    )
+
+    export = build_requirement_export_from_requirements(
+        [tvu_req],
+        {"SYS": sys_doc, "TVU": tvu_doc},
+        base_path=tmp_path,
+        prefixes=("TVU",),
+        link_lookup=[sys_req, tvu_req],
+    )
+    rendered = render_requirements_markdown(export)
+
+    assert "[SYS1](#SYS1)" not in rendered
+    assert "outside exported scope" in rendered


### PR DESCRIPTION
### Motivation
- Provide the ability to export requirements across multiple documents with explicit document-scoping (current, subtree, all, manual) and preserve sensible ordering/hierarchy when exporting multiple documents.
- Persist and restore the document selection state in the export dialog so user choices survive between sessions.
- Improve link rendering in markdown exports to mark links that point outside the exported scope.

### Description
- Added `document_scope` and `selected_document_prefixes` to `ExportDialogState` and wired persistence in `app/config.py`.
- Extended the export dialog (`app/ui/export_dialog.py`) with a document-scope radio box, a manual document checklist, normalization helpers, validation to require at least one document for manual scope, and state/plan integration (`RequirementExportPlan`).
- Updated main frame/export flow (`app/ui/main_frame/documents.py`) to resolve document prefixes for the chosen scope (current, subtree, all, manual), load requirements for selected prefixes, preserve document hierarchy ordering, build per-document context preface, and adapt export pipelines (DOCX/HTML/tabular formats) to use multiple-document prefixes and link lookups.
- Adjusted markdown rendering (`app/core/requirement_export.py`) to avoid linking to requirements outside the export and to show an "outside exported scope" suffix for such links.
- Added/updated i18n strings in `app/locale/en` and `app/locale/ru` and documentation (`docs/ARCHITECTURE.md`) describing the new document-scoping UI and behavior.
- Updated and added unit and GUI tests to cover document-scope defaults, manual selection validation, ordering of subtree/manual selections, and markdown behavior for links outside the export.

### Testing
- Ran GUI tests in `tests/gui/test_export_dialog.py`, including new smoke tests for document selection and manual-selection validation, and they passed.
- Ran unit tests `tests/unit/test_main_frame_documents.py` covering prefix ordering and default document scope, and they passed.
- Ran unit tests `tests/unit/test_requirement_export_markdown.py` including the new test that verifies links outside the exported scope are marked, and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de23422f508320b082a3a677e4980d)