### PR TITLE
Добавить отступы формы в отдельном окне редактора требований

### DIFF
--- a/app/ui/detached_editor.py
+++ b/app/ui/detached_editor.py
@@ -71,6 +71,7 @@ class DetachedEditorFrame(wx.Frame):
             container,
             on_save=self._handle_save,
             on_discard=self._handle_cancel,
+            detached_mode=True,
         )
         self.editor.set_service(service)
         editor_sizer = wx.BoxSizer(wx.VERTICAL)
@@ -212,4 +213,3 @@ class DetachedEditorFrame(wx.Frame):
         if base:
             return _("Requirement {rid}: {title}").format(rid=rid, title=base)
         return _("Requirement {rid}").format(rid=rid)
-

--- a/app/ui/editor_panel.py
+++ b/app/ui/editor_panel.py
@@ -278,6 +278,8 @@ class EditorPanel(wx.Panel):
         parent: wx.Window,
         on_save: Callable[[], None] | None = None,
         on_discard: Callable[[], bool] | None = None,
+        *,
+        detached_mode: bool = False,
     ):
         """Initialize requirement editor widgets."""
         super().__init__(parent)
@@ -315,6 +317,7 @@ class EditorPanel(wx.Panel):
         self._text_histories: dict[wx.TextCtrl, _TextHistoryState] = {}
         self._defer_autosize_layout = False
         self._id_display_link: wx.adv.HyperlinkCtrl | None = None
+        self._detached_mode = bool(detached_mode)
 
         self._attachment_link_re = re.compile(r"attachment:([A-Za-z0-9_-]+)")
 
@@ -608,7 +611,12 @@ class EditorPanel(wx.Panel):
         root_sizer.Add(self._content_panel, 1, wx.EXPAND)
         root_sizer.Add(separator, 0, wx.EXPAND)
         root_sizer.Add(footer, 0, wx.EXPAND)
-        self.SetSizer(root_sizer)
+        if self._detached_mode:
+            outer_sizer = wx.BoxSizer(wx.VERTICAL)
+            outer_sizer.Add(root_sizer, 1, wx.EXPAND | wx.ALL, dip(self, 8))
+            self.SetSizer(outer_sizer)
+        else:
+            self.SetSizer(root_sizer)
 
         self.attachments: list[dict[str, str]] = []
         self.context_docs: list[str] = []

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -402,7 +402,9 @@ pipeline, fallback cleanup, and regression coverage strategy), see
   ownership/revision links, classification enums and approval date). Requirement
   switching now applies batched autosize/layout updates under a frozen content
   panel, so keyboard navigation through the list no longer triggers a visible
-  per-field relayout cascade.
+  per-field relayout cascade. When the same editor is hosted in the detached
+  floating window (`DetachedEditorFrame`), the panel applies a small outer
+  inset so standalone editing does not render flush against the frame edges.
 
 ## Cross-cutting infrastructure
 

--- a/tests/gui/test_editor_dirty.py
+++ b/tests/gui/test_editor_dirty.py
@@ -406,6 +406,24 @@ def test_detached_editor_cancel_closes_window_without_saving(wx_app, tmp_path):
         parent.Destroy()
 
 
+@pytest.mark.gui_smoke
+def test_editor_panel_detached_mode_adds_outer_inset(wx_app):
+    pytest.importorskip("wx")
+    import wx
+
+    from app.ui.editor_panel import EditorPanel
+
+    frame = wx.Frame(None)
+    try:
+        panel = EditorPanel(frame, detached_mode=True)
+        sizer = panel.GetSizer()
+        assert sizer is not None
+        outer_item = sizer.GetItem(0)
+        assert outer_item is not None
+        assert outer_item.GetBorder() > 0
+    finally:
+        frame.Destroy()
+
 
 @pytest.mark.gui_smoke
 def test_editor_panel_verification_methods_compact_selector_updates_selection(wx_app):


### PR DESCRIPTION
### Motivation
- Когда редактор открывается в отдельном плавающем окне, форма рендерилась вплотную к границам окна и выглядела неаккуратно, поэтому нужен небольшой внешний отступ для standalone-режима. 
- Избегать хардкодинга в `DetachedEditorFrame` и сделать поведение расширяемым на уровне панели ― чтобы не ломать встроенный (вправо) редактор и упростить поддержку. 

### Description
- Добавлен параметр `detached_mode: bool` в `EditorPanel` и внутренняя переменная `self._detached_mode` для явного различения режимов. 
- Включён внешний контейнер: при `detached_mode=True` основной `root_sizer` оборачивается в `outer_sizer` с отступом `dip(self, 8)`, чтобы контент не прилипал к краям окна. 
- `DetachedEditorFrame` теперь создаёт `EditorPanel(..., detached_mode=True)`, гарантирующе ожидаемое поведение отдельно открываемого окна. 
- Обновлена документация `docs/ARCHITECTURE.md` и добавлен GUI smoke-тест `test_editor_panel_detached_mode_adds_outer_inset` в `tests/gui/test_editor_dirty.py`, проверяющий наличие внешнего border у корневого sizer в detached-режиме. 

### Testing
- Запущен целевой smoke-набор: `python3 -m pytest --suite gui-smoke -q tests/gui/test_editor_dirty.py -k "detached_mode_adds_outer_inset or detached_editor_cancel_closes_window_without_saving"`. 
- Результат прогонки: `2 passed, 15 deselected`.
- Из заметок по тестированию: визуальную проверку пришлось свести к проверке структуры sizer (границы), так как в текущем раннере отсутствует удобный механизм автоснимков GUI для скриншотов.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e238d426e08320bc945de057151d43)