### PR TITLE
Make wxPython optional and avoid importing GUI on CLI startup

### DIFF
--- a/app/application.py
+++ b/app/application.py
@@ -5,7 +5,6 @@ from collections.abc import Callable
 
 from pathlib import Path
 from typing import TYPE_CHECKING, Protocol
-from .config import ConfigManager
 from .confirm import (
     ConfirmDecision,
     RequirementUpdatePrompt,
@@ -15,13 +14,19 @@ from .confirm import (
 from .mcp.controller import MCPController
 from .services.requirements import RequirementsService
 from .settings import AppSettings
-from .ui.requirement_model import RequirementModel
 
 if TYPE_CHECKING:  # pragma: no cover - type checking only
     from .agent import LocalAgent
+    from .config import ConfigManager
+    from .ui.requirement_model import RequirementModel
 
 ConfirmCallback = Callable[[str], bool]
 RequirementUpdateConfirmCallback = Callable[[RequirementUpdatePrompt], ConfirmDecision]
+
+def _default_requirement_model_factory() -> "RequirementModel":
+    from .ui.requirement_model import RequirementModel
+
+    return RequirementModel()
 
 
 class RequirementsServiceFactory(Protocol):
@@ -64,17 +69,21 @@ class ApplicationContext:
         app_name: str = "CookaReq",
         confirm_callback: ConfirmCallback,
         requirement_update_confirm_callback: RequirementUpdateConfirmCallback,
-        config_factory: Callable[[str], ConfigManager] | None = None,
-        requirement_model_factory: Callable[[], RequirementModel] | None = None,
+        config_factory: Callable[[str], "ConfigManager"] | None = None,
+        requirement_model_factory: Callable[[], "RequirementModel"] | None = None,
         requirements_service_cls: type[RequirementsService] = RequirementsService,
         local_agent_cls: type[LocalAgent] | None = None,
         mcp_controller_cls: type[MCPController] = MCPController,
     ) -> None:
         """Initialise the dependency container shared across frontends."""
         self._app_name = app_name
-        self._config_factory = config_factory or (lambda name: ConfigManager(name))
+        if config_factory is None:
+            from .config import ConfigManager
+
+            config_factory = lambda name: ConfigManager(name)
+        self._config_factory = config_factory
         self._requirement_model_factory = (
-            requirement_model_factory or RequirementModel
+            requirement_model_factory or _default_requirement_model_factory
         )
         self._requirements_service_cls = requirements_service_cls
         self._local_agent_cls = local_agent_cls

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -30,6 +30,11 @@ For the agent chat transcript ordering refactor (single canonical timeline
 pipeline, fallback cleanup, and regression coverage strategy), see
 `docs/AGENT_TIMELINE_STABILIZATION_PLAN.md`.
 
+
+## Packaging profile
+
+`wxPython` is declared as an optional `gui` extra in `pyproject.toml`, so CLI/server usage can install base dependencies without GUI toolkit payload. Install GUI runtime with `pip install cookareq[gui]`.
+
 ## Core domain: requirements and traceability
 
 * **On-disk layout** — each document lives under `requirements/<PREFIX>/`.
@@ -172,6 +177,7 @@ pipeline, fallback cleanup, and regression coverage strategy), see
 
 ## Application services and configuration context
 
+* **Bootstrap boundaries** — `ApplicationContext` now lazily imports GUI-bound pieces (`ConfigManager`, `RequirementModel`) only when they are actually requested. CLI startup (`python3 -m app.cli`) therefore avoids importing `wx` and can run in headless/minimal environments while still sharing the same composition root.
 * **`RequirementsService`** — wraps the document store with caching, consistent
   path resolution and domain-specific errors (`DocumentNotFoundError`,
   `ValidationError`). Both the GUI and automation flows consume this service

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,6 @@ version = "0.1.0"
 authors = [{ name = "Maksim Lashkevich & Codex" }]
 license = { file = "LICENSE" }
 dependencies = [
-    "wxPython",
     "jsonschema",
     "charset-normalizer",
     "fastapi",
@@ -19,6 +18,9 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+gui = [
+    "wxPython",
+]
 dev = [
     "pytest",
     "pytest-xvfb",

--- a/tests/unit/test_cli_main.py
+++ b/tests/unit/test_cli_main.py
@@ -57,3 +57,12 @@ def test_cli_main_runs_startup_dependency_check(monkeypatch):
 
     assert cli_main.main(["doc", "list", "."]) == 0
     assert calls[:2] == ["logging", "deps"]
+
+
+def test_importing_cli_main_does_not_import_wx() -> None:
+    import importlib
+
+    module = importlib.import_module("app.cli.main")
+
+    assert module is not None
+    assert "wx" not in sys.modules

--- a/tests/unit/test_packaging_dependencies.py
+++ b/tests/unit/test_packaging_dependencies.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def _pyproject() -> dict:
+    return tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+
+
+def test_wxpython_is_gui_extra_only() -> None:
+    data = _pyproject()
+    deps = data["project"]["dependencies"]
+    optional = data["project"]["optional-dependencies"]
+
+    assert "wxPython" not in deps
+    assert "wxPython" in optional["gui"]


### PR DESCRIPTION
### Motivation

- Reduce default install size and allow headless CLI usage by not forcing `wxPython` as a hard dependency. 
- Avoid importing GUI-bound modules during CLI startup so the CLI can run in minimal/headless environments. 

### Description

- Move `wxPython` out of top-level `project.dependencies` into an optional `gui` extra in `pyproject.toml` (`gui = ["wxPython"]`).
- Introduce lazy imports in `ApplicationContext` by deferring `ConfigManager` and `RequirementModel` imports and adding a `_default_requirement_model_factory()` helper so GUI-bound code is only imported when accessed.
- Update type annotations to reference `ConfigManager` and `RequirementModel` via string annotations where necessary to avoid early imports.
- Add documentation in `docs/ARCHITECTURE.md` describing the packaging profile and noting that `ApplicationContext` lazily imports GUI pieces.
- Add/modify tests: update `tests/unit/test_cli_main.py` to assert importing `app.cli.main` does not import `wx`, and add `tests/unit/test_packaging_dependencies.py` to assert `wxPython` is only present in the `gui` optional extra.

### Testing

- Ran unit tests including `tests/unit/test_cli_main.py` and `tests/unit/test_packaging_dependencies.py`; all tests passed. 
- The CLI import test confirms `wx` is not in `sys.modules` after importing `app.cli.main` and the packaging test confirms `wxPython` lives only in the `gui` extra.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c22d2802c8320be9bb6ae0837e7ab)