### PR TITLE
Rename 'Data Module(s)' to 'Document(s)' in UI and localization

### DIFF
--- a/app/locale/en/LC_MESSAGES/CookaReq.po
+++ b/app/locale/en/LC_MESSAGES/CookaReq.po
@@ -1126,7 +1126,7 @@ msgid "Custom labels (comma-separated)"
 msgstr "Custom labels (comma-separated)"
 
 msgid "Delete document {prefix} and its subtree?"
-msgstr "Delete data module {prefix} and its subtree?"
+msgstr "Delete document {prefix} and its subtree?"
 
 msgid "Delete item {rid}?"
 msgstr "Delete item {rid}?"
@@ -1138,16 +1138,14 @@ msgid "Discard unsaved changes?"
 msgstr "Discard unsaved changes?"
 
 msgid "Document not found"
-msgstr "Data module not found"
+msgstr "Document not found"
 
 msgid "Document prefix is required."
-msgstr "Data module prefix is required."
+msgstr "Document prefix is required."
 
 
-msgid "Data Modules"
-msgstr "Data Modules"
 msgid "Documents"
-msgstr "Data Modules"
+msgstr "Documents"
 
 msgid "Edit label"
 msgstr "Edit label"
@@ -1203,7 +1201,7 @@ msgstr ""
 "Minimum allowed value is 1000 tokens; CookaReq defaults to 5000 when unset."
 
 msgid "New document"
-msgstr "New data module"
+msgstr "New document"
 
 msgid ""
 "Number of times to retry a failed HTTP request. Example: 3\n"
@@ -1233,7 +1231,7 @@ msgstr ""
 "Keeps the list ordering consistent between sessions."
 
 msgid "Edit document"
-msgstr "Edit data module"
+msgstr "Edit document"
 
 msgid "Requirement {rid}"
 msgstr "Requirement {rid}"
@@ -1279,25 +1277,25 @@ msgid "comma-separated parent requirement IDs"
 msgstr "comma-separated parent requirement IDs"
 
 msgid "create document"
-msgstr "create data module"
+msgstr "create document"
 
 msgid "create new item"
 msgstr "create new item"
 
 msgid "delete document"
-msgstr "delete data module"
+msgstr "delete document"
 
 msgid "delete item"
 msgstr "delete item"
 
 msgid "document not found: {prefix}"
-msgstr "data module not found: {prefix}"
+msgstr "document not found: {prefix}"
 
 msgid "document prefix"
-msgstr "data module prefix"
+msgstr "document prefix"
 
 msgid "document title"
-msgstr "data module title"
+msgstr "document title"
 
 msgid "edit existing item"
 msgstr "edit existing item"
@@ -1326,6 +1324,9 @@ msgstr "item title"
 msgid "labels must be a list"
 msgstr "labels must be a list"
 
+msgid "Links"
+msgstr "Links"
+
 msgid "link requirements"
 msgstr "link requirements"
 
@@ -1336,10 +1337,10 @@ msgid "links must be a list"
 msgstr "links must be a list"
 
 msgid "list documents"
-msgstr "list data modules"
+msgstr "list documents"
 
 msgid "manage documents"
-msgstr "manage data modules"
+msgstr "manage documents"
 
 msgid "manage items"
 msgstr "manage items"
@@ -1354,7 +1355,7 @@ msgid "export requirements"
 msgstr "export requirements"
 
 msgid "document prefixes (comma separated)"
-msgstr "data module prefixes (comma separated)"
+msgstr "document prefixes (comma separated)"
 
 msgid "title for exported document"
 msgstr "title for exported document"
@@ -1366,7 +1367,7 @@ msgid "output format"
 msgstr "output format"
 
 msgid "parent document prefix"
-msgstr "parent data module prefix"
+msgstr "parent document prefix"
 
 msgid "parent requirement identifiers"
 msgstr "parent requirement identifiers"
@@ -1390,10 +1391,10 @@ msgid "show what would be deleted"
 msgstr "show what would be deleted"
 
 msgid "target document prefix"
