### PR TITLE
Persist LabelSelectionDialog layout/column widths and fix unchecked selection handling

### DIFF
--- a/app/ui/label_selection_dialog.py
+++ b/app/ui/label_selection_dialog.py
@@ -52,6 +52,11 @@ class LabelSelectionDialog(wx.Dialog):
         self._selected_keys: set[str] = {key for key in selected if isinstance(key, str)}
         self._config = self._resolve_config(parent)
         self._include_inherited_key = "labels_include_inherited"
+        self._size_w_key = "label_selection_w"
+        self._size_h_key = "label_selection_h"
+        self._pos_x_key = "label_selection_x"
+        self._pos_y_key = "label_selection_y"
+        self._col_width_key_prefix = "label_selection_col_width_"
         self._has_inherited_toggle = inherited_labels is not None
         self._include_inherited = self._read_include_inherited_default()
 
@@ -65,6 +70,7 @@ class LabelSelectionDialog(wx.Dialog):
         self.list.AssignImageList(self._img_list, wx.IMAGE_LIST_SMALL)
 
         self.list.Bind(wx.EVT_SIZE, self._on_list_size)
+        self.list.Bind(wx.EVT_LIST_COL_END_DRAG, self._on_column_resize)
 
         sizer = wx.BoxSizer(wx.VERTICAL)
         if self._has_inherited_toggle:
@@ -90,9 +96,74 @@ class LabelSelectionDialog(wx.Dialog):
             sizer.Add(btn_sizer, 0, wx.ALIGN_RIGHT | wx.ALL, 5)
         self.SetSizer(sizer)
         sizer.Fit(self)
-        self.SetMinSize(self.GetSize())
+        self._load_layout()
         self._populate_labels()
-        wx.CallAfter(self._resize_columns)
+        self.Bind(wx.EVT_CLOSE, self._on_close)
+
+    def _read_int(self, key: str, default: int) -> int:
+        try:
+            value = self._config.get_value(key, default)
+        except Exception:
+            return default
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return default
+
+    def _write_int(self, key: str, value: int) -> None:
+        self._config.set_value(key, int(value))
+
+    def _load_layout(self) -> None:
+        default_w = self.FromDIP(920)
+        default_h = self.FromDIP(680)
+        min_w = self.FromDIP(640)
+        min_h = self.FromDIP(460)
+        max_w = self.FromDIP(1700)
+        max_h = self.FromDIP(1200)
+        width = max(min_w, min(self._read_int(self._size_w_key, default_w), max_w))
+        height = max(min_h, min(self._read_int(self._size_h_key, default_h), max_h))
+        self.SetMinSize((min_w, min_h))
+        self.SetSize((width, height))
+        pos_x = self._read_int(self._pos_x_key, -1)
+        pos_y = self._read_int(self._pos_y_key, -1)
+        if pos_x != -1 and pos_y != -1:
+            self.SetPosition((pos_x, pos_y))
+            rect = self.GetRect()
+            if not any(
+                wx.Display(index).GetGeometry().Intersects(rect)
+                for index in range(wx.Display.GetCount())
+            ):
+                if self.GetParent():
+                    self.CenterOnParent()
+                else:
+                    self.Centre()
+        else:
+            if self.GetParent():
+                self.CenterOnParent()
+            else:
+                self.Centre()
+
+    def _save_layout(self) -> None:
+        width, height = self.GetSize()
+        pos_x, pos_y = self.GetPosition()
+        self._write_int(self._size_w_key, width)
+        self._write_int(self._size_h_key, height)
+        self._write_int(self._pos_x_key, pos_x)
+        self._write_int(self._pos_y_key, pos_y)
+        for index in range(self.list.GetColumnCount()):
+            col_width = self.list.GetColumnWidth(index)
+            if col_width > 0:
+                self._write_int(f"{self._col_width_key_prefix}{index}", col_width)
+        self._config.flush()
+
+    def _restore_column_widths(self) -> bool:
+        restored = False
+        for index in range(self.list.GetColumnCount()):
+            width = self._read_int(f"{self._col_width_key_prefix}{index}", -1)
+            if width > 0:
+                self.list.SetColumnWidth(index, width)
+                restored = True
+        return restored
 
     def _resolve_config(self, parent: wx.Window | None) -> ConfigManager:
         cfg = getattr(parent, "config", None)
