### PR TITLE
Improve grouping-level localization in labels dialog

### DIFF
--- a/app/locale/en/LC_MESSAGES/CookaReq.po
+++ b/app/locale/en/LC_MESSAGES/CookaReq.po
@@ -3546,5 +3546,5 @@ msgstr "n/a"
 msgid "Grouping level"
 msgstr "Grouping level"
 
-msgid "None"
-msgstr "None"
+msgid "No grouping"
+msgstr "No grouping"

--- a/app/locale/ru/LC_MESSAGES/CookaReq.po
+++ b/app/locale/ru/LC_MESSAGES/CookaReq.po
@@ -3566,5 +3566,5 @@ msgstr "н/д"
 msgid "Grouping level"
 msgstr "Уровень группировки"
 
-msgid "None"
-msgstr "Нет"
+msgid "No grouping"
+msgstr "Без группировки"

--- a/app/ui/labels_dialog.py
+++ b/app/ui/labels_dialog.py
@@ -11,7 +11,7 @@ from ..services.requirements import LabelDef, label_color
 from ..i18n import _
 
 
-GROUP_LEVEL_CHOICES: list[tuple[int, str]] = [(0, _("None")), (1, "1"), (2, "2"), (3, "3")]
+GROUP_LEVEL_CHOICES: list[tuple[int, str]] = [(0, _("No grouping")), (1, "1"), (2, "2"), (3, "3")]
 
 
 class _LabelEditDialog(wx.Dialog):
@@ -199,7 +199,7 @@ class LabelsDialog(wx.Dialog):
         for lbl in self._labels:
             idx = self.list.InsertItem(self.list.GetItemCount(), lbl.key)
             self.list.SetItem(idx, 1, lbl.title)
-            self.list.SetItem(idx, 2, str(lbl.group_level) if lbl.group_level else _("None"))
+            self.list.SetItem(idx, 2, str(lbl.group_level) if lbl.group_level else _("No grouping"))
             self.list.SetItem(idx, 3, str(self._label_usage_count(lbl.key)))
             img_idx = self._get_icon_index(label_color(lbl))
             self.list.SetItemColumnImage(idx, 0, img_idx)
@@ -499,7 +499,7 @@ class LabelsDialog(wx.Dialog):
             lbl.group_level = group_level
             self.list.SetItem(idx, 0, lbl.key)
             self.list.SetItem(idx, 1, lbl.title)
-            self.list.SetItem(idx, 2, str(lbl.group_level) if lbl.group_level else _("None"))
+            self.list.SetItem(idx, 2, str(lbl.group_level) if lbl.group_level else _("No grouping"))
             if new_key != old_key:
                 self._original_key_lookup.pop(old_key, None)
                 self._original_key_lookup[new_key] = original_key
@@ -511,7 +511,7 @@ class LabelsDialog(wx.Dialog):
             else:
                 if original_key in self._key_changes:
                     self._key_changes.pop(original_key, None)
-            self.list.SetItem(idx, 2, str(lbl.group_level) if lbl.group_level else _("None"))
+            self.list.SetItem(idx, 2, str(lbl.group_level) if lbl.group_level else _("No grouping"))
             self.list.SetItem(idx, 3, str(self._label_usage_count(lbl.key)))
             self._update_dirty_state()
         finally:


### PR DESCRIPTION
### Motivation

- Заменить расплывчатый UI-текст `None` для уровня группировки на предметный `No grouping` чтобы улучшить понятность и обеспечить согласованную локализацию (русский — `Без группировки`).
- Правка также призвана убрать несоответствие отображения в диалоге меток и таблице списка меток между англ. и рус. каталогами.
- В процессе работы обнаружены проблемы с покрытием переводов (отсутствуют msgid, не связанные с этой правкой), и поиск «None» дал много нерелевантных совпадений, что усложнило внесение изменений.

### Description

- В `app/ui/labels_dialog.py` обновлён `GROUP_LEVEL_CHOICES` на `_("No grouping")` и все места отображения уровня группировки (в т.ч. при populate и после редактирования) теперь используют `No grouping` вместо `None`.
- В каталогах переводов добавлен/обновлён msgid `"No grouping"` в `app/locale/en/LC_MESSAGES/CookaReq.po` и соответствующий перевод `"Без группировки"` в `app/locale/ru/LC_MESSAGES/CookaReq.po`.
- Изменения сохранены в репозитории (коммит: "Improve grouping-level localization in labels dialog").

### Testing

- Запущена команда `python3 -m pytest --suite core -q tests/unit/test_labels_dialog.py tests/slow/test_translation_coverage.py`.
- `tests/unit/test_labels_dialog.py` прошёл успешно.
- `tests/slow/test_translation_coverage.py::test_source_strings_are_in_catalogue` завершился с ошибкой из‑за уже существующих отсутствующих строк в каталоге (`Filter` и диагностическое сообщение про `trace_matrix.py`), которые не связаны с этой правкой.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f395074f188320bbb1c3da24e2f890)