-msgstr "target data module prefix"
+msgstr "target document prefix"
 
 msgid "unknown document prefix: {prefix}"
-msgstr "unknown data module prefix: {prefix}"
+msgstr "unknown document prefix: {prefix}"
 
 msgid "unknown priority: {value}"
 msgstr "unknown priority: {value}"
@@ -1630,10 +1631,10 @@ msgid "Restart response generation"
 msgstr "Restart response generation"
 
 
-msgid "Show Data Modules Hierarchy"
-msgstr "Show Data Modules Hierarchy"
+msgid "Show Documents Hierarchy"
+msgstr "Show Documents Hierarchy"
 msgid "Show Hierarchy"
-msgstr "Show Data Modules Hierarchy"
+msgstr "Show Documents Hierarchy"
 
 msgid "LLM ↔ MCP tool exchanges:"
 msgstr "LLM ↔ MCP tool exchanges:"
@@ -3176,8 +3177,8 @@ msgstr "Shared artifact"
 msgid "Shared artifacts: {prefix}"
 msgstr "Shared artifacts: {prefix}"
 
-msgid "Shared artifacts are available to all requirements in this data module. Attach key source files here so they can be reused in reviews and exports."
-msgstr "Shared artifacts are available to all requirements in this data module. Attach key source files here so they can be reused in reviews and exports."
+msgid "Shared artifacts are available to all requirements in this document. Attach key source files here so they can be reused in reviews and exports."
+msgstr "Shared artifacts are available to all requirements in this document. Attach key source files here so they can be reused in reviews and exports."
 
 msgid "Select shared artifact"
 msgstr "Select shared artifact"
@@ -3273,12 +3274,12 @@ msgid "File is missing on disk."
 msgstr "File is missing on disk."
 
 
-msgid "Data Module Artifacts"
-msgstr "Data Module Artifacts"
+msgid "Document Artifacts"
+msgstr "Document Artifacts"
 
 
-msgid "Shared artifacts are available to all requirements in this data module. Attach key source files here so they can be reused in reviews and exports. For export preface inclusion use UTF-8 text files (.txt, .md, .csv, .json, .yaml, .yml, .log, .ini)."
-msgstr "Shared artifacts are available to all requirements in this data module. Attach key source files here so they can be reused in reviews and exports. For export preface inclusion use UTF-8 text files (.txt, .md, .csv, .json, .yaml, .yml, .log, .ini)."
+msgid "Shared artifacts are available to all requirements in this document. Attach key source files here so they can be reused in reviews and exports. For export preface inclusion use UTF-8 text files (.txt, .md, .csv, .json, .yaml, .yml, .log, .ini)."
+msgstr "Shared artifacts are available to all requirements in this document. Attach key source files here so they can be reused in reviews and exports. For export preface inclusion use UTF-8 text files (.txt, .md, .csv, .json, .yaml, .yml, .log, .ini)."
 
 
 msgid "Text files (*.txt;*.md;*.csv;*.json;*.yaml;*.yml;*.log;*.ini)|*.txt;*.md;*.csv;*.json;*.yaml;*.yml;*.log;*.ini|All files (*.*)|*.*"

--- a/app/locale/ru/LC_MESSAGES/CookaReq.po
+++ b/app/locale/ru/LC_MESSAGES/CookaReq.po
@@ -1140,7 +1140,7 @@ msgid "Custom labels (comma-separated)"
 msgstr "Произвольные метки (через запятую)"
 
 msgid "Delete document {prefix} and its subtree?"
-msgstr "Удалить модуль данных {prefix} и все дочерние элементы?"
+msgstr "Удалить документ {prefix} и все дочерние элементы?"
 
 msgid "Delete item {rid}?"
 msgstr "Удалить требование {rid}?"
@@ -1152,16 +1152,14 @@ msgid "Discard unsaved changes?"
 msgstr "Отменить несохранённые изменения?"
 
 msgid "Document not found"
