### PR TITLE
Add python-docx to required dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "bleach",
     "polib",
     "reportlab",
+    "python-docx",
     "matplotlib",
     "latex2mathml",
     "mathml2omml",


### PR DESCRIPTION
### Motivation
- Модуль `app/core/requirement_export.py` напрямую импортирует `docx`, но `python-docx` отсутствовал в упаковочных метаданных, что может приводить к runtime-ошибкам при установке из `pyproject.toml`/PEP 621 metadata.

### Description
- Добавлена зависимость `"python-docx"` в список `[project].dependencies` в `pyproject.toml`, чтобы привязать packaging metadata к реальному использованию библиотеки в коде.

### Testing
- Запуск целевого набора тестов `pytest --suite core -q tests/unit/test_requirement_export_docx.py` не был выполнен из-за отсутствия `pytest` в текущем системном окружении (`/usr/bin/python3: No module named pytest` и `pyenv: pytest: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d5de39a148320a04991cf54b9dd52)