### PR TITLE
Синхронизировать колонки диалога выбора родительского требования с главным списком

### DIFF
--- a/app/ui/editor_panel.py
+++ b/app/ui/editor_panel.py
@@ -91,6 +91,7 @@ class RequirementLinkPickerDialog(wx.Dialog):
         candidates: list[dict[str, str]],
         selected_rids: set[str] | None = None,
         current_prefix: str | None = None,
+        list_columns: list[str] | None = None,
     ):
         super().__init__(
             parent,
@@ -105,6 +106,7 @@ class RequirementLinkPickerDialog(wx.Dialog):
         self._current_prefix = (current_prefix or "").strip().upper()
         self._source_options: list[tuple[str, str]] = []
         self._source_filter_key = ""
+        self._list_columns = list_columns or ["labels", "id", "source", "status"]
 
         root = wx.BoxSizer(wx.VERTICAL)
         search_row = wx.BoxSizer(wx.HORIZONTAL)
@@ -118,7 +120,7 @@ class RequirementLinkPickerDialog(wx.Dialog):
 
         self._list_panel = ListPanel(self)
         self._list_panel.document_summary.Hide()
-        self._list_panel.set_columns(["id", "status", "type", "priority", "owner", "labels", "verification"])
+        self._list_panel.set_columns(self._list_columns)
         self._list_panel.filter_btn.Bind(wx.EVT_BUTTON, self._on_filter_button)
         self._list_panel.list.Bind(wx.EVT_LIST_ITEM_SELECTED, self._on_item_selected)
         self._list_panel.list.Bind(wx.EVT_LIST_ITEM_DESELECTED, self._on_item_deselected)
@@ -288,9 +290,23 @@ class RequirementLinkPickerDialog(wx.Dialog):
         self._visible_candidates = list(filtered_by_source)
         requirements = []
         for idx, row in enumerate(self._visible_candidates, start=1):
+            labels = row.get("labels")
+            if not isinstance(labels, list):
+                labels = []
             requirements.append(
                 Requirement.from_mapping(
-                    {"id": idx, "title": str(row.get("title", "")), "statement": str(row.get("statement", ""))},
+                    {
+                        "id": idx,
+                        "title": str(row.get("title", "")),
+                        "statement": str(row.get("statement", "")),
+                        "status": str(row.get("status", Status.DRAFT.value)),
+                        "type": str(row.get("type", RequirementType.REQUIREMENT.value)),
+                        "priority": str(row.get("priority", Priority.MEDIUM.value)),
+                        "owner": str(row.get("owner", "")),
+                        "source": str(row.get("source", "")),
+                        "labels": labels,
+                        "verification": row.get("verification", Verification.NOT_DEFINED.value),
+                    },
                     doc_prefix=str(row.get("prefix", "")),
                     rid=row["rid"],
                 )
@@ -1252,6 +1268,13 @@ class EditorPanel(wx.Panel):
                     "rid": rid,
                     "title": str(getattr(requirement, "title", "") or "").strip(),
                     "statement": str(getattr(requirement, "statement", "") or "").strip(),
+                    "status": str(getattr(requirement, "status", Status.DRAFT.value)),
+                    "type": str(getattr(requirement, "type", RequirementType.REQUIREMENT.value)),
+                    "priority": str(getattr(requirement, "priority", Priority.MEDIUM.value)),
+                    "owner": str(getattr(requirement, "owner", "") or "").strip(),
+                    "source": str(getattr(requirement, "source", "") or "").strip(),
+                    "labels": list(getattr(requirement, "labels", []) or []),
+                    "verification": list(getattr(requirement, "verification", []) or [Verification.NOT_DEFINED.value]),
                     "document": docs.get(prefix, prefix),
                     "prefix": prefix.upper(),
                     "distance": _ancestor_distance(current_prefix, prefix.upper()),
@@ -1260,6 +1283,21 @@ class EditorPanel(wx.Panel):
         rows.sort(key=lambda row: (row["rid"], row["title"]))
         return rows
 
+    def _resolve_link_picker_columns(self) -> list[str]:
+        """Reuse configured main-list columns in the links picker."""
+        config = getattr(self, "config", None)
+        if config is None:
+            top_level = wx.GetTopLevelParent(self)
+            config = getattr(top_level, "config", None) if top_level is not None else None
+        if config is None:
+            return ["labels", "id", "source", "status"]
+        try:
+            columns = list(config.get_columns())
+        except Exception:
+            logger.exception("Failed to read columns from config for link picker")
+            return ["labels", "id", "source", "status"]
+        return columns or ["labels", "id", "source", "status"]
+
     def _show_link_picker(self, attr: str, selected_rids: set[str] | None = None) -> list[str]:
         """Open picker dialog and return selected RIDs."""
         dialog = RequirementLinkPickerDialog(
@@ -1267,6 +1305,7 @@ class EditorPanel(wx.Panel):
             self._collect_link_picker_candidates(attr),
             selected_rids=selected_rids,
             current_prefix=self._effective_prefix(),
+            list_columns=self._resolve_link_picker_columns(),
         )
         try:
             if dialog.ShowModal() != wx.ID_OK:

--- a/tests/gui/test_link_titles.py
+++ b/tests/gui/test_link_titles.py
@@ -154,3 +154,43 @@ def test_remove_link_by_index_updates_links_table(wx_app):
     assert panel.links_panel.GetItemCount() == 1
     assert panel.links_panel.GetItem(0, 0).GetText() == "SYS2"
     frame.Destroy()
+
+
+def test_link_picker_uses_main_columns_and_shows_labels(wx_app, tmp_path):
+    frame = wx.Frame(None)
+    panel = EditorPanel(frame)
+    service = RequirementsService(tmp_path)
+    service.save_document(Document(prefix="REQ", title="Requirements"))
+    service.save_document(Document(prefix="SYS", title="Systems"))
+    service.save_requirement_payload(
+        "SYS",
+        {
+            "id": 123,
+            "title": "Parent",
+            "statement": "",
+            "type": "requirement",
+            "status": "approved",
+            "owner": "QA",
+            "priority": "medium",
+            "source": "Spec",
+            "verification": "analysis",
+            "acceptance": None,
+            "assumptions": "",
+            "conditions": "",
+            "rationale": "",
+            "labels": ["Safety", "UI"],
+            "attachments": [],
+            "revision": 1,
+            "modified_at": "",
+            "notes": "",
+        },
+    )
+    panel.set_service(service)
+    panel.set_document("REQ")
+    panel.config.set_columns(["labels", "id", "source", "status"])
+
+    candidates = panel._collect_link_picker_candidates("links")
+    assert candidates and candidates[0]["labels"] == ["Safety", "UI"]
+    columns = panel._resolve_link_picker_columns()
+    assert columns == ["labels", "id", "source", "status"]
+    frame.Destroy()


### PR DESCRIPTION
### Motivation
- При выборе родительского требования диалог использовал другой, захардкоженный набор колонок и «обрезанные» данные кандидатов, из‑за чего порядок колонок отличался от главного списка и метки не отображались.
- Требовалось привести схему данных и набор колонок к единому стандарту, чтобы убрать рассинхрон интерфейса и корректно рендерить `labels` и другие поля.

### Description
- Переработан `RequirementLinkPickerDialog` в `app/ui/editor_panel.py` для приёма опции `list_columns` и установки колонок через `self._list_panel.set_columns(...)` вместо хардкода. 
- Расширена формируемая полезная нагрузка кандидатов: теперь строки пикера содержат `status`, `type`, `priority`, `owner`, `source`, `labels`, `verification` и т.д., чтобы `ListPanel` мог корректно заполнить все колонки. 
- Добавлен метод `_resolve_link_picker_columns`, который пытается взять порядок колонок из активного UI `config.get_columns()` с безопасным fallback на `[

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f23e23bd0483208fa27cdd67551555)