-msgstr "Модуль данных не найден"
+msgstr "Документ не найден"
 
 msgid "Document prefix is required."
-msgstr "Требуется указать префикс модуля данных."
+msgstr "Требуется указать префикс документа."
 
 
-msgid "Data Modules"
-msgstr "Модули данных"
 msgid "Documents"
-msgstr "Модули данных"
+msgstr "Документы"
 
 msgid "Edit label"
 msgstr "Изменить метку"
@@ -1217,7 +1215,7 @@ msgstr ""
 "Минимально допустимое значение — 1000 токенов; по умолчанию CookaReq использует 5000, если поле пустое."
 
 msgid "New document"
-msgstr "Новый модуль данных"
+msgstr "Новый документ"
 
 msgid ""
 "Number of times to retry a failed HTTP request. Example: 3\n"
@@ -1247,7 +1245,7 @@ msgstr ""
 "Позволяет сохранять порядок списка между сеансами."
 
 msgid "Edit document"
-msgstr "Изменить модуль данных"
+msgstr "Изменить документ"
 
 msgid "Requirement {rid}"
 msgstr "Требование {rid}"
@@ -1293,25 +1291,25 @@ msgid "comma-separated parent requirement IDs"
 msgstr "идентификаторы родительских требований через запятую"
 
 msgid "create document"
-msgstr "создать модуль данных"
+msgstr "создать документ"
 
 msgid "create new item"
 msgstr "создать новый элемент"
 
 msgid "delete document"
-msgstr "удалить модуль данных"
+msgstr "удалить документ"
 
 msgid "delete item"
 msgstr "удалить элемент"
 
 msgid "document not found: {prefix}"
-msgstr "модуль данных не найден: {prefix}"
+msgstr "документ не найден: {prefix}"
 
 msgid "document prefix"
-msgstr "префикс модуля данных"
+msgstr "префикс документа"
 
 msgid "document title"
-msgstr "название модуля данных"
+msgstr "название документа"
 
 msgid "edit existing item"
 msgstr "изменить существующий элемент"
@@ -1340,6 +1338,9 @@ msgstr "название элемента"
 msgid "labels must be a list"
 msgstr "метки должны быть списком"
 
+msgid "Links"
+msgstr "Связи"
+
 msgid "link requirements"
 msgstr "связать требования"
 
@@ -1350,10 +1351,10 @@ msgid "links must be a list"
 msgstr "связи должны быть списком"
 
 msgid "list documents"
-msgstr "список модулей данных"
+msgstr "список документов"
 
 msgid "manage documents"
-msgstr "управлять модулями данных"
+msgstr "управлять документами"
 
 msgid "manage items"
 msgstr "управлять элементами"
@@ -1368,7 +1369,7 @@ msgid "export requirements"
 msgstr "экспортировать требования"
 
 msgid "document prefixes (comma separated)"
-msgstr "префиксы модулей данных через запятую"
+msgstr "префиксы документов через запятую"
 
 msgid "title for exported document"
 msgstr "заголовок экспортируемого документа"
@@ -1380,7 +1381,7 @@ msgid "output format"
 msgstr "формат вывода"
 
 msgid "parent document prefix"
-msgstr "префикс родительского модуля данных"
+msgstr "префикс родительского документа"
 
 msgid "parent requirement identifiers"
 msgstr "идентификаторы родительских требований"
@@ -1404,10 +1405,10 @@ msgid "show what would be deleted"
 msgstr "показать, что будет удалено"
 
 msgid "target document prefix"
-msgstr "префикс целевого модуля данных"
+msgstr "префикс целевого документа"
 
 msgid "unknown document prefix: {prefix}"
-msgstr "неизвестный префикс модуля данных: {prefix}"
+msgstr "неизвестный префикс документа: {prefix}"
 
 msgid "unknown priority: {value}"
 msgstr "неизвестный приоритет: {value}"
@@ -1644,10 +1645,10 @@ msgid "Restart response generation"
 msgstr "Запустить генерацию ответа заново"
 
 
