### PR TITLE
Add file-link context menu to EditorPanel (open, reveal, remove)

### DIFF
--- a/app/locale/en/LC_MESSAGES/CookaReq.po
+++ b/app/locale/en/LC_MESSAGES/CookaReq.po
@@ -3560,3 +3560,41 @@ msgid ""
 msgstr ""
 "Global font size for the application interface.\n"
 "Applied to all windows and panels after pressing OK."
+
+msgid "Remove file link"
+msgstr "Remove file link"
+
+msgid "Show in file manager"
+msgstr "Show in file manager"
+
+msgid "Unable to show file in the file manager."
+msgstr "Unable to show file in the file manager."
+
+msgid "Filter"
+msgstr "Filter"
+
+msgid ""
+"Trace matrix module has invalid Python syntax in your local working copy.\n"
+"Check for unresolved merge/conflict edits and run:\n"
+"python3 -m py_compile app/ui/trace_matrix.py\n"
+"git restore app/ui/trace_matrix.py"
+msgstr ""
+"Trace matrix module has invalid Python syntax in your local working copy.\n"
+"Check for unresolved merge/conflict edits and run:\n"
+"python3 -m py_compile app/ui/trace_matrix.py\n"
+"git restore app/ui/trace_matrix.py"
+
+msgid "invalid context_docs path '{path}': absolute paths are not allowed"
+msgstr "invalid context_docs path '{path}': absolute paths are not allowed"
+
+msgid "invalid context_docs path '{path}': parent directory '..' is not allowed"
+msgstr "invalid context_docs path '{path}': parent directory '..' is not allowed"
+
+msgid "invalid context_docs path '{path}': path escapes document root"
+msgstr "invalid context_docs path '{path}': path escapes document root"
+
+msgid "invalid context_docs path '{path}': file does not exist"
+msgstr "invalid context_docs path '{path}': file does not exist"
+
+msgid "invalid context_docs path '{path}': not a file"
+msgstr "invalid context_docs path '{path}': not a file"

--- a/app/locale/ru/LC_MESSAGES/CookaReq.po
+++ b/app/locale/ru/LC_MESSAGES/CookaReq.po
@@ -3580,3 +3580,41 @@ msgid ""
 msgstr ""
 "Глобальный размер шрифта для интерфейса приложения.\n"
 "Применяется ко всем окнам и панелям после нажатия OK."
+
+msgid "Remove file link"
+msgstr "Удалить ссылку на файл"
+
+msgid "Show in file manager"
+msgstr "Показать в проводнике"
+
+msgid "Unable to show file in the file manager."
+msgstr "Не удалось показать файл в проводнике."
+
+msgid "Filter"
+msgstr "Фильтр"
+
+msgid ""
+"Trace matrix module has invalid Python syntax in your local working copy.\n"
+"Check for unresolved merge/conflict edits and run:\n"
+"python3 -m py_compile app/ui/trace_matrix.py\n"
+"git restore app/ui/trace_matrix.py"
+msgstr ""
+"В локальной рабочей копии модуль матрицы трассировки содержит недопустимый Python-синтаксис.\n"
+"Проверьте незавершённые правки/конфликты и выполните:\n"
+"python3 -m py_compile app/ui/trace_matrix.py\n"
+"git restore app/ui/trace_matrix.py"
+
+msgid "invalid context_docs path '{path}': absolute paths are not allowed"
+msgstr "недопустимый путь context_docs '{path}': абсолютные пути запрещены"
+
+msgid "invalid context_docs path '{path}': parent directory '..' is not allowed"
+msgstr "недопустимый путь context_docs '{path}': родительская директория '..' запрещена"
+
+msgid "invalid context_docs path '{path}': path escapes document root"
+msgstr "недопустимый путь context_docs '{path}': путь выходит за корень документа"
+
+msgid "invalid context_docs path '{path}': file does not exist"
+msgstr "недопустимый путь context_docs '{path}': файл не существует"
+
+msgid "invalid context_docs path '{path}': not a file"
+msgstr "недопустимый путь context_docs '{path}': это не файл"

--- a/app/ui/editor_panel.py
+++ b/app/ui/editor_panel.py
@@ -32,6 +32,7 @@ from ..core.model import (
     Status,
     Verification,
 )
