### PR TITLE
Normalize escaped newlines in CLI requirement text fields

### DIFF
--- a/app/cli/commands.py
+++ b/app/cli/commands.py
@@ -23,6 +23,7 @@ from app.services.requirements import (
     ValidationError,
     parse_rid,
 )
+from app.core.markdown_utils import normalize_escaped_newlines
 from app.core.model import (
     Link,
     Priority,
@@ -52,6 +53,14 @@ REQ_TYPE_CHOICES = [e.value for e in RequirementType]
 STATUS_CHOICES = [e.value for e in Status]
 PRIORITY_CHOICES = [e.value for e in Priority]
 VERIFICATION_CHOICES = [e.value for e in Verification]
+MULTILINE_TEXT_FIELDS = {
+    "statement",
+    "conditions",
+    "rationale",
+    "assumptions",
+    "notes",
+}
+OPTIONAL_MULTILINE_TEXT_FIELDS = {"acceptance"}
 
 @dataclass
 class Command:
@@ -407,6 +416,16 @@ def _write_trace_matrix_json(out: TextIO, matrix: TraceMatrix) -> None:
     out.write("\n")
 
 
+def _normalize_cli_text_value(name: str, value: Any) -> Any:
+    """Normalize escaped line breaks for CLI-facing multiline text fields."""
+    if (
+        name in MULTILINE_TEXT_FIELDS | OPTIONAL_MULTILINE_TEXT_FIELDS
+        and isinstance(value, str)
+    ):
+        return normalize_escaped_newlines(value)
+    return value
+
+
 def _resolve_text_field(
     args: argparse.Namespace,
     base: Mapping[str, Any],
@@ -416,11 +435,11 @@ def _resolve_text_field(
     sentinel = object()
     arg_value = getattr(args, name, sentinel)
     if arg_value is not sentinel and arg_value not in (None, ""):
-        return str(arg_value)
+        return _normalize_cli_text_value(name, str(arg_value))
     base_value = base.get(name, sentinel)
     if base_value is not sentinel and base_value not in (None, ""):
-        return base_value
-    return default
+        return _normalize_cli_text_value(name, base_value)
+    return _normalize_cli_text_value(name, default)
 
 
 def _resolve_optional_field(
@@ -432,8 +451,8 @@ def _resolve_optional_field(
     sentinel = object()
     arg_value = getattr(args, name, sentinel)
     if arg_value not in (sentinel, None):
-        return arg_value
-    return base.get(name, default)
+        return _normalize_cli_text_value(name, arg_value)
+    return _normalize_cli_text_value(name, base.get(name, default))
 
 
 def _resolve_labels(

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -10,7 +10,7 @@ so you know which modules are involved and which regressions to guard against.
 | Path | Description |
 | --- | --- |
 | `app/main.py`, `app/application.py` | GUI entry point and the dependency container (`ApplicationContext`). |
-| `app/cli/` | CLI entry points (`python3 -m app.cli`) and command handlers for document/item/link/trace/export/check workflows, including filtered requirement listing (`item list`) in text/JSON formats. CLI commands return explicit process status codes so automation can rely on shell exit semantics. |
+| `app/cli/` | CLI entry points (`python3 -m app.cli`) and command handlers for document/item/link/trace/export/check workflows, including filtered requirement listing (`item list`) in text/JSON formats. CLI commands return explicit process status codes so automation can rely on shell exit semantics. Multiline human-authored item fields normalize escaped `\n`, `\r\n` and `\r` sequences before persistence, allowing shell-friendly Markdown input without sidecar payload files. |
 | `app/core/` | Persistent requirement store, core models, search helpers, trace matrix generation, import/export code. |
 | `app/services/` | High-level facades on top of the core, including document caching, user document ingestion and configuration. |
 | `app/agent/` | The local agent that orchestrates LLM calls, MCP tool executions and confirmation flows. |

--- a/tests/unit/test_cli_item.py
+++ b/tests/unit/test_cli_item.py
@@ -97,6 +97,71 @@ def test_item_edit_updates_fields(tmp_path, capsys, cli_context):
     assert data["id"] == 1
     assert data["revision"] == 2
 
+@pytest.mark.unit
+def test_item_add_normalizes_escaped_newlines_in_multiline_fields(
+    tmp_path, capsys, cli_context
+):
+    doc = Document(
+        prefix="SYS", title="System", labels=DocumentLabels(allow_freeform=True)
+    )
+    save_document(tmp_path / "SYS", doc)
+
+    add_args = argparse.Namespace(
+        directory=str(tmp_path),
+        prefix="SYS",
+        title="Multiline",
+        statement=r"Line 1\n\n- item",
+        acceptance=r"Given A\r\nWhen B\rThen C",
+        conditions=r"Condition 1\nCondition 2",
+        rationale=r"Why\nBecause",
+        assumptions=r"Assumption 1\nAssumption 2",
+        notes=r"Note 1\nNote 2",
+        labels=None,
+    )
+
+    commands.cmd_item_add(add_args, cli_context)
+    rid = capsys.readouterr().out.strip()
+    assert rid == "SYS1"
+
+    data = json.loads(item_path(tmp_path / "SYS", doc, 1).read_text(encoding="utf-8"))
+    assert data["statement"] == "Line 1\n\n- item"
+    assert data["acceptance"] == "Given A\nWhen B\nThen C"
+    assert data["conditions"] == "Condition 1\nCondition 2"
+    assert data["rationale"] == "Why\nBecause"
+    assert data["assumptions"] == "Assumption 1\nAssumption 2"
+    assert data["notes"] == "Note 1\nNote 2"
+
+
+@pytest.mark.unit
+def test_item_edit_normalizes_escaped_newlines_in_statement(
+    tmp_path, capsys, cli_context
+):
+    doc = Document(prefix="SYS", title="System")
+    save_document(tmp_path / "SYS", doc)
+
+    add_args = argparse.Namespace(
+        directory=str(tmp_path),
+        prefix="SYS",
+        title="Seed",
+        statement="Initial",
+        labels=None,
+    )
+    commands.cmd_item_add(add_args, cli_context)
+    rid = capsys.readouterr().out.strip()
+
+    edit_args = argparse.Namespace(
+        directory=str(tmp_path),
+        rid=rid,
+        statement=r"Line 1\n\n- item",
+    )
+
+    commands.cmd_item_edit(edit_args, cli_context)
+    assert capsys.readouterr().out.strip() == rid
+
+    data = json.loads(item_path(tmp_path / "SYS", doc, 1).read_text(encoding="utf-8"))
+    assert data["statement"] == "Line 1\n\n- item"
+    assert data["revision"] == 2
+
 
 @pytest.mark.unit
 def test_item_edit_keeps_revision_when_statement_not_changed(tmp_path, capsys, cli_context):


### PR DESCRIPTION
### Motivation

- Сделать CLI удобным для создания/редактирования человекочитаемых многострочных полей: принимать shell-экранированные переносы (`\n`, `\r\n`, `\r`) и сохранять их как реальные LF в JSON-представлении требования.  
- Переиспользовать существующую утилиту `normalize_escaped_newlines()` из `app/core/markdown_utils.py` чтобы сохранить единое поведение с путями экспорта/рендеринга.

### Description

- Импортировал и применил `normalize_escaped_newlines()` в CLI-слое (`app/cli/commands.py`) через новый helper `_normalize_cli_text_value()` и декларативные множества полей `MULTILINE_TEXT_FIELDS` и `OPTIONAL_MULTILINE_TEXT_FIELDS`.  
- Применил нормализацию в ` _resolve_text_field()` и `_resolve_optional_field()` так, чтобы и аргументы `--statement`/`--conditions`/`--rationale`/`--assumptions`/`--notes`, и опциональное `--acceptance` корректно превратили escaped-последовательности в реальные переводы строк.  
- Добавил unit-тесты в `tests/unit/test_cli_item.py` для `item add` и `item edit`, проверяющие поведение на `\n\n`, `\r\n` и `\r` примерах.  
- Обновил `docs/ARCHITECTURE.md`, зафиксировав поведение CLI по нормализации многострочных полей.

### Testing

- Запуск новых/изменённых тестов: `source .venv/bin/activate && python -m pytest --suite core -q tests/unit/test_cli_item.py -q` — все тесты в этом файле прошли успешно.  
- Статический чек: `source .venv/bin/activate && ruff check app/cli/commands.py tests/unit/test_cli_item.py docs/ARCHITECTURE.md` — прошло без ошибок.  
- Полный прогон `source .venv/bin/activate && python -m pytest --suite core -q -m "not gui"` выявил 6 уже существующих, не связанных с этой правкой, падений (document serialization / agent timeline / CLI import isolation / doc-store assertions); их фиксы вынесены в отдельные задачи.  
- Проблемы окружения: `pytest` отсутствовал в системном `python3`, поэтому пришлось запускать тесты через проектное окружение (`.venv`) — инструкция в `AGENTS.md` это описывает, но это привело к первоначальной путанице при локальном прогоне.  

Если нужно, могу вынести нормализацию на более низкий уровень (например, в `Requirement.from_mapping()` или в store) и/или добавить опциональный флаг, отключающий CLI-нормализацию; также рекомендую отдельно разобраться с упавшими тестами, чтобы полный non-GUI прогон снова был «зеленым».

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3b8c036800832099a48091f40b1b44)