-msgid "Show Data Modules Hierarchy"
-msgstr "Показать иерархию модулей данных"
+msgid "Show Documents Hierarchy"
+msgstr "Показать иерархию документов"
 msgid "Show Hierarchy"
-msgstr "Показать иерархию модулей данных"
+msgstr "Показать иерархию документов"
 
 msgid "LLM ↔ MCP tool exchanges:"
 msgstr "Обмен инструментов между LLM и MCP:"
@@ -3196,8 +3197,8 @@ msgstr "Общий артефакт"
 msgid "Shared artifacts: {prefix}"
 msgstr "Общие артефакты: {prefix}"
 
-msgid "Shared artifacts are available to all requirements in this data module. Attach key source files here so they can be reused in reviews and exports."
-msgstr "Общие артефакты доступны всем требованиям в этом модуле данных. Добавляйте сюда ключевые исходные файлы, чтобы переиспользовать их в ревью и экспорте."
+msgid "Shared artifacts are available to all requirements in this document. Attach key source files here so they can be reused in reviews and exports."
+msgstr "Общие артефакты доступны всем требованиям в этом документе. Добавляйте сюда ключевые исходные файлы, чтобы переиспользовать их в ревью и экспорте."
 
 msgid "Select shared artifact"
 msgstr "Выберите общий артефакт"
@@ -3293,12 +3294,12 @@ msgid "File is missing on disk."
 msgstr "Файл отсутствует на диске."
 
 
-msgid "Data Module Artifacts"
-msgstr "Артефакты модуля данных"
+msgid "Document Artifacts"
+msgstr "Артефакты документа"
 
 
-msgid "Shared artifacts are available to all requirements in this data module. Attach key source files here so they can be reused in reviews and exports. For export preface inclusion use UTF-8 text files (.txt, .md, .csv, .json, .yaml, .yml, .log, .ini)."
-msgstr "Общие артефакты доступны всем требованиям в этом модуле данных. Добавляйте сюда ключевые исходные файлы, чтобы переиспользовать их в ревью и экспорте. Для включения в пролог экспорта используйте UTF-8 текстовые файлы (.txt, .md, .csv, .json, .yaml, .yml, .log, .ini)."
+msgid "Shared artifacts are available to all requirements in this document. Attach key source files here so they can be reused in reviews and exports. For export preface inclusion use UTF-8 text files (.txt, .md, .csv, .json, .yaml, .yml, .log, .ini)."
+msgstr "Общие артефакты доступны всем требованиям в этом документе. Добавляйте сюда ключевые исходные файлы, чтобы переиспользовать их в ревью и экспорте. Для включения в пролог экспорта используйте UTF-8 текстовые файлы (.txt, .md, .csv, .json, .yaml, .yml, .log, .ini)."
 
 
 msgid "Text files (*.txt;*.md;*.csv;*.json;*.yaml;*.yml;*.log;*.ini)|*.txt;*.md;*.csv;*.json;*.yaml;*.yml;*.log;*.ini|All files (*.*)|*.*"

--- a/app/ui/document_tree.py
+++ b/app/ui/document_tree.py
@@ -37,7 +37,7 @@ class DocumentTree(wx.Panel):
         sizer = wx.BoxSizer(wx.VERTICAL)
         static_text = getattr(wx, "StaticText", None)
         if static_text is not None:
-            self._title_label = static_text(self, label=_("Data Modules"))
+            self._title_label = static_text(self, label=_("Documents"))
             title_flags = getattr(wx, "LEFT", 0) | getattr(wx, "RIGHT", 0) | getattr(wx, "TOP", 0)
             sizer.Add(self._title_label, 0, title_flags, 6)
         else:
@@ -46,7 +46,7 @@ class DocumentTree(wx.Panel):
         self.SetSizer(sizer)
         self._node_for_prefix: dict[str, wx.TreeItemId] = {}
         self._prefix_for_id: dict[wx.TreeItemId, str] = {}