@@ -118,6 +189,12 @@ class LabelSelectionDialog(wx.Dialog):
             return
 
     def _sync_checked_selection(self) -> None:
+        visible_keys = {
+            label.key
+            for label in self._labels
+            if isinstance(label.key, str)
+        }
+        self._selected_keys.difference_update(visible_keys)
         for idx in self.list.GetCheckedItems():
             if 0 <= idx < len(self._labels):
                 self._selected_keys.add(self._labels[idx].key)
@@ -138,7 +215,8 @@ class LabelSelectionDialog(wx.Dialog):
             self.list.SetItemColumnImage(idx, 0, img_idx)
             if lbl.key in self._selected_keys:
                 self.list.CheckItem(idx)
-        self._resize_columns()
+        if not self._restore_column_widths():
+            self._resize_columns()
 
     def _on_toggle_inherited(self, event: wx.CommandEvent) -> None:  # pragma: no cover - GUI event
         self._sync_checked_selection()
@@ -170,7 +248,15 @@ class LabelSelectionDialog(wx.Dialog):
             self.list.SetColumnWidth(2, third)
 
     def _on_list_size(self, _event: wx.Event) -> None:  # pragma: no cover - GUI event
-        self._resize_columns()
+        if not self._restore_column_widths():
+            self._resize_columns()
+
+    def _on_column_resize(self, _event: wx.ListEvent) -> None:  # pragma: no cover - GUI event
+        self._save_layout()
+
+    def _on_close(self, event: wx.CloseEvent) -> None:  # pragma: no cover - GUI event
+        self._save_layout()
+        event.Skip()
 
     def get_selected(self) -> list[str]:
         """Return names of checked and custom labels."""
@@ -188,3 +274,7 @@ class LabelSelectionDialog(wx.Dialog):
                 if name not in names:
                     names.append(name)
         return names
+
+    def Destroy(self) -> bool:  # pragma: no cover - GUI side effect
+        self._save_layout()
+        return super().Destroy()

--- a/tests/gui/test_list_panel_gui.py
+++ b/tests/gui/test_list_panel_gui.py
@@ -531,10 +531,15 @@ def test_list_panel_bulk_labels_change(monkeypatch, wx_app):
     captured: dict[str, object] = {}
 
     class DummyDialog:
-        def __init__(self, parent, labels, selected, allow_freeform):
+        def __init__(self, parent, labels, selected, allow_freeform, **kwargs):
             captured["labels"] = labels
             captured["selected"] = selected
             captured["allow_freeform"] = allow_freeform
+            captured["inherited_labels"] = kwargs.get("inherited_labels")
+            captured["label_sources"] = kwargs.get("label_sources")
+            captured["inherited_label_sources"] = kwargs.get(
+                "inherited_label_sources"
+            )
 
         def ShowModal(self):
             return wx.ID_OK
@@ -567,6 +572,8 @@ def test_list_panel_bulk_labels_change(monkeypatch, wx_app):
     assert captured["allow_freeform"] is True
     available = {label.key for label in captured["labels"]}
     assert {"backend", "api", "legacy"}.issubset(available)
+    inherited_available = {label.key for label in captured["inherited_labels"] or []}
+    assert {"backend", "api", "legacy"}.issubset(inherited_available)
     assert captured["selected"] == ["backend"]
     assert captured.get("destroyed") is True
 

