### PR TITLE
Fix trace_matrix import failure by restoring corrupted helper block

### DIFF
--- a/app/ui/trace_matrix.py
+++ b/app/ui/trace_matrix.py
@@ -158,15 +158,46 @@ def _entry_field_value(entry, field: str) -> str:
     return str(value)
 
 
-    """Render one directional target row without duplicating equivalent RID/title prefixes."""
+def _build_axis_line(entry, selected_fields: tuple[str, ...]) -> str:
+    lines = [_entry_field_value(entry, field) for field in selected_fields]
+    filtered = [line for line in lines if line.strip()]
+    return "\n".join(filtered)
+
+
+def _normalize_directional_target_values(values: list[str], target_fields: tuple[str, ...]) -> list[str]:
+    """Drop duplicate RID when title already starts with the same identifier."""
     field_to_value = dict(zip(target_fields, values, strict=False))
     rid_value = field_to_value.get("rid", "").strip()
     title_value = field_to_value.get("title", "").strip()
-        values = [
-            value
-            for idx, value in enumerate(values)
-            if target_fields[idx] != "rid"
-        ]
+    if rid_value and title_value and title_starts_with_rid(title_value, rid_value):
+        return [value for idx, value in enumerate(values) if target_fields[idx] != "rid"]
+    return values
+
+
+def apply_display_options(matrix: TraceMatrix, options: TraceMatrixDisplayOptions) -> TraceMatrix:
+    """Return matrix reordered/filtered according to ``options``."""
+
+    rows = tuple(sorted(matrix.rows, key=lambda entry: _entry_field_value(entry, options.row_sort_field)))
+    columns = tuple(sorted(matrix.columns, key=lambda entry: _entry_field_value(entry, options.column_sort_field)))
+
+    if options.hide_unlinked:
+        rows = tuple(
+            row
+            for row in rows
+            if any((cell := matrix.cells.get((row.rid, column.rid))) is not None and cell.links for column in columns)
+        )
+        columns = tuple(
+            column
+            for column in columns
+            if any((cell := matrix.cells.get((row.rid, column.rid))) is not None and cell.links for row in rows)
+        )
+
+    return TraceMatrix(
+        config=matrix.config,
+        direction=matrix.direction,
+        rows=rows,
+        columns=columns,
+        cells=matrix.cells,
         summary=matrix.summary,
         documents=matrix.documents,
     )
@@ -1565,6 +1596,7 @@ def _directional_row_values(
     chunks: list[str] = []
     for target in row.targets:
         values = [_entry_field_value(target, field).strip() for field in target_fields]
+        values = _normalize_directional_target_values(values, target_fields)
         normalized = " | ".join(value for value in values if value)
         if normalized:
             chunks.append(normalized)


### PR DESCRIPTION
### Motivation
- Модуль `app/ui/trace_matrix.py` не импортировался из‑за структурно повреждённого фрагмента (вызов `IndentationError`), что ломало GUI‑функциональность вокруг просмотра матрицы трассируемости.  
- Нужно было не просто исправить отступ, а восстановить отсутствовавшие вспомогательные функции, которые используются в `TraceMatrixFrame` и экспортах.  
- Возвращение корректного поведения directional-форматирования требуется, чтобы не дублировать RID в целевых строках при экспортах/отображении.  

### Description
- Восстановлена функция ` _build_axis_line` для корректной сборки заголовков/текстов требований в матрице.  
- Добавлена ` _normalize_directional_target_values` и интегрирована в `_directional_row_values` чтобы удалять дублирующий `rid`, когда `title` начинается с того же идентификатора.  
- Восстановлена `apply_display_options` с сортировкой и фильтрацией `hide_unlinked`, возвращающая корректную `TraceMatrix` проекцию.  
- Изменения ограничены логикой UI‑помощников и не затрагивают core алгоритмы построения матрицы.  

### Testing
- Скомпилировал модуль командой `python3 -m py_compile app/ui/trace_matrix.py`, компиляция прошла успешно.  
- Запущены модульные тесты `pytest --suite core -q tests/unit/test_ui_module_syntax.py tests/unit/test_main_frame_documents.py`, результаты: `2 passed`.  
- Запущены GUI smoke‑тесты `pytest --suite gui-smoke -q tests/gui/test_main_auxiliary_windows.py::test_trace_matrix_import_syntax_error_shows_recovery_hint tests/gui/test_trace_matrix_window.py::test_trace_matrix_frame_renders_links`, результаты: `2 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef6b98b8d48320ac79543aba03aa71)