-        self.root = self.tree.AddRoot(_("Data Modules"))
+        self.root = self.tree.AddRoot(_("Documents"))
         self.tree.Bind(wx.EVT_TREE_SEL_CHANGED, self._handle_select)
         self.tree.Bind(wx.EVT_TREE_ITEM_MENU, self._show_context_menu)
         if hasattr(wx, "EVT_CONTEXT_MENU"):

--- a/app/ui/main_frame/documents.py
+++ b/app/ui/main_frame/documents.py
@@ -772,7 +772,7 @@ class MainFrameDocumentsMixin:
 
 
     def on_open_data_module_artifacts(self: MainFrame, _event: wx.Event) -> None:
-        """Open shared artifacts manager for currently selected data module."""
+        """Open shared artifacts manager for currently selected document."""
 
         if not self.current_doc_prefix:
             wx.MessageBox(_("Select requirements folder first"), _("No Data"))

--- a/app/ui/navigation.py
+++ b/app/ui/navigation.py
@@ -96,7 +96,7 @@ class Navigation:
         )
         settings_item = file_menu.Append(wx.ID_PREFERENCES, _("Settings"))
         labels_item = file_menu.Append(wx.ID_ANY, _("Manage Labels"))
-        data_module_artifacts_item = file_menu.Append(wx.ID_ANY, _("Data Module Artifacts"))
+        data_module_artifacts_item = file_menu.Append(wx.ID_ANY, _("Document Artifacts"))
         exit_item = file_menu.Append(wx.ID_EXIT, _("E&xit"))
         self.frame.Bind(wx.EVT_MENU, self.on_open_folder, open_item)
         self.frame.Bind(wx.EVT_MENU, self.on_new_requirement, new_item)
@@ -123,7 +123,7 @@ class Navigation:
         view_menu.AppendSubMenu(columns_menu, _("Columns"))
         self.hierarchy_menu_item = view_menu.AppendCheckItem(
             wx.ID_ANY,
-            _("Show Data Modules Hierarchy"),
+            _("Show Documents Hierarchy"),
         )
         self.frame.Bind(
             wx.EVT_MENU,

--- a/app/ui/shared_artifacts_dialog.py
+++ b/app/ui/shared_artifacts_dialog.py
@@ -149,7 +149,7 @@ class SharedArtifactsDialog(wx.Dialog):
         main.Add(close_row, 0, wx.LEFT | wx.RIGHT | wx.BOTTOM | wx.EXPAND, 10)
 
         hint = _(
-            "Shared artifacts are available to all requirements in this data module."
+            "Shared artifacts are available to all requirements in this document."
             " Attach key source files here so they can be reused in reviews and exports."
             " For export preface inclusion use UTF-8 text files (.txt, .md, .csv, .json, .yaml, .yml, .log, .ini)."
         )


### PR DESCRIPTION
### Motivation
- Unify terminology by replacing the legacy term "Data Module(s)" with "Document(s)" across the UI and localization files.
- Make labels and help text consistent with the rest of the application that refers to document folders and document prefixes.
- Add a missing `"Links"` translation entry present in both English and Russian catalogs.

### Description
- Updated English and Russian PO files under `app/locale/*/LC_MESSAGES/CookaReq.po` to replace occurrences of "Data Module"/"data module" with "Document"/"document" and added the `msgid "Links"`/`msgstr` entries.
- Changed the tree title and root label in `app/ui/document_tree.py` to use `_("Documents")` instead of `_("Data Modules")`.
- Updated menu and tooltip labels in `app/ui/navigation.py` to show `_("Document Artifacts")` and `_("Show Documents Hierarchy")`.
- Adjusted help text and dialog captions in `app/ui/shared_artifacts_dialog.py` and `app/ui/main_frame/documents.py` to reference "document" wording and clarified the shared-artifacts hint.

### Testing
- No automated tests were run for these localization and UI text changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df447a477c8320be39a4a1104c410f)