+from ..util.system_open import open_file, reveal_in_file_manager
 from ..util.time import local_now_str, normalize_timestamp
 from ..i18n import _
 from . import locale
@@ -691,6 +692,14 @@ class EditorPanel(wx.Panel):
             wx.EVT_SIZE,
             lambda evt: (evt.Skip(), self._autosize_attachment_columns()),
         )
+        self.attachments_list.Bind(
+            wx.EVT_LIST_ITEM_RIGHT_CLICK,
+            self._on_attachment_context_menu,
+        )
+        self.attachments_list.Bind(
+            wx.EVT_CONTEXT_MENU,
+            self._on_attachment_context_menu,
+        )
         attachment_row = wx.BoxSizer(wx.HORIZONTAL)
         btn_row = wx.BoxSizer(wx.HORIZONTAL)
         self.add_attachment_btn = wx.Button(a_box, label=_("Add"))
@@ -719,6 +728,14 @@ class EditorPanel(wx.Panel):
         self.context_docs_list.Bind(
             wx.EVT_SIZE,
             lambda evt: (evt.Skip(), self._autosize_context_docs_columns()),
+        )
+        self.context_docs_list.Bind(
+            wx.EVT_LIST_ITEM_RIGHT_CLICK,
+            self._on_context_doc_context_menu,
+        )
+        self.context_docs_list.Bind(
+            wx.EVT_CONTEXT_MENU,
+            self._on_context_doc_context_menu,
         )
         self._context_docs_list = self.context_docs_list
         context_row = wx.BoxSizer(wx.HORIZONTAL)
@@ -2118,8 +2135,119 @@ class EditorPanel(wx.Panel):
 
     def _on_remove_attachment(self, _event: wx.CommandEvent) -> None:
         idx = self.attachments_list.GetFirstSelected()