--- a/tests/unit/test_label_selection_dialog.py
+++ b/tests/unit/test_label_selection_dialog.py
@@ -68,6 +68,25 @@ def test_label_selection_dialog_inherited_toggle_is_persisted(
         parent.Destroy()
 
 
+def test_label_selection_dialog_unchecked_label_is_removed_from_selection(wx_app: wx.App) -> None:
+    dlg = LabelSelectionDialog(
+        None,
+        [
+            LabelDef(key="backend", title="Backend", color=None),
+            LabelDef(key="legacy", title="Legacy", color=None),
+        ],
+        ["backend", "legacy"],
+    )
+    try:
+        assert dlg.list.IsItemChecked(0)
+        assert dlg.list.IsItemChecked(1)
+        dlg.list.CheckItem(1, False)
+        result = dlg.get_selected()
+        assert result == ["backend"]
+    finally:
+        dlg.Destroy()
+
+
 def test_editor_panel_passes_full_inherited_labels_to_selection_dialog(
     wx_app: wx.App, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -138,5 +157,41 @@ def test_label_selection_dialog_shows_document_source_column(wx_app: wx.App) -> 
         assert dlg.list.GetItemCount() == 2
         assert dlg.list.GetItemText(1, 2) == "SYS"
         dlg.Destroy()
+    finally:
+        parent.Destroy()
+
+
+def test_label_selection_dialog_persists_layout_and_column_widths(
+    wx_app: wx.App, tmp_path: Path
+) -> None:
+    config = ConfigManager(path=tmp_path / "config.json")
+    parent = wx.Frame(None)
+    parent.config = config  # type: ignore[attr-defined]
+    labels = [
+        LabelDef(key="local", title="Local", color=None),
+        LabelDef(key="parent", title="Parent", color=None),
+    ]
+    try:
+        dlg = LabelSelectionDialog(parent, labels, [], inherited_labels=labels)
+        dlg.SetSize((780, 560))
+        dlg.SetPosition((120, 140))
+        dlg.list.SetColumnWidth(0, 180)
+        dlg.list.SetColumnWidth(1, 220)
+        dlg.list.SetColumnWidth(2, 260)
+        dlg.Destroy()
+
+        dlg_restored = LabelSelectionDialog(parent, labels, [], inherited_labels=labels)
+        try:
+            restored_size = dlg_restored.GetSize()
+            restored_pos = dlg_restored.GetPosition()
+            assert restored_size.GetWidth() == 780
+            assert restored_size.GetHeight() == 560
+            assert restored_pos.x == 120
+            assert restored_pos.y == 140
+            assert dlg_restored.list.GetColumnWidth(0) == 180
+            assert dlg_restored.list.GetColumnWidth(1) == 220
+            assert dlg_restored.list.GetColumnWidth(2) == 260
+        finally:
+            dlg_restored.Destroy()
     finally:
         parent.Destroy()


### PR DESCRIPTION
### Motivation

- Remembering dialog geometry and column widths improves UX by restoring the user's previous layout for `LabelSelectionDialog` between launches.
- Column drag and window close should persist layout to the `ConfigManager` so custom adjustments are preserved.
- Selection state needed to remove unchecked visible labels while still preserving selections for labels not currently visible (e.g. inherited vs local). 

### Description

- Added persistent layout support by introducing `_load_layout`, `_save_layout`, `_read_int`, `_write_int`, and `_restore_column_widths` to store and restore dialog `width`, `height`, `x`, `y`, and per-column widths using config keys like `label_selection_w`, `label_selection_col_width_{index}`. 
- Hooked layout persistence into events by binding `EVT_LIST_COL_END_DRAG` to `_on_column_resize`, saving layout on `EVT_CLOSE` in `_on_close`, and overriding `Destroy` to call `_save_layout`. 
- Updated `_populate_labels` to restore saved column widths if available and fall back to `_resize_columns` otherwise. 
- Fixed selection synchronization in `_sync_checked_selection` to remove visible but unchecked labels from `_selected_keys` before re-adding checked items, ensuring unchecked items are dropped while preserving selections for hidden labels. 

### Testing

- Added `test_label_selection_dialog_unchecked_label_is_removed_from_selection` which verifies unchecked visible labels are removed from the selection and it passed. 
- Added `test_label_selection_dialog_persists_layout_and_column_widths` which verifies size, position and column widths are persisted across dialog instances and it passed. 
- Ran the unit test suite for `tests/unit/test_label_selection_dialog.py` and the new tests passed alongside existing dialog tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9df37caf8832095887f6446248366)