### PR TITLE
Validate --context-docs in CLI item add/edit

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,8 @@ python3 -m app.cli check --llm --mcp
 
 Every command validates inputs before mutating files and reuses the same schema as the GUI, including label validation, revision requirements, and MCP authentication checks.
 
+For `item add`/`item edit`, `--context-docs` must be a JSON array of strings with **relative** paths inside the current document directory (for example `SYS/...`). Absolute paths, `..`, and any path escape outside of the document root are rejected. Each referenced path must already exist and point to a regular file.
+
 ## Local agent and MCP integration
 
 `app.agent.local_agent.LocalAgent` wraps the `LLMClient` and `MCPClient` to execute tool calls in response to LLM prompts. The GUI exposes it via the **Command** dialog/agent panel, while the CLI offers health checks through `python3 -m app.cli check`.

--- a/app/cli/commands.py
+++ b/app/cli/commands.py
@@ -9,7 +9,7 @@ import json
 import sys
 from copy import deepcopy
 from dataclasses import MISSING, asdict, dataclass, field, fields
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Any, TextIO
 from collections.abc import Callable, Mapping
 
@@ -519,6 +519,55 @@ def _resolve_context_docs(
     return [str(item) for item in deepcopy(base_value) if str(item).strip()]
 
 
+
+
+def _validate_context_doc_paths(*, context_docs: list[str], document_root: Path) -> list[str]:
+    """Validate context-doc paths as existing files under ``document_root``."""
+    validated: list[str] = []
+    for raw_path in context_docs:
+        candidate = str(raw_path).strip()
+        if not candidate:
+            continue
+
+        rel = PurePosixPath(candidate)
+        if rel.is_absolute():
+            raise ValidationError(
+                _("invalid context_docs path '{path}': absolute paths are not allowed").format(
+                    path=candidate
+                )
+            )
+        if any(part == ".." for part in rel.parts):
+            raise ValidationError(
+                _("invalid context_docs path '{path}': parent directory '..' is not allowed").format(
+                    path=candidate
+                )
+            )
+
+        target = (document_root / Path(rel)).resolve()
+        try:
+            target.relative_to(document_root)
+        except ValueError as exc:
+            raise ValidationError(
+                _("invalid context_docs path '{path}': path escapes document root").format(
+                    path=candidate
+                )
+            ) from exc
+
+        if not target.exists():
+            raise ValidationError(
+                _("invalid context_docs path '{path}': file does not exist").format(
+                    path=candidate
+                )
+            )
+        if not target.is_file():
+            raise ValidationError(
+                _("invalid context_docs path '{path}': not a file").format(path=candidate)
+            )
+
+        validated.append(rel.as_posix())
+
+    return validated
+
 def _resolve_revision(
     args: argparse.Namespace, base: Mapping[str, Any]
 ) -> int | None:
@@ -663,6 +712,11 @@ def cmd_item_add(
     service = _service_for(context, args.directory)
     try:
         payload = build_item_payload(args, base)
+        document_root = (Path(args.directory) / args.prefix).resolve()
+        payload["context_docs"] = _validate_context_doc_paths(
+            context_docs=list(payload.get("context_docs", [])),
+            document_root=document_root,
+        )
         req = service.create_requirement(prefix=args.prefix, data=payload)
     except DocumentNotFoundError:
         sys.stdout.write(
@@ -708,6 +762,11 @@ def cmd_item_edit(
 
     try:
         payload = build_item_payload(args, base_payload)
+        document_root = (Path(args.directory) / prefix).resolve()
+        payload["context_docs"] = _validate_context_doc_paths(
+            context_docs=list(payload.get("context_docs", [])),
+            document_root=document_root,
+        )
     except ValidationError as exc:
         sys.stdout.write(_("{msg}\n").format(msg=str(exc)))
         return 1

--- a/tests/unit/test_cli_item.py
+++ b/tests/unit/test_cli_item.py
@@ -633,6 +633,10 @@ def test_item_add_accepts_context_docs(tmp_path, capsys, cli_context):
     doc = Document(prefix="SYS", title="System")
     save_document(tmp_path / "SYS", doc)
 
+    (tmp_path / "SYS" / "related" / "math").mkdir(parents=True)
+    (tmp_path / "SYS" / "related" / "math" / "overview.md").write_text("overview", encoding="utf-8")
+    (tmp_path / "SYS" / "related" / "math" / "details.md").write_text("details", encoding="utf-8")
+
     add_args = argparse.Namespace(
         directory=str(tmp_path),
         prefix="SYS",
@@ -653,6 +657,10 @@ def test_item_add_accepts_context_docs(tmp_path, capsys, cli_context):
 def test_item_edit_updates_context_docs(tmp_path, capsys, cli_context):
     doc = Document(prefix="SYS", title="System")
     save_document(tmp_path / "SYS", doc)
+
+    (tmp_path / "SYS" / "related").mkdir(parents=True)
+    (tmp_path / "SYS" / "related" / "one.md").write_text("one", encoding="utf-8")
+    (tmp_path / "SYS" / "related" / "two.md").write_text("two", encoding="utf-8")
 
     add_args = argparse.Namespace(
         directory=str(tmp_path),
@@ -675,3 +683,62 @@ def test_item_edit_updates_context_docs(tmp_path, capsys, cli_context):
     path = item_path(tmp_path / "SYS", doc, 1)
     data = json.loads(path.read_text(encoding="utf-8"))
     assert data["context_docs"] == ["related/two.md"]
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("context_docs", "expected"),
+    [
+        ('["/tmp/outside.md"]', "absolute paths"),
+        ('["../outside.md"]', "parent directory"),
+        ('["related/missing.md"]', "does not exist"),
+    ],
+)
+def test_item_add_rejects_invalid_context_docs(tmp_path, capsys, cli_context, context_docs, expected):
+    doc = Document(prefix="SYS", title="System")
+    save_document(tmp_path / "SYS", doc)
+    (tmp_path / "SYS" / "related").mkdir(parents=True)
+    (tmp_path / "SYS" / "related" / "ok.md").write_text("ok", encoding="utf-8")
+
+    add_args = argparse.Namespace(
+        directory=str(tmp_path),
+        prefix="SYS",
+        title="Login",
+        statement="Initial",
+        context_docs=context_docs,
+    )
+    exit_code = commands.cmd_item_add(add_args, cli_context)
+
+    out = capsys.readouterr().out
+    assert exit_code == 1
+    assert "invalid context_docs path" in out
+    assert expected in out
+
+
+@pytest.mark.unit
+def test_item_edit_rejects_context_doc_directory(tmp_path, capsys, cli_context):
+    doc = Document(prefix="SYS", title="System")
+    save_document(tmp_path / "SYS", doc)
+    (tmp_path / "SYS" / "related").mkdir(parents=True)
+    (tmp_path / "SYS" / "related" / "one.md").write_text("one", encoding="utf-8")
+
+    add_args = argparse.Namespace(
+        directory=str(tmp_path),
+        prefix="SYS",
+        title="Login",
+        statement="Initial",
+        context_docs='["related/one.md"]',
+    )
+    commands.cmd_item_add(add_args, cli_context)
+    rid = capsys.readouterr().out.strip()
+
+    edit_args = argparse.Namespace(
+        directory=str(tmp_path),
+        rid=rid,
+        context_docs='["related"]',
+    )
+    exit_code = commands.cmd_item_edit(edit_args, cli_context)
+
+    out = capsys.readouterr().out
+    assert exit_code == 1
+    assert "invalid context_docs path 'related': not a file" in out


### PR DESCRIPTION
### Motivation
- Уточнить и ужесточить валидацию аргумента `--context-docs` для CLI-команд `item add` и `item edit`, чтобы предотвратить ссылку на произвольные файлы вне текущего документа и сохранить согласованность с хранением относительных markdown-путей в репозитории. 
- Сохранить совместимость с GUI, не затрагивая GUI-логику и формат полезной нагрузки (payload).

### Description
- Добавлена функция `_validate_context_doc_paths(*, context_docs: list[str], document_root: Path)` в `app/cli/commands.py`, которая проверяет, что каждая запись:
  - представлена строкой в JSON-массиве (существующая проверка),
  - не является абсолютным путем,
  - не содержит сегментов `..`,
  - не уходит за пределы каталога документа (`document_root`),
  - существует и является обычным файлом; при успехе путь нормализуется в POSIX-формат.
- Интеграция валидации в CLI-потоки: `cmd_item_add` и `cmd_item_edit` теперь вызывают `_validate_context_doc_paths` после сборки payload и перед сохранением/созданием требования, при этом GUI-слои не менялись.
- Тесты: обновлены существующие unit-тесты, которые проверяли позитивный сценарий, так что они создают соответствующие файлы в тестовом каталоге документа; добавлены негативные сценарии (отклонение абсолютного пути, `..`, несуществующего файла и указания директории вместо файла). Изменены/созданы файлы: `app/cli/commands.py`, `tests/unit/test_cli_item.py`, `README.md` (обновление секции CLI с ограничениями `--context-docs`).

### Testing
- Выполнена статическая/синтаксическая проверка: `python3 -m py_compile app/cli/commands.py tests/unit/test_cli_item.py` — успешно.
- Юнит-тесты добавлены/обновлены (`tests/unit/test_cli_item.py`) покрывают: успешные сценарии с существующими файлами и ошибки при абсолютных путях, `..`, несуществующих файлах и попытке указать директорию; локально запустить `pytest` не удалось из-за отсутствия установленного `pytest` в окружении (ошибки: `No module named pytest` / `pyenv: pytest: command not found`), поэтому полный прогон `pytest --suite core -q tests/unit/test_cli_item.py -k context_docs` не был выполнен.
- Проблемы окружения: отсутствует доступный `pytest` для текущего `python3` (см. выше), что блокирует автоматический запуск набора тестов в этой сессии; рекомендую в CI/devcontainer зафиксировать интерпретатор и установить `pytest` для надежного воспроизведения проверок.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1413b0dda4832087be1e7ea752036a)