-        if idx != -1:
-            del self.attachments[idx]
+        self._remove_attachment_by_index(idx)
+
+
+    def _selected_list_index_from_context_event(self, list_ctrl: wx.ListCtrl, event: wx.Event) -> int:
+        """Return the row targeted by a list context-menu event."""
+        get_index = getattr(event, "GetIndex", None)
+        if callable(get_index):
+            try:
+                index = int(get_index())
+            except (TypeError, ValueError):
+                index = wx.NOT_FOUND
+            if index >= 0:
+                return index
+        get_position = getattr(event, "GetPosition", None)
+        if callable(get_position):
+            pos = get_position()
+            try:
+                if pos.x != -1 or pos.y != -1:
+                    local_pos = list_ctrl.ScreenToClient(pos) if isinstance(event, wx.ContextMenuEvent) else pos
+                    hit = list_ctrl.HitTest(local_pos)
+                    index = hit[0] if isinstance(hit, tuple) else hit
+                    if int(index) >= 0:
+                        return int(index)
+            except Exception:
+                pass
+        return list_ctrl.GetFirstSelected()
+
+    def _resolve_requirement_file_path(self, stored_path: str) -> Path | None:
+        """Resolve a requirement-local stored file path to an absolute path."""
+        raw = str(stored_path or "").strip()
+        if not raw:
+            return None
+        candidate = Path(raw)
+        if candidate.is_absolute():
+            return candidate
+        service = self._service
+        prefix = self._effective_prefix()
+        if service is None or not prefix:
+            return None
+        return Path(service.root) / prefix / candidate
+
+    def _show_missing_file_message(self, path: Path | None, title: str) -> None:
+        message = _("File is missing on disk.")
+        if path is not None:
+            message = f"{message}\n{path}"
+        wx.MessageBox(message, title, style=wx.OK | wx.ICON_WARNING)
+
+    def _open_requirement_file(self, path: Path | None, title: str) -> None:
+        if path is None or not path.exists() or not path.is_file():
+            self._show_missing_file_message(path, title)
+            return
+        if not open_file(path):
+            wx.MessageBox(
+                _("Unable to open file with the default application."),
+                _("Error"),
+                style=wx.OK | wx.ICON_ERROR,
+            )
+
+    def _reveal_requirement_file(self, path: Path | None, title: str) -> None:
+        if path is None or not path.exists() or not path.is_file():
+            self._show_missing_file_message(path, title)
+            return
+        if not reveal_in_file_manager(path):
+            wx.MessageBox(
+                _("Unable to show file in the file manager."),
+                _("Error"),
+                style=wx.OK | wx.ICON_ERROR,
+            )
+
+    def _show_file_link_context_menu(
+        self,
+        *,
+        list_ctrl: wx.ListCtrl,
+        index: int,
+        stored_path: str,
+        title: str,
+        remove_label: str,
+        remove_callback: Callable[[int], None],
+    ) -> None:
+        if index < 0:
+            return
+        list_ctrl.Select(index)
+        list_ctrl.Focus(index)
+        path = self._resolve_requirement_file_path(stored_path)
+        menu = wx.Menu()
+        remove_item = menu.Append(wx.ID_ANY, remove_label)
+        open_item = menu.Append(wx.ID_ANY, _("Open"))
+        reveal_item = menu.Append(wx.ID_ANY, _("Show in file manager"))
+        file_available = path is not None and path.exists() and path.is_file()
+        open_item.Enable(file_available)
+        reveal_item.Enable(file_available)
+        menu.Bind(wx.EVT_MENU, lambda _evt, row=index: remove_callback(row), remove_item)
+        menu.Bind(wx.EVT_MENU, lambda _evt, p=path, t=title: self._open_requirement_file(p, t), open_item)
+        menu.Bind(wx.EVT_MENU, lambda _evt, p=path, t=title: self._reveal_requirement_file(p, t), reveal_item)
+        list_ctrl.PopupMenu(menu)
+        menu.Destroy()
+
+    def _on_attachment_context_menu(self, event: wx.Event) -> None:
+        index = self._selected_list_index_from_context_event(self.attachments_list, event)
+        if not (0 <= index < len(self.attachments)):
+            return
+        self._show_file_link_context_menu(
+            list_ctrl=self.attachments_list,
+            index=index,
+            stored_path=self.attachments[index].get("path", ""),
+            title=_("Attachments"),
+            remove_label=_("Remove file link"),
+            remove_callback=self._remove_attachment_by_index,
+        )
+
+    def _remove_attachment_by_index(self, index: int) -> None:
+        if 0 <= index < len(self.attachments):
+            del self.attachments[index]
             self._refresh_attachments()
 
     def _create_icon_button(
@@ -2741,6 +2869,23 @@ class EditorPanel(wx.Panel):
 
     def _on_remove_context_doc(self, _event: wx.Event) -> None:
         idx = self.context_docs_list.GetFirstSelected()
-        if idx >= 0:
-            del self.context_docs[idx]
+        self._remove_context_doc_by_index(idx)
+
+    def _on_context_doc_context_menu(self, event: wx.Event) -> None:
+        list_ctrl = self.context_docs_list
+        index = self._selected_list_index_from_context_event(list_ctrl, event)
+        if not (0 <= index < len(self.context_docs)):
+            return
+        self._show_file_link_context_menu(
+            list_ctrl=list_ctrl,
+            index=index,
+            stored_path=self.context_docs[index],
+            title=_("Context docs"),
+            remove_label=_("Remove file link"),
+            remove_callback=self._remove_context_doc_by_index,
+        )
+
+    def _remove_context_doc_by_index(self, index: int) -> None:
+        if 0 <= index < len(self.context_docs):
+            del self.context_docs[index]
             self._refresh_context_docs()

--- a/app/util/system_open.py
+++ b/app/util/system_open.py
@@ -1,4 +1,4 @@
-"""Helpers for opening system folders in the default file browser."""
+"""Helpers for opening files and folders with the operating system."""
 
 from __future__ import annotations
 
@@ -8,12 +8,16 @@ import sys
 from pathlib import Path
 
 
-def open_directory(directory: Path) -> bool:
-    """Open ``directory`` in the system file browser."""
+def _resolve_best_effort(path: Path) -> Path:
     try:
-        resolved = directory.resolve()
+        return path.resolve()
     except OSError:
-        resolved = directory
+        return path
+
+
+def open_path(path: Path) -> bool:
+    """Open ``path`` with the platform default handler."""
+    resolved = _resolve_best_effort(path)
     try:  # pragma: no cover - platform-dependent side effect
         if sys.platform.startswith("win"):
             os.startfile(str(resolved))  # type: ignore[attr-defined]
@@ -21,5 +25,32 @@ def open_directory(directory: Path) -> bool:
         if sys.platform == "darwin":
             return subprocess.call(["open", str(resolved)]) == 0
         return subprocess.call(["xdg-open", str(resolved)]) == 0
+    except Exception:  # pragma: no cover - best effort helper
+        return False
+
+
+def open_file(file_path: Path) -> bool:
+    """Open ``file_path`` in the default application."""
+    return open_path(file_path)
+
+
+def open_directory(directory: Path) -> bool:
+    """Open ``directory`` in the system file browser."""
+    return open_path(directory)
+
+
+def reveal_in_file_manager(file_path: Path) -> bool:
+    """Open the file manager and select ``file_path`` when the platform supports it."""
+    resolved = _resolve_best_effort(file_path)
+    try:  # pragma: no cover - platform-dependent side effect
+        if sys.platform.startswith("win"):
+            subprocess.Popen(["explorer", "/select,", str(resolved)])
+            return True
+        if sys.platform == "darwin":
+            return subprocess.call(["open", "-R", str(resolved)]) == 0
+        directory = resolved.parent if resolved.parent else Path(".")
+        # xdg-open has no cross-desktop "select this file" flag; opening the
+        # containing directory is the reliable Linux fallback.
+        return subprocess.call(["xdg-open", str(directory)]) == 0
     except Exception:  # pragma: no cover - best effort helper
         return False

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -411,7 +411,11 @@ pipeline, fallback cleanup, and regression coverage strategy), see
   `EditorPanel` keeps the requirement form in an explicit two-stage sequence: a
   primary block (ID/title/statement/context/rationale/notes/source/status/labels,
   attachments and a context-docs picker that stores relative Markdown paths under
-  the current document) followed by extended metadata (acceptance, assumptions,
+  the current document). Attachment and context-doc rows share a file-link
+  context menu for removing only the stored link, opening the file through the
+  OS default application, or revealing it in the platform file manager (Windows
+  selects the file, Linux opens its containing directory as a portable fallback).
+  The primary block is followed by extended metadata (acceptance, assumptions,
   ownership/revision links, classification enums and approval date). Requirement
   switching now applies batched autosize/layout updates under a frozen content
   panel, so keyboard navigation through the list no longer triggers a visible

--- a/tests/gui/test_editor_dirty.py
+++ b/tests/gui/test_editor_dirty.py
@@ -542,3 +542,36 @@ def test_editor_panel_attachment_and_context_lists_are_compact_and_fill_columns(
         assert not panel.remove_attachment_btn.IsShown()
     finally:
         frame.Destroy()
+
+@pytest.mark.gui_smoke
+def test_editor_panel_context_menu_helpers_remove_file_links(wx_app, tmp_path):
+    pytest.importorskip("wx")
+    import wx
+
+    from app.core.document_store import Document
+    from app.services.requirements import RequirementsService
+    from app.ui.editor_panel import EditorPanel
+
+    frame = wx.Frame(None)
+    try:
+        panel = EditorPanel(frame)
+        service = RequirementsService(tmp_path)
+        service.save_document(Document(prefix="SYS", title="System"))
+        panel.set_service(service)
+        panel.set_document("SYS")
+
+        attachment_file = tmp_path / "SYS" / "assets" / "diagram.png"
+        attachment_file.parent.mkdir(parents=True, exist_ok=True)
+        attachment_file.write_text("data", encoding="utf-8")
+        panel.attachments = [{"id": "att-1", "path": "assets/diagram.png", "note": "ref"}]
+        panel.context_docs = ["related/context.md"]
+
+        assert panel._resolve_requirement_file_path("assets/diagram.png") == attachment_file
+
+        panel._remove_attachment_by_index(0)
+        panel._remove_context_doc_by_index(0)
+
+        assert panel.attachments == []
+        assert panel.context_docs == []
+    finally:
+        frame.Destroy()

--- a/tests/unit/test_system_open.py
+++ b/tests/unit/test_system_open.py
@@ -1,0 +1,29 @@
+"""Tests for OS file-opening command helpers."""
+
+from pathlib import Path
+
+from app.util import system_open
+
+
+def test_reveal_in_file_manager_uses_explorer_select_on_windows(monkeypatch, tmp_path: Path) -> None:
+    calls: list[list[str]] = []
+    target = tmp_path / "file.txt"
+    target.write_text("data", encoding="utf-8")
+    monkeypatch.setattr(system_open.sys, "platform", "win32")
+    monkeypatch.setattr(system_open.subprocess, "Popen", lambda args: calls.append(args))
+
+    assert system_open.reveal_in_file_manager(target) is True
+
+    assert calls == [["explorer", "/select,", str(target.resolve())]]
+
+
+def test_reveal_in_file_manager_opens_parent_on_linux(monkeypatch, tmp_path: Path) -> None:
+    calls: list[list[str]] = []
+    target = tmp_path / "file.txt"
+    target.write_text("data", encoding="utf-8")
+    monkeypatch.setattr(system_open.sys, "platform", "linux")
+    monkeypatch.setattr(system_open.subprocess, "call", lambda args: calls.append(args) or 0)
+
+    assert system_open.reveal_in_file_manager(target) is True
+
+    assert calls == [["xdg-open", str(tmp_path.resolve())]]


### PR DESCRIPTION
### Motivation

- Пользовательский сценарий: в форме редактирования требований нужно правым кликом по строке файла (вложение или context doc) иметь пункты «Удалить ссылку», «Открыть» и «Показать в проводнике», с кроссплатформенным поведением.
- Требовалось сделать это аккуратно, переиспользуя логику и не ломая существующие UX / локализацию.
- При реализации возникла необходимость надёжно решать «показать файл» на Windows и Linux, а также обеспечить покрытие переводов, чтобы тесты i18n не падали.

### Description

- Добавлено контекстное меню для списка вложений (`attachments_list`) с пунктами удаления ссылки, открытия файла и показа в файловом менеджере, и аналогичное меню для списка контекстных документов (`context_docs_list`).
- Выведены вспомогательные методы в `EditorPanel`: детект позиции строки под событием контекстного меню, резолв относительного пути требования в абсолютный путь проекта, показ сообщений об отсутствующем файле, открытие файла и показ в менеджере файлов. (функции: `_selected_list_index_from_context_event`, `_resolve_requirement_file_path`, `_show_missing_file_message`, `_open_requirement_file`, `_reveal_requirement_file`, `_show_file_link_context_menu`, `_remove_*_by_index`).
- Добавлен модуль-утилита `app/util/system_open.py` с переносимыми хелперами `open_path`, `open_file`, `open_directory`, `reveal_in_file_manager`; на Windows используется `explorer /select,`, на macOS `open -R`, на Linux в качестве надёжного фолбэка открывается содержащая директория через `xdg-open` (универсального «select file» у `xdg-open` нет). 
- Обновлены строки локализации `app/locale/*/LC_MESSAGES/CookaReq.po` для новых пунктов меню и нескольких отсутствовавших ранее исходных сообщений, и добавлена краткая заметка в `docs/ARCHITECTURE.md` о поведении меню и кроссплатформенном отличии Windows/Linux.
- Добавлены тесты: GUI-regression `tests/gui/test_editor_dirty.py::test_editor_panel_context_menu_helpers_remove_file_links` и unit-тест `tests/unit/test_system_open.py` для проверки платформного поведения `reveal_in_file_manager`.

### Testing

- Запущены targeted GUI smoke тесты: `source .venv/bin/activate && python -m pytest --suite gui-smoke -q tests/gui/test_editor_dirty.py tests/gui/test_editor_insert_image.py tests/unit/test_system_open.py` — все тесты в прогоне прошли (GUI smoke набор + новый unit — зелёный, итог: 22 passed для gui-smoke set during run). 
- Прогон проверки переводов: `source .venv/bin/activate && python -m pytest --suite quality-i18n -q` — прошёл (исправлены отсутствующие записи в PO-файлах). 
- Прогон non-GUI subset: `source .venv/bin/activate && python -m pytest --suite core -q -m "not gui" tests/unit/test_system_open.py` — прошёл (unit tests зелёные).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3b86ea45508320a9c3ee3e